### PR TITLE
Add getrandom wrapper func and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ A Rust library to securely get random entropy. This crate derives its name from
 Linux's `getrandom` function, but is cross platform, roughly supporting the same
 set of platforms as Rust's `std` lib.
 
+This is a low-level API. Most users should prefer a high-level random-number
+library like [Rand] or a cryptography library.
+
+[Rand]: https://crates.io/crates/rand
+
 
 ## Usage
 
@@ -19,7 +24,15 @@ Add this to your `Cargo.toml`:
 getrandom = "0.1"
 ```
 
-TODO
+Then invoke the `getrandom` function:
+
+```rust
+fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
+    let mut buf = [0u8; 32];
+    getrandom::getrandom(&mut buf)?;
+    buf
+}
+```
 
 
 # License

--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
 }
 ```
 
+## Features
+
+This library is `no_std` compatible on SGX but requires `std` on most platforms.
+
+For WebAssembly (`wasm32`), Enscripten targets are supported directly; otherwise
+one of the following features must be enabled:
+
+-   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)
+-   [`stdweb`](https://crates.io/crates/stdweb)
+
 
 # License
 

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -11,7 +11,7 @@ extern "C" {
     fn cloudabi_sys_random_get(buf: *mut u8, len: usize) -> u16;
 }
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let errno = unsafe { cloudabi_sys_random_get(dest.as_ptr(), dest.len()) };
     if errno == 0 {
         Ok(())

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -11,7 +11,7 @@ extern "C" {
     fn cloudabi_sys_random_get(buf: *mut u8, len: usize) -> u16;
 }
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     let errno = unsafe { cloudabi_sys_random_get(dest.as_ptr(), dest.len()) };
     if errno == 0 {
         Ok(())

--- a/src/dragonfly_haiku.rs
+++ b/src/dragonfly_haiku.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f,
             || File::open("/dev/random").map_err(From::from),

--- a/src/dragonfly_haiku.rs
+++ b/src/dragonfly_haiku.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f,
             || File::open("/dev/random").map_err(From::from),

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -10,6 +10,6 @@
 //! `Err(UNAVAILABLE_ERROR)`
 use super::UNAVAILABLE_ERROR;
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     Err(UNAVAILABLE_ERROR)
 }

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -10,6 +10,6 @@
 //! `Err(UNAVAILABLE_ERROR)`
 use super::UNAVAILABLE_ERROR;
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     Err(UNAVAILABLE_ERROR)
 }

--- a/src/emscripten.rs
+++ b/src/emscripten.rs
@@ -15,7 +15,7 @@ use super::utils::use_init;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     // `Crypto.getRandomValues` documents `dest` should be at most 65536
     // bytes. `crypto.randomBytes` documents: "To minimize threadpool
     // task length variation, partition large randomBytes requests when

--- a/src/emscripten.rs
+++ b/src/emscripten.rs
@@ -15,7 +15,7 @@ use super::utils::use_init;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     // `Crypto.getRandomValues` documents `dest` should be at most 65536
     // bytes. `crypto.randomBytes` documents: "To minimize threadpool
     // task length variation, partition large randomBytes requests when

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,18 +12,29 @@ use core::fmt;
 #[cfg(not(target_env = "sgx"))]
 use std::{io, error};
 
+/// An unknown error.
 pub const UNKNOWN_ERROR: Error = Error(unsafe {
     NonZeroU32::new_unchecked(0x756e6b6e) // "unkn"
 });
 
+/// No generator is available.
 pub const UNAVAILABLE_ERROR: Error = Error(unsafe {
     NonZeroU32::new_unchecked(0x4e416e61) // "NAna"
 });
 
+/// The error type.
+/// 
+/// This type is small and no-std compatible.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Error(NonZeroU32);
 
 impl Error {
+    /// Extract the error code.
+    /// 
+    /// This may equal one of the codes defined in this library or may be a
+    /// system error code.
+    /// 
+    /// One may attempt to format this error via the `Display` implementation.
     pub fn code(&self) -> NonZeroU32 {
         self.0
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -51,9 +51,9 @@ impl From<io::Error> for Error {
 }
 
 #[cfg(not(target_env = "sgx"))]
-impl Into<io::Error> for Error {
-    fn into(self) -> io::Error {
-        match self {
+impl From<Error> for io::Error {
+    fn from(err: Error) -> Self {
+        match err {
             UNKNOWN_ERROR => io::Error::new(io::ErrorKind::Other,
                 "getrandom error: unknown"),
             UNAVAILABLE_ERROR => io::Error::new(io::ErrorKind::Other,

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -13,7 +13,7 @@ use super::Error;
 use core::ptr;
 use std::io;
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let mib = [libc::CTL_KERN, libc::KERN_ARND];
     // kern.arandom permits a maximum buffer size of 256 bytes
     for chunk in dest.chunks_mut(256) {

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -13,7 +13,7 @@ use super::Error;
 use core::ptr;
 use std::io;
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     let mib = [libc::CTL_KERN, libc::KERN_ARND];
     // kern.arandom permits a maximum buffer size of 256 bytes
     for chunk in dest.chunks_mut(256) {

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -11,7 +11,7 @@ extern crate fuchsia_cprng;
 
 use super::Error;
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     fuchsia_cprng::cprng_draw(dest);
     Ok(())
 }

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -11,7 +11,7 @@ extern crate fuchsia_cprng;
 
 use super::Error;
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     fuchsia_cprng::cprng_draw(dest);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,8 @@
 //! The bare WASM target `wasm32-unknown-unknown` tries to call the javascript
 //! methods directly, using either `stdweb` or `wasm-bindgen` depending on what
 //! features are activated for this crate. Note that if both features are
-//! enabled `wasm-bindgen` will be used.
+//! enabled `wasm-bindgen` will be used. If neither feature is enabled,
+//! `getrandom` will always fail.
 //!
 //! ## Early boot
 //!
@@ -112,14 +113,14 @@ pub use error::{Error, UNKNOWN_ERROR, UNAVAILABLE_ERROR};
 
 // System-specific implementations.
 // 
-// These should all provide getrandom_os with the same signature as getrandom.
+// These should all provide getrandom_inner with the same signature as getrandom.
 
 macro_rules! mod_use {
     ($cond:meta, $module:ident) => {
         #[$cond]
         mod $module;
         #[$cond]
-        use $module::getrandom_os;
+        use $module::getrandom_inner;
     }
 }
 
@@ -204,5 +205,5 @@ mod_use!(
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
 pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
-    getrandom_os(dest)
+    getrandom_inner(dest)
 }

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -38,7 +38,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), io::Error> {
     Ok(())
 }
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     RNG_SOURCE.with(|f| {
         use_init(f,
         || {

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -38,7 +38,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), io::Error> {
     Ok(())
 }
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     RNG_SOURCE.with(|f| {
         use_init(f,
         || {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -21,7 +21,7 @@ extern {
     ) -> c_int;
 }
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
         SecRandomCopyBytes(
             kSecRandomDefault,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -21,7 +21,7 @@ extern {
     ) -> c_int;
 }
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
         SecRandomCopyBytes(
             kSecRandomDefault,

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -19,7 +19,7 @@ static RNG_INIT: AtomicBool = ATOMIC_BOOL_INIT;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f, || {
             // read one byte from "/dev/random" to ensure that

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -19,7 +19,7 @@ static RNG_INIT: AtomicBool = ATOMIC_BOOL_INIT;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f, || {
             // read one byte from "/dev/random" to ensure that

--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -12,7 +12,7 @@ extern crate libc;
 use super::Error;
 use std::io;
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe {
             libc::getentropy(

--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -12,7 +12,7 @@ extern crate libc;
 use super::Error;
 use std::io;
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe {
             libc::getentropy(

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f,
             || File::open("rand:").map_err(From::from),

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -15,7 +15,7 @@ use std::cell::RefCell;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     RNG_FILE.with(|f| {
         use_init(f,
             || File::open("rand:").map_err(From::from),

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -29,7 +29,7 @@ fn get_rand_u64() -> Result<u64, Error> {
     Err(UNKNOWN_ERROR)
 }
 
-pub fn getrandom_os(mut dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(mut dest: &mut [u8]) -> Result<(), Error> {
     while dest.len() >= 8 {
         let (chunk, left) = {dest}.split_at_mut(8);
         dest = left;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -29,7 +29,7 @@ fn get_rand_u64() -> Result<u64, Error> {
     Err(UNKNOWN_ERROR)
 }
 
-pub fn getrandom(mut dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(mut dest: &mut [u8]) -> Result<(), Error> {
     while dest.len() >= 8 {
         let (chunk, left) = {dest}.split_at_mut(8);
         dest = left;

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -53,7 +53,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     // The documentation says 1024 is the maximum for getrandom
     // and 1040 for /dev/random.
     RNG_SOURCE.with(|f| {

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -53,7 +53,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), Error> {
     Ok(())
 }
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     // The documentation says 1024 is the maximum for getrandom
     // and 1040 for /dev/random.
     RNG_SOURCE.with(|f| {

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -48,7 +48,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), Error> {
         syscall(SYS_GETRANDOM, dest.as_mut_ptr(), dest.len(), 0)
     };
     if ret == -1 || ret != dest.len() as i64 {
-        return Err(io::Error::last_os_error().from());
+        return Err(io::Error::last_os_error().into());
     }
     Ok(())
 }
@@ -75,7 +75,7 @@ pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
                 },
             }
         })
-    }).map_err(|_| Error::Unknown)
+    })
 }
 
 fn is_getrandom_available() -> bool {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,7 +15,7 @@ use self::winapi::um::winnt::PVOID;
 use std::io;
 use super::Error;
 
-pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
         RtlGenRandom(dest.as_mut_ptr() as PVOID, dest.len() as ULONG)
     };

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -15,7 +15,7 @@ use self::winapi::um::winnt::PVOID;
 use std::io;
 use super::Error;
 
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_os(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
         RtlGenRandom(dest.as_mut_ptr() as PVOID, dest.len() as ULONG)
     };


### PR DESCRIPTION
Add a wrapper function for docs and to ensure all platforms have the same API.

Add docs (based on `rand_os`).