### PR TITLE
Revise error types and codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
         - rm -rf target/doc
         - cargo doc --no-deps --all --all-features
         - cargo deadlinks --dir target/doc
+        # also test minimum dependency versions are usable
+        - cargo generate-lockfile -Z minimal-versions
+        - cargo test
 
     - rust: nightly
       os: osx
@@ -52,6 +55,9 @@ matrix:
         - rm -rf target/doc
         - cargo doc --no-deps --all --all-features
         - cargo deadlinks --dir target/doc
+        # also test minimum dependency versions are usable
+        - cargo generate-lockfile -Z minimal-versions
+        - cargo test
 
     - rust: nightly
       env: DESCRIPTION="WASM via emscripten, stdweb and wasm-bindgen"
@@ -91,6 +97,14 @@ matrix:
         - rustup target add x86_64-unknown-netbsd
         - rustup target add x86_64-unknown-redox
       script:
+        - cargo build --target=x86_64-sun-solaris --all-features
+        - cargo build --target=x86_64-unknown-cloudabi --all-features
+        - cargo build --target=x86_64-unknown-freebsd --all-features
+        #- cargo build --target=x86_64-unknown-fuchsia --all-features
+        - cargo build --target=x86_64-unknown-netbsd --all-features
+        - cargo build --target=x86_64-unknown-redox --all-features
+        # also test minimum dependency versions are usable
+        - cargo generate-lockfile -Z minimal-versions
         - cargo build --target=x86_64-sun-solaris --all-features
         - cargo build --target=x86_64-unknown-cloudabi --all-features
         - cargo build --target=x86_64-unknown-freebsd --all-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,10 @@ matrix:
     - rust: 1.28.0
       env: DESCRIPTION="Linux, 1.28.0"
       os: linux
-      before_script:
-        - cargo generate-lockfile -Z minimal-versions
 
     - rust: 1.28.0
       env: DESCRIPTION="OSX, 1.22.0"
       os: osx
-      before_script:
-        - cargo generate-lockfile -Z minimal-versions
 
     - rust: stable
       env: DESCRIPTION="Linux, stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,14 @@ matrix:
     - rust: 1.28.0
       env: DESCRIPTION="Linux, 1.28.0"
       os: linux
+      before_script:
+        - cargo generate-lockfile -Z minimal-versions
 
     - rust: 1.28.0
       env: DESCRIPTION="OSX, 1.22.0"
       os: osx
+      before_script:
+        - cargo generate-lockfile -Z minimal-versions
 
     - rust: stable
       env: DESCRIPTION="Linux, stable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,10 @@ members = [
 ]
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2"
+libc = "0.2.27"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["minwindef", "ntsecapi", "winnt"] }
+winapi = { version = "0.3.6", features = ["minwindef", "ntsecapi", "winnt"] }
 
 [target.'cfg(target_os = "cloudabi")'.dependencies]
 cloudabi = "0.0.3"
@@ -27,5 +27,5 @@ cloudabi = "0.0.3"
 fuchsia-cprng = "0.1"
 
 [target.wasm32-unknown-unknown.dependencies]
-wasm-bindgen = { version = "0.2.12", optional = true }
-stdweb = { version = "0.4", optional = true }
+wasm-bindgen = { version = "0.2.29", optional = true }
+stdweb = { version = "0.4.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ members = [
     "tests/wasm_bindgen",
 ]
 
+[dependencies]
+log = { version = "0.4", optional = true }
+
 [target.'cfg(unix)'.dependencies]
 libc = "0.2.27"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ members = [
 log = { version = "0.4", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-libc = "0.2.27"
+# In general, we need at least 0.2.27. On Solaris, we need some unknown newer version.
+libc = "0.2.50"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3.6", features = ["minwindef", "ntsecapi", "winnt"] }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
 
 This library is `no_std` compatible on SGX but requires `std` on most platforms.
 
+The `log` library is supported as an optional dependency. If enabled, error
+reporting will be improved on some platforms.
+
 For WebAssembly (`wasm32`), Enscripten targets are supported directly; otherwise
 one of the following features must be enabled:
 

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -11,7 +11,7 @@
 extern crate cloudabi;
 
 use core::num::NonZeroU32;
-use error::Error;
+use Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let errno = unsafe { cloudabi::random_get(dest) };

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -19,6 +19,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         Ok(())
     } else {
         let code = NonZeroU32::new(errno as u32).unwrap();
+        error!("cloudabi::random_get syscall failed with code {}", code);
         Err(Error::from(code))
     }
 }

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -22,3 +22,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         Err(Error::from(code))
     }
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/dragonfly_haiku.rs
+++ b/src/dragonfly_haiku.rs
@@ -7,11 +7,12 @@
 // except according to those terms.
 
 //! Implementation for DragonFly / Haiku
-use super::Error;
-use super::utils::use_init;
+use error::Error;
+use utils::use_init;
 use std::fs::File;
 use std::io::Read;
 use std::cell::RefCell;
+use std::num::NonZeroU32;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
@@ -23,3 +24,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         )
     })
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/dragonfly_haiku.rs
+++ b/src/dragonfly_haiku.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for DragonFly / Haiku
-use error::Error;
+use Error;
 use utils::use_init;
 use std::fs::File;
 use std::io::Read;

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -7,9 +7,13 @@
 // except according to those terms.
 
 //! A dummy implementation for unsupported targets which always returns
-//! `Err(UNAVAILABLE_ERROR)`
-use super::UNAVAILABLE_ERROR;
+//! `Err(error::UNAVAILABLE)`
+use std::num::NonZeroU32;
+use error::{Error, UNAVAILABLE};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    Err(UNAVAILABLE_ERROR)
+pub fn getrandom_inner(_: &mut [u8]) -> Result<(), Error> {
+    Err(UNAVAILABLE)
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroU32;
 use {Error, ERROR_UNAVAILABLE};
 
 pub fn getrandom_inner(_: &mut [u8]) -> Result<(), Error> {
+    error!("no support for this platform");
     Err(ERROR_UNAVAILABLE)
 }
 

--- a/src/dummy.rs
+++ b/src/dummy.rs
@@ -7,12 +7,12 @@
 // except according to those terms.
 
 //! A dummy implementation for unsupported targets which always returns
-//! `Err(error::UNAVAILABLE)`
+//! `Err(ERROR_UNAVAILABLE)`
 use std::num::NonZeroU32;
-use error::{Error, UNAVAILABLE};
+use {Error, ERROR_UNAVAILABLE};
 
 pub fn getrandom_inner(_: &mut [u8]) -> Result<(), Error> {
-    Err(UNAVAILABLE)
+    Err(ERROR_UNAVAILABLE)
 }
 
 #[inline(always)]

--- a/src/emscripten.rs
+++ b/src/emscripten.rs
@@ -7,11 +7,12 @@
 // except according to those terms.
 
 //! Implementation for Emscripten
-use super::Error;
+use error::Error;
 use std::fs::File;
 use std::io::Read;
 use std::cell::RefCell;
-use super::utils::use_init;
+use std::num::NonZeroU32;
+use utils::use_init;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
@@ -29,3 +30,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         })
     })
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/emscripten.rs
+++ b/src/emscripten.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for Emscripten
-use error::Error;
+use Error;
 use std::fs::File;
 use std::io::Read;
 use std::cell::RefCell;

--- a/src/error.rs
+++ b/src/error.rs
@@ -12,20 +12,25 @@ use core::fmt;
 #[cfg(not(target_env = "sgx"))]
 use std::{io, error};
 
+// A randomly-chosen 16-bit prefix for our codes
+pub(crate) const CODE_PREFIX: u32 = 0x57f40000;
+const CODE_UNKNOWN: u32 = CODE_PREFIX | 0;
+const CODE_UNAVAILABLE: u32 = CODE_PREFIX | 1;
+
 /// An unknown error.
-pub const UNKNOWN_ERROR: Error = Error(unsafe {
-    NonZeroU32::new_unchecked(0x756e6b6e) // "unkn"
+pub const UNKNOWN: Error = Error(unsafe {
+    NonZeroU32::new_unchecked(CODE_UNKNOWN)
 });
 
 /// No generator is available.
-pub const UNAVAILABLE_ERROR: Error = Error(unsafe {
-    NonZeroU32::new_unchecked(0x4e416e61) // "NAna"
+pub const UNAVAILABLE: Error = Error(unsafe {
+    NonZeroU32::new_unchecked(CODE_UNAVAILABLE)
 });
 
 /// The error type.
 /// 
 /// This type is small and no-std compatible.
-#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Error(NonZeroU32);
 
 impl Error {
@@ -38,14 +43,34 @@ impl Error {
     pub fn code(&self) -> NonZeroU32 {
         self.0
     }
+    
+    fn msg(&self) -> Option<&'static str> {
+        if let Some(msg) = super::error_msg_inner(self.0) {
+            Some(msg)
+        } else {
+            match *self {
+                UNKNOWN => Some("getrandom: unknown error"),
+                UNAVAILABLE => Some("getrandom: unavailable"),
+                _ => None
+            }
+        }
+    }
+}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self.msg() {
+            Some(msg) => write!(f, "Error(\"{}\")", msg),
+            None => write!(f, "Error({})", self.0.get()),
+        }
+    }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match *self {
-            UNKNOWN_ERROR => write!(f, "Getrandom Error: unknown"),
-            UNAVAILABLE_ERROR => write!(f, "Getrandom Error: unavailable"),
-            code => write!(f, "Getrandom Error: {}", code.0.get()),
+        match self.msg() {
+            Some(msg) => write!(f, "{}", msg),
+            None => write!(f, "getrandom: unknown code {}", self.0.get()),
         }
     }
 }
@@ -63,22 +88,31 @@ impl From<io::Error> for Error {
             .and_then(|code| NonZeroU32::new(code as u32))
             .map(|code| Error(code))
             // in practice this should never happen
-            .unwrap_or(UNKNOWN_ERROR)
+            .unwrap_or(UNKNOWN)
     }
 }
 
 #[cfg(not(target_env = "sgx"))]
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {
-        match err {
-            UNKNOWN_ERROR => io::Error::new(io::ErrorKind::Other,
-                "getrandom error: unknown"),
-            UNAVAILABLE_ERROR => io::Error::new(io::ErrorKind::Other,
-                "getrandom error: entropy source is unavailable"),
-            code => io::Error::from_raw_os_error(code.0.get() as i32),
+        match err.msg() {
+            Some(msg) => io::Error::new(io::ErrorKind::Other, msg),
+            None => io::Error::from_raw_os_error(err.0.get() as i32),
         }
     }
 }
 
 #[cfg(not(target_env = "sgx"))]
 impl error::Error for Error { }
+
+#[cfg(test)]
+mod tests {
+    use std::mem::size_of;
+    use super::Error;
+    
+    #[test]
+    fn test_size() {
+        assert_eq!(size_of::<Error>(), 4);
+        assert_eq!(size_of::<Result<(), Error>>(), 4);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,11 +19,15 @@ const CODE_UNAVAILABLE: u32 = CODE_PREFIX | 1;
 
 /// An unknown error.
 pub const UNKNOWN: Error = Error(unsafe {
+/// 
+/// This is the following constant: 57F40000 (hex) / 1475608576 (decimal).
     NonZeroU32::new_unchecked(CODE_UNKNOWN)
 });
 
 /// No generator is available.
 pub const UNAVAILABLE: Error = Error(unsafe {
+/// 
+/// This is the following constant: 57F40001 (hex) / 1475608577 (decimal).
     NonZeroU32::new_unchecked(CODE_UNAVAILABLE)
 });
 
@@ -61,7 +65,7 @@ impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.msg() {
             Some(msg) => write!(f, "Error(\"{}\")", msg),
-            None => write!(f, "Error({})", self.0.get()),
+            None => write!(f, "Error({:08X})", self.0),
         }
     }
 }
@@ -70,7 +74,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.msg() {
             Some(msg) => write!(f, "{}", msg),
-            None => write!(f, "getrandom: unknown code {}", self.0.get()),
+            None => write!(f, "getrandom: unknown code {:08X}", self.0),
         }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,16 +18,16 @@ const CODE_UNKNOWN: u32 = CODE_PREFIX | 0;
 const CODE_UNAVAILABLE: u32 = CODE_PREFIX | 1;
 
 /// An unknown error.
-pub const UNKNOWN: Error = Error(unsafe {
 /// 
 /// This is the following constant: 57F40000 (hex) / 1475608576 (decimal).
+pub const ERROR_UNKNOWN: Error = Error(unsafe {
     NonZeroU32::new_unchecked(CODE_UNKNOWN)
 });
 
 /// No generator is available.
-pub const UNAVAILABLE: Error = Error(unsafe {
 /// 
 /// This is the following constant: 57F40001 (hex) / 1475608577 (decimal).
+pub const ERROR_UNAVAILABLE: Error = Error(unsafe {
     NonZeroU32::new_unchecked(CODE_UNAVAILABLE)
 });
 
@@ -53,8 +53,8 @@ impl Error {
             Some(msg)
         } else {
             match *self {
-                UNKNOWN => Some("getrandom: unknown error"),
-                UNAVAILABLE => Some("getrandom: unavailable"),
+                ERROR_UNKNOWN => Some("getrandom: unknown error"),
+                ERROR_UNAVAILABLE => Some("getrandom: unavailable"),
                 _ => None
             }
         }
@@ -92,7 +92,7 @@ impl From<io::Error> for Error {
             .and_then(|code| NonZeroU32::new(code as u32))
             .map(|code| Error(code))
             // in practice this should never happen
-            .unwrap_or(UNKNOWN)
+            .unwrap_or(ERROR_UNKNOWN)
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -65,7 +65,7 @@ impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.msg() {
             Some(msg) => write!(f, "Error(\"{}\")", msg),
-            None => write!(f, "Error({:08X})", self.0),
+            None => write!(f, "Error(0x{:08X})", self.0),
         }
     }
 }
@@ -74,7 +74,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self.msg() {
             Some(msg) => write!(f, "{}", msg),
-            None => write!(f, "getrandom: unknown code {:08X}", self.0),
+            None => write!(f, "getrandom: unknown code 0x{:08X}", self.0),
         }
     }
 }

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -9,7 +9,7 @@
 //! Implementation for FreeBSD
 extern crate libc;
 
-use error::Error;
+use Error;
 use core::ptr;
 use std::io;
 use std::num::NonZeroU32;

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -9,9 +9,10 @@
 //! Implementation for FreeBSD
 extern crate libc;
 
-use super::Error;
+use error::Error;
 use core::ptr;
 use std::io;
+use std::num::NonZeroU32;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let mib = [libc::CTL_KERN, libc::KERN_ARND];
@@ -30,3 +31,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     }
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -26,6 +26,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
             )
         };
         if ret == -1 || len != chunk.len() {
+            error!("freebsd: kern.arandom syscall failed");
             return Err(io::Error::last_os_error().into());
         }
     }

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -9,9 +9,13 @@
 //! Implementation for Fuchsia Zircon
 extern crate fuchsia_cprng;
 
-use super::Error;
+use std::num::NonZeroU32;
+use error::Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     fuchsia_cprng::cprng_draw(dest);
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -10,7 +10,7 @@
 extern crate fuchsia_cprng;
 
 use std::num::NonZeroU32;
-use error::Error;
+use Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     fuchsia_cprng::cprng_draw(dest);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ extern crate wasm_bindgen;
 
 #[cfg(feature = "log")] #[macro_use] extern crate log;
 #[allow(unused)]
-#[cfg(not(feature = "log"))] macro_rules! warn { ($($x:tt)*) => () }
+#[cfg(not(feature = "log"))] macro_rules! error { ($($x:tt)*) => () }
 
 #[cfg(any(
     target_os = "android",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,10 @@ extern crate wasm_bindgen;
           feature = "stdweb"))]
 #[macro_use] extern crate stdweb;
 
+#[cfg(feature = "log")] #[macro_use] extern crate log;
+#[allow(unused)]
+#[cfg(not(feature = "log"))] macro_rules! warn { ($($x:tt)*) => () }
+
 #[cfg(any(
     target_os = "android",
     target_os = "netbsd",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,7 @@ extern crate wasm_bindgen;
     target_arch = "wasm32",
 ))]
 mod utils;
-mod error;
-pub use error::{Error, UNKNOWN_ERROR, UNAVAILABLE_ERROR};
+pub mod error;
 
 
 // System-specific implementations.
@@ -136,7 +135,7 @@ macro_rules! mod_use {
         #[$cond]
         mod $module;
         #[$cond]
-        use $module::getrandom_inner;
+        use $module::{getrandom_inner, error_msg_inner};
     }
 }
 
@@ -221,7 +220,7 @@ mod_use!(
 /// In general, `getrandom` will be fast enough for interactive usage, though
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom(dest: &mut [u8]) -> Result<(), error::Error> {
     getrandom_inner(dest)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@ extern crate wasm_bindgen;
     target_arch = "wasm32",
 ))]
 mod utils;
-pub mod error;
-
+mod error;
+pub use error::{Error, ERROR_UNKNOWN, ERROR_UNAVAILABLE};
 
 // System-specific implementations.
 // 

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -9,12 +9,13 @@
 //! Implementation for Linux / Android
 extern crate libc;
 
-use super::Error;
-use super::utils::use_init;
+use error::Error;
+use utils::use_init;
 use std::fs::File;
 use std::io;
 use std::io::Read;
 use std::cell::RefCell;
+use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static RNG_INIT: AtomicBool = AtomicBool::new(false);
@@ -80,3 +81,6 @@ fn is_getrandom_available() -> bool {
 
     AVAILABLE.load(Ordering::Relaxed)
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -34,6 +34,7 @@ fn syscall_getrandom(dest: &mut [u8]) -> Result<(), io::Error> {
         libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), dest.len(), 0)
     };
     if ret < 0 || (ret as usize) != dest.len() {
+        error!("Linux getrandom syscall failed with return value {}", ret);
         return Err(io::Error::last_os_error());
     }
     Ok(())

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -9,7 +9,7 @@
 //! Implementation for Linux / Android
 extern crate libc;
 
-use error::Error;
+use Error;
 use utils::use_init;
 use std::fs::File;
 use std::io;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -9,8 +9,9 @@
 //! Implementation for MacOS / iOS
 extern crate libc;
 
-use super::Error;
+use error::Error;
 use std::io;
+use std::num::NonZeroU32;
 use self::libc::{c_int, size_t};
 
 enum SecRandom {}
@@ -40,3 +41,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         Ok(())
     }
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -9,7 +9,7 @@
 //! Implementation for MacOS / iOS
 extern crate libc;
 
-use error::Error;
+use Error;
 use std::io;
 use std::num::NonZeroU32;
 use self::libc::{c_int, size_t};

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -36,6 +36,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         )
     };
     if ret == -1 {
+        error!("SecRandomCopyBytes call failed");
         Err(io::Error::last_os_error().into())
     } else {
         Ok(())

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -8,7 +8,7 @@
 
 //! Implementation for NetBSD
 
-use error::Error;
+use Error;
 use utils::use_init;
 use std::fs::File;
 use std::io::Read;

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -8,11 +8,12 @@
 
 //! Implementation for NetBSD
 
-use super::Error;
-use super::utils::use_init;
+use error::Error;
+use utils::use_init;
 use std::fs::File;
 use std::io::Read;
 use std::cell::RefCell;
+use std::num::NonZeroU32;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 static RNG_INIT: AtomicBool = AtomicBool::new(false);
@@ -32,3 +33,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         }, |f| f.read_exact(dest).map_err(From::from))
     })
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -22,6 +22,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
             )
         };
         if ret == -1 {
+            error!("libc::getentropy call failed");
             return Err(io::Error::last_os_error().into());
         }
     }

--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -9,7 +9,7 @@
 //! Implementation for OpenBSD / Bitrig
 extern crate libc;
 
-use error::Error;
+use Error;
 use std::io;
 use std::num::NonZeroU32;
 

--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -9,8 +9,9 @@
 //! Implementation for OpenBSD / Bitrig
 extern crate libc;
 
-use super::Error;
+use error::Error;
 use std::io;
+use std::num::NonZeroU32;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
@@ -26,3 +27,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     }
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -7,11 +7,12 @@
 // except according to those terms.
 
 //! Implementation for Redox
-use super::Error;
-use super::utils::use_init;
+use error::Error;
+use utils::use_init;
 use std::fs::File;
 use std::io::Read;
 use std::cell::RefCell;
+use std::num::NonZeroU32;
 
 thread_local!(static RNG_FILE: RefCell<Option<File>> = RefCell::new(None));
 
@@ -23,3 +24,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         )
     }).map_err(From::from)
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for Redox
-use error::Error;
+use Error;
 use utils::use_init;
 use std::fs::File;
 use std::io::Read;

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for SGX using RDRAND instruction
-use error::{Error, UNKNOWN};
+use {Error, ERROR_UNKNOWN};
 
 use core::{mem, ptr};
 use core::arch::x86_64::_rdrand64_step;
@@ -27,7 +27,7 @@ fn get_rand_u64() -> Result<u64, Error> {
             }
         };
     }
-    Err(UNKNOWN)
+    Err(ERROR_UNKNOWN)
 }
 
 pub fn getrandom_inner(mut dest: &mut [u8]) -> Result<(), Error> {

--- a/src/sgx.rs
+++ b/src/sgx.rs
@@ -7,10 +7,11 @@
 // except according to those terms.
 
 //! Implementation for SGX using RDRAND instruction
-use super::{Error, UNKNOWN_ERROR};
+use error::{Error, UNKNOWN};
 
 use core::{mem, ptr};
 use core::arch::x86_64::_rdrand64_step;
+use core::num::NonZeroU32;
 
 #[cfg(not(target_feature = "rdrand"))]
 compile_error!("enable rdrand target feature!");
@@ -26,7 +27,7 @@ fn get_rand_u64() -> Result<u64, Error> {
             }
         };
     }
-    Err(UNKNOWN_ERROR)
+    Err(UNKNOWN)
 }
 
 pub fn getrandom_inner(mut dest: &mut [u8]) -> Result<(), Error> {
@@ -46,3 +47,6 @@ pub fn getrandom_inner(mut dest: &mut [u8]) -> Result<(), Error> {
     }
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/solarish.rs
+++ b/src/solarish.rs
@@ -19,7 +19,7 @@
 //! libc::dlsym.
 extern crate libc;
 
-use error::Error;
+use Error;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io;

--- a/src/solarish.rs
+++ b/src/solarish.rs
@@ -45,6 +45,7 @@ fn libc_getrandom(rand: GetRandomFn, dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { rand(dest.as_mut_ptr(), dest.len(), 0) as libc::ssize_t };
 
     if ret == -1 || ret != dest.len() as libc::ssize_t {
+        error!("getrandom syscall failed with ret={}", ret);
         Err(io::Error::last_os_error().into())
     } else {
         Ok(())

--- a/src/solarish.rs
+++ b/src/solarish.rs
@@ -19,11 +19,12 @@
 //! libc::dlsym.
 extern crate libc;
 
-use super::Error;
+use error::Error;
 use std::cell::RefCell;
 use std::fs::File;
 use std::io;
 use std::io::Read;
+use std::num::NonZeroU32;
 use utils::use_init;
 
 #[cfg(target_os = "illumos")]
@@ -97,3 +98,6 @@ fn fetch_getrandom() -> Option<GetRandomFn> {
     let ptr = FPTR.load(Ordering::SeqCst);
     unsafe { mem::transmute::<usize, Option<GetRandomFn>>(ptr) }
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use error::Error;
+use Error;
 use core::cell::RefCell;
 use core::ops::DerefMut;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use super::Error;
+use error::Error;
 use core::cell::RefCell;
 use core::ops::DerefMut;
 

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroU32;
 use wasm_bindgen::prelude::*;
 
 use __wbg_shims::*;
-use error::Error;
+use Error;
 use utils::use_init;
 
 const CODE_PREFIX: u32 = ::error::CODE_PREFIX | 0x8e00;

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -10,13 +10,17 @@
 
 use std::cell::RefCell;
 use std::mem;
+use std::num::NonZeroU32;
 
 use wasm_bindgen::prelude::*;
 
-use super::__wbg_shims::*;
-use super::{Error, UNAVAILABLE_ERROR};
-use super::utils::use_init;
+use __wbg_shims::*;
+use error::Error;
+use utils::use_init;
 
+const CODE_PREFIX: u32 = ::error::CODE_PREFIX | 0x8e00;
+const CODE_CRYPTO_UNDEF: u32 = CODE_PREFIX | 1;
+const CODE_GRV_UNDEF: u32 = CODE_PREFIX | 2;
 
 #[derive(Clone, Debug)]
 pub enum RngSource {
@@ -75,18 +79,29 @@ fn getrandom_init() -> Result<RngSource, Error> {
     // we're in an older web browser and the OS RNG isn't available.
     let crypto = this.crypto();
     if crypto.is_undefined() {
-        let msg = "self.crypto is undefined";
-        return Err(UNAVAILABLE_ERROR)   // TODO: report msg
+        return Err(Error::from(unsafe {
+            NonZeroU32::new_unchecked(CODE_CRYPTO_UNDEF)
+        }));
     }
 
     // Test if `crypto.getRandomValues` is undefined as well
     let crypto: BrowserCrypto = crypto.into();
     if crypto.get_random_values_fn().is_undefined() {
-        let msg = "crypto.getRandomValues is undefined";
-        return Err(UNAVAILABLE_ERROR)   // TODO: report msg
+        return Err(Error::from(unsafe {
+            NonZeroU32::new_unchecked(CODE_GRV_UNDEF)
+        }));
     }
 
     // Ok! `self.crypto.getRandomValues` is a defined value, so let's
     // assume we can do browser crypto.
     Ok(RngSource::Browser(crypto))
+}
+
+#[inline(always)]
+pub fn error_msg_inner(n: NonZeroU32) -> Option<&'static str> {
+    match n.get() {
+        CODE_CRYPTO_UNDEF => Some("getrandom: self.crypto is undefined"),
+        CODE_GRV_UNDEF => Some("crypto.getRandomValues is undefined"),
+        _ => None
+    }
 }

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -66,7 +66,8 @@ fn getrandom_init() -> Result<RngSource, Error> {
         else { unreachable!() }
     } else {
         let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-        Err(ERROR_UNAVAILABLE)  // TODO: forward err
+        warn!("getrandom unavailable: {}", err);
+        Err(ERROR_UNAVAILABLE)
     }
 }
 
@@ -101,7 +102,8 @@ fn getrandom_fill(source: &mut RngSource, dest: &mut [u8]) -> Result<(), Error> 
 
         if js!{ return @{ result.as_ref() }.success } != true {
             let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-            return Err(ERROR_UNKNOWN)  // TODO: forward err
+            warn!("getrandom failed: {}", err);
+            return Err(ERROR_UNKNOWN)
         }
     }
     Ok(())

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -10,12 +10,13 @@
 
 use std::cell::RefCell;
 use std::mem;
+use std::num::NonZeroU32;
 
 use stdweb::unstable::TryInto;
 use stdweb::web::error::Error as WebError;
 
-use super::{Error, UNAVAILABLE_ERROR, UNKNOWN_ERROR};
-use super::utils::use_init;
+use error::{Error, UNAVAILABLE, UNKNOWN};
+use utils::use_init;
 
 #[derive(Clone, Debug)]
 enum RngSource {
@@ -65,7 +66,7 @@ fn getrandom_init() -> Result<RngSource, Error> {
         else { unreachable!() }
     } else {
         let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-        Err(UNAVAILABLE_ERROR)  // TODO: forward err
+        Err(UNAVAILABLE)  // TODO: forward err
     }
 }
 
@@ -100,8 +101,11 @@ fn getrandom_fill(source: &mut RngSource, dest: &mut [u8]) -> Result<(), Error> 
 
         if js!{ return @{ result.as_ref() }.success } != true {
             let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-            return Err(UNKNOWN_ERROR)  // TODO: forward err
+            return Err(UNKNOWN)  // TODO: forward err
         }
     }
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -66,7 +66,7 @@ fn getrandom_init() -> Result<RngSource, Error> {
         else { unreachable!() }
     } else {
         let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-        warn!("getrandom unavailable: {}", err);
+        error!("getrandom unavailable: {}", err);
         Err(ERROR_UNAVAILABLE)
     }
 }
@@ -102,7 +102,7 @@ fn getrandom_fill(source: &mut RngSource, dest: &mut [u8]) -> Result<(), Error> 
 
         if js!{ return @{ result.as_ref() }.success } != true {
             let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-            warn!("getrandom failed: {}", err);
+            error!("getrandom failed: {}", err);
             return Err(ERROR_UNKNOWN)
         }
     }

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -15,7 +15,7 @@ use std::num::NonZeroU32;
 use stdweb::unstable::TryInto;
 use stdweb::web::error::Error as WebError;
 
-use error::{Error, UNAVAILABLE, UNKNOWN};
+use {Error, ERROR_UNAVAILABLE, ERROR_UNKNOWN};
 use utils::use_init;
 
 #[derive(Clone, Debug)]
@@ -66,7 +66,7 @@ fn getrandom_init() -> Result<RngSource, Error> {
         else { unreachable!() }
     } else {
         let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-        Err(UNAVAILABLE)  // TODO: forward err
+        Err(ERROR_UNAVAILABLE)  // TODO: forward err
     }
 }
 
@@ -101,7 +101,7 @@ fn getrandom_fill(source: &mut RngSource, dest: &mut [u8]) -> Result<(), Error> 
 
         if js!{ return @{ result.as_ref() }.success } != true {
             let err: WebError = js!{ return @{ result }.error }.try_into().unwrap();
-            return Err(UNKNOWN)  // TODO: forward err
+            return Err(ERROR_UNKNOWN)  // TODO: forward err
         }
     }
     Ok(())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -20,7 +20,10 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
         RtlGenRandom(dest.as_mut_ptr() as PVOID, dest.len() as ULONG)
     };
-    if ret == 0 { return Err(io::Error::last_os_error().into()); }
+    if ret == 0 {
+        error!("RtlGenRandom call failed");
+        return Err(io::Error::last_os_error().into());
+    }
     Ok(())
 }
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -13,7 +13,8 @@ use self::winapi::shared::minwindef::ULONG;
 use self::winapi::um::ntsecapi::RtlGenRandom;
 use self::winapi::um::winnt::PVOID;
 use std::io;
-use super::Error;
+use std::num::NonZeroU32;
+use error::Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {
@@ -22,3 +23,6 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     if ret == 0 { return Err(io::Error::last_os_error().into()); }
     Ok(())
 }
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -14,7 +14,7 @@ use self::winapi::um::ntsecapi::RtlGenRandom;
 use self::winapi::um::winnt::PVOID;
 use std::io;
 use std::num::NonZeroU32;
-use error::Error;
+use Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe {


### PR DESCRIPTION
This makes a few changes:

-   revises error codes to have a common prefix
-   allows custom codes and messages per target
-   makes the `error` module public

It feels quite clunky having to add an empty `fn error_msg_inner` to all modules, but I don't see a better approach.

@newpavlov review? I think this concludes all my to-do list for the first release.

BTW the `dummy` module was broken; we don't appear to have a test for it (I hacked `lib.rs` locally).