### PR TITLE
Prepare 0.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,5 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.0] - 2019-03-23
+Publish initial implementation.
+
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.


### PR DESCRIPTION
@newpavlov I think we are ready for the initial release?

This would mark the lib as ready for testing, though the real testing happens when Rand 0.7 reaches pre-release status.