### PR TITLE
Added support for wasm32-unknown-wasi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,11 @@ matrix:
         - cargo test
 
     - rust: nightly
-      env: DESCRIPTION="WASM via emscripten, stdweb and wasm-bindgen"
+      env: DESCRIPTION="WASM via emscripten, stdweb, wasm-bindgen and WASI"
       install:
         - rustup target add wasm32-unknown-unknown
         - rustup target add wasm32-unknown-emscripten
+        - rustup target add wasm32-unknown-wasi
         - nvm install 9
         - ./utils/ci/install_cargo_web.sh
         - cargo web prepare-emscripten
@@ -80,6 +81,7 @@ matrix:
         #- cargo web test --target wasm32-unknown-emscripten
         #- cargo web test --nodejs --target wasm32-unknown-emscripten
         #- cargo build --target wasm32-unknown-unknown # without any features
+        - cargo build --target wasm32-unknown-wasi
         - cargo build --target wasm32-unknown-unknown --features=wasm-bindgen
         - cargo web test --target wasm32-unknown-unknown --features=stdweb
         - cargo build --manifest-path tests/wasm_bindgen/Cargo.toml --target wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.2] - 2019-04-06
+- Add support for `wasm32-unknown-wasi` target.
+
 ## [0.1.1] - 2019-04-05
 - Enable std functionality for CloudABI by default.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,5 +36,8 @@ fuchsia-cprng = "0.1"
 wasm-bindgen = { version = "0.2.29", optional = true }
 stdweb = { version = "0.4.9", optional = true }
 
+[target.wasm32-unknown-wasi.dependencies]
+libc = "0.2.51"
+
 [features]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This library is `no_std` compatible, but uses `std` on most platforms.
 The `log` library is supported as an optional dependency. If enabled, error
 reporting will be improved on some platforms.
 
-For WebAssembly (`wasm32`), Enscripten targets are supported directly; otherwise
+For WebAssembly (`wasm32`), WASI and Emscripten targets are supported directly; otherwise
 one of the following features must be enabled:
 
 -   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,0 +1,27 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation for WASI
+use crate::Error;
+use core::num::NonZeroU32;
+use std::io;
+
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+    let ret = unsafe { 
+        libc::__wasi_random_get(dest.as_mut_ptr() as *mut libc::c_void, dest.len())
+    };
+    if ret == libc::__WASI_ESUCCESS {
+        Ok(())
+    } else {
+        error!("WASI: __wasi_random_get failed with return value {}", ret);
+        Err(io::Error::last_os_error().into())
+    }
+}
+
+#[inline(always)]
+pub fn error_msg_inner(_: NonZeroU32) -> Option<&'static str> { None }


### PR DESCRIPTION
This update adds support for the `wasm32-unknown-wasi` compilation target. Random data is generated using the `__wasi_random_get` function.