### PR TITLE
Update the WASI support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ matrix:
       install:
         - rustup target add wasm32-unknown-unknown
         - rustup target add wasm32-unknown-emscripten
-        - rustup target add wasm32-unknown-wasi
+        - rustup target add wasm32-wasi
         - nvm install 9
         - ./utils/ci/install_cargo_web.sh
         - cargo web prepare-emscripten
@@ -81,7 +81,7 @@ matrix:
         #- cargo web test --target wasm32-unknown-emscripten
         #- cargo web test --nodejs --target wasm32-unknown-emscripten
         #- cargo build --target wasm32-unknown-unknown # without any features
-        - cargo build --target wasm32-unknown-wasi
+        - cargo build --target wasm32-wasi
         - cargo build --target wasm32-unknown-unknown --features=wasm-bindgen
         - cargo web test --target wasm32-unknown-unknown --features=stdweb
         - cargo build --manifest-path tests/wasm_bindgen/Cargo.toml --target wasm32-unknown-unknown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.1.3] - 2019-05-15
+- Update for `wasm32-unknown-wasi` being renamed to `wasm32-wasi`, and for
+  WASI being categorized as an OS.
+
 ## [0.1.2] - 2019-04-06
 - Add support for `wasm32-unknown-wasi` target.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ fuchsia-cprng = "0.1"
 wasm-bindgen = { version = "0.2.29", optional = true }
 stdweb = { version = "0.4.9", optional = true }
 
-[target.wasm32-unknown-wasi.dependencies]
-libc = "0.2.51"
+[target.wasm32-wasi.dependencies]
+libc = "0.2.54"
 
 [features]
 std = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,8 +46,8 @@
 //! enabled `wasm-bindgen` will be used. If neither feature is enabled,
 //! `getrandom` will always fail.
 //! 
-//! The WASI target `wasm32-unknown-wasi` uses the `__wasi_random_get` 
-//! function defined by the WASI standard.
+//! The WASI target `wasm32-wasi` uses the `__wasi_random_get` function defined
+//! by the WASI standard.
 //! 
 //!
 //! ## Early boot
@@ -143,7 +143,7 @@ extern crate std;
     target_os = "linux",
     all(
         target_arch = "wasm32", 
-        not(target_env = "wasi")
+        not(target_os = "wasi")
     ),
 ))]
 mod utils;
@@ -190,13 +190,13 @@ mod_use!(cfg(target_os = "redox"), use_file);
 mod_use!(cfg(target_os = "solaris"), solaris_illumos);
 mod_use!(cfg(windows), windows);
 mod_use!(cfg(target_env = "sgx"), sgx);
-mod_use!(cfg(target_env = "wasi"), wasi);
+mod_use!(cfg(target_os = "wasi"), wasi);
 
 mod_use!(
     cfg(all(
         target_arch = "wasm32",
         not(target_os = "emscripten"),
-        not(target_env = "wasi"),
+        not(target_os = "wasi"),
         feature = "wasm-bindgen"
     )),
     wasm32_bindgen
@@ -206,7 +206,7 @@ mod_use!(
     cfg(all(
         target_arch = "wasm32",
         not(target_os = "emscripten"),
-        not(target_env = "wasi"),
+        not(target_os = "wasi"),
         not(feature = "wasm-bindgen"),
         feature = "stdweb",
     )),
@@ -237,7 +237,7 @@ mod_use!(
             target_arch = "wasm32",
             any(
                 target_os = "emscripten",
-                target_env = "wasi",
+                target_os = "wasi",
                 feature = "wasm-bindgen",
                 feature = "stdweb",
             ),


### PR DESCRIPTION
 - WASI is now categorized as an OS rather than an environment.
   (https://github.com/rust-lang/rust/pull/60117)
 - The WASI triple is renamed from wasm32-unknown-wasi to wasm32-wasi.
   (https://github.com/rust-lang/rust/pull/60585)
