### PR TITLE
macos: Cleanup SecRandom type

### DIFF
--- a/src/macos.rs
+++ b/src/macos.rs
@@ -11,7 +11,6 @@ extern crate std;
 
 use crate::Error;
 use std::io;
-use core::ffi::c_void;
 use core::num::NonZeroU32;
 
 // TODO: Make extern once extern_types feature is stabilized. See:

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -11,29 +11,23 @@ extern crate std;
 
 use crate::Error;
 use std::io;
+use core::ffi::c_void;
 use core::num::NonZeroU32;
 
-enum SecRandom {}
-
-/// Essentially a null pointer (type `SecRandomRef`)
-#[allow(non_upper_case_globals)]
-const kSecRandomDefault: *const SecRandom = 0 as *const SecRandom;
+// TODO: Make extern once extern_types feature is stabilized. See:
+//   https://github.com/rust-lang/rust/issues/43467
+#[repr(C)]
+struct SecRandom([u8; 0]);
 
 #[link(name = "Security", kind = "framework")]
 extern {
-    fn SecRandomCopyBytes(
-        rnd: *const SecRandom, count: libc::size_t, bytes: *mut u8,
-    ) -> libc::c_int;
+    static kSecRandomDefault: *const SecRandom;
+
+    fn SecRandomCopyBytes(rnd: *const SecRandom, count: usize, bytes: *mut u8) -> libc::c_int;
 }
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe {
-        SecRandomCopyBytes(
-            kSecRandomDefault,
-            dest.len() as libc::size_t,
-            dest.as_mut_ptr(),
-        )
-    };
+    let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
     if ret == -1 {
         error!("SecRandomCopyBytes call failed");
         Err(io::Error::last_os_error().into())


### PR DESCRIPTION
Right now `SecRandom` is an uninhabited type. However, opaque pointers
are not supposed to be pointers to uninhabited types or ZSTs. This
issue was solved in `core` by introducing `core::ffi:c_void` that just
does all the right things.

This PR:

  - Changes `SecRandom` to be a `transparent` wrapper around `c_void`.
  - Links `kSecRandomDefault` instead of defining it ourself.
  - Should not change any behavior on macos.