### PR TITLE
freebsd: Increase consistancy with libc implementation

### DIFF
--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -14,21 +14,30 @@ use std::io;
 use core::ptr;
 use core::num::NonZeroU32;
 
+fn kern_arnd(buf: &mut [u8]) -> Result<usize, Error> {
+    static MIB: [libc::c_int; 2] = [libc::CTL_KERN, libc::KERN_ARND];
+    let mut len = buf.len();
+    let ret = unsafe {
+        libc::sysctl(
+            MIB.as_ptr(),
+            MIB.len() as libc::c_uint,
+            buf.as_mut_ptr() as *mut _,
+            &mut len,
+            ptr::null(),
+            0,
+        )
+    };
+    if ret == -1 {
+        error!("freebsd: kern.arandom syscall failed");
+        return Err(io::Error::last_os_error().into());
+    }
+    Ok(len)
+}
+
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let mib = [libc::CTL_KERN, libc::KERN_ARND];
-    // kern.arandom permits a maximum buffer size of 256 bytes
-    for chunk in dest.chunks_mut(256) {
-        let mut len = chunk.len();
-        let ret = unsafe {
-            libc::sysctl(
-                mib.as_ptr(), mib.len() as libc::c_uint,
-                chunk.as_mut_ptr() as *mut _, &mut len, ptr::null(), 0,
-            )
-        };
-        if ret == -1 || len != chunk.len() {
-            error!("freebsd: kern.arandom syscall failed");
-            return Err(io::Error::last_os_error().into());
-        }
+    let mut start = 0;
+    while start < dest.len() {
+        start += kern_arnd(&mut dest[start..])?;
     }
     Ok(())
 }


### PR DESCRIPTION
In #35 @myfreeweb pointed out that the [FreeBSD's libc implemenation](https://github.com/freebsd/freebsd/blob/d946d8f14c81df5c94524f0c759db84880bbcae8/lib/libc/gen/getentropy.c#L64-L71) calls `kern_arnd` in a loop, and simply retries if the syscall returns a short buffer.

There doesn't seem like a good reason to differ from their implementation, so this PR changes the implementation to be more like the one for Linux `getrandom`.