### PR TITLE
Check for AMD RDRAND bug

### DIFF
--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -26,7 +26,7 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
             // AMD CPUs from families 14h to 16h (pre Ryzen) will sometimes give
             // bogus random data. Discard these values and warn the user.
             // See https://github.com/systemd/systemd/issues/11810#issuecomment-489727505
-            if el == 0 || el == !0 {
+            if cfg!(not(target_env = "sgx")) && (el == 0 || el == !0) {
                 error!("RDRAND returned suspicious value {}, CPU RNG is broken", el);
                 return Err(Error::UNKNOWN)
             }

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -23,6 +23,13 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
     for _ in 0..RETRY_LIMIT {
         let mut el = mem::uninitialized();
         if _rdrand64_step(&mut el) == 1 {
+            // AMD CPUs from families 14h to 16h (pre Ryzen) will sometimes give
+            // bogus random data. Discard these values and warn the user.
+            // See https://github.com/systemd/systemd/issues/11810#issuecomment-489727505
+            if el == 0 || el == !0 {
+                error!("RDRAND returned suspicious value {}, CPU RNG is broken", el);
+                return Err(Error::UNKNOWN)
+            }
             return Ok(el.to_ne_bytes());
         }
     }
@@ -36,14 +43,14 @@ compile_error!(
     "SGX targets require 'rdrand' target feature. Enable by using -C target-feature=+rdrnd."
 );
 
-#[cfg(any(target_env = "sgx", target_feature = "rdrand"))]
+#[cfg(target_feature = "rdrand")]
 fn is_rdrand_supported() -> bool {
     true
 }
 
 // TODO use is_x86_feature_detected!("rdrand") when that works in core. See:
 // https://github.com/rust-lang-nursery/stdsimd/issues/464
-#[cfg(not(any(target_env = "sgx", target_feature = "rdrand")))]
+#[cfg(not(target_feature = "rdrand"))]
 fn is_rdrand_supported() -> bool {
     use core::arch::x86_64::__cpuid;
     use lazy_static::lazy_static;


### PR DESCRIPTION
Pre-Ryzen AMD CPUs have a very serious bug where they will sometimes give `0xFFFFFFFF` as the output of RDRAND without setting the carry flag. This issue usually occurs when those CPU's awake from sleep: https://github.com/systemd/systemd/issues/11810#issuecomment-489727505

This CL simply implement's systemd's fix, where they [check for the bogus value and issue an error](https://github.com/systemd/systemd/blob/master/src/basic/random-util.c#L129-L138).

This PR also cleans up the `target_feature` checks. As we already fail to compile on `sgx` when `rdrand` is not enabled, the `is_rdrand_supported` function checks can just be `target_feature = "rdrand"`.