### PR TITLE
Use shared File instead of shared FD.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -74,6 +74,12 @@ impl From<NonZeroU32> for Error {
     }
 }
 
+impl From<&Error> for Error {
+    fn from(error: &Error) -> Self {
+        *error
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::Error;


### PR DESCRIPTION
Fixes #44 and removes use of `unsafe` code.

This can be implemented without `unsafe` because [`&'_ File` implements `Read`](https://doc.rust-lang.org/std/fs/struct.File.html#implementations), indicating that files can be read by multiple readers at the same time.