### PR TITLE
Alternative way to detect AMD bug

### DIFF
--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -27,7 +27,7 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
             // set CF on bogus random data, so we check these values explictly.
             // See https://github.com/systemd/systemd/issues/11810#issuecomment-489727505
             // We perform this check regardless of target to guard against
-            // future implementations that incorrectly set CF.
+            // any implementation that incorrectly fails to set CF.
             if el != 0 && el != !0 {
                 return Ok(el.to_ne_bytes());
             }


### PR DESCRIPTION
This is an alternative way to do the AMD bug detection "fixed" in #43.

@newpavlov feel free to immediately close this if you think this way is overly complex.

Before we checked the return value of RDRAND to detect the bug. However, this will occasionally return a false positive (every (1/2)^63 invocations), so we use the existing retry loop to try again. I also added comments explaining that:
  
  - The issue here is AMD not setting the CF flag properly (as RDRAND is allowed to fail)
  - Why we perform this check on all targets.