### PR TITLE
Remove lazy_static dependancy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,13 +102,14 @@ matrix:
 
     - rust: nightly
       env: DESCRIPTION="cross-platform build only"
+      # Redox: wait for https://github.com/rust-lang/rust/issues/60139
       install:
         - rustup target add x86_64-sun-solaris
         - rustup target add x86_64-unknown-cloudabi
         - rustup target add x86_64-unknown-freebsd
         - rustup target add x86_64-fuchsia
         - rustup target add x86_64-unknown-netbsd
-        - rustup target add x86_64-unknown-redox
+        # - rustup target add x86_64-unknown-redox
         - rustup target add x86_64-fortanix-unknown-sgx
         # For no_std targets
         - rustup component add rust-src
@@ -119,7 +120,7 @@ matrix:
         - cargo build --target=x86_64-unknown-freebsd --all-features
         - cargo build --target=x86_64-fuchsia --all-features
         - cargo build --target=x86_64-unknown-netbsd --all-features
-        - cargo build --target=x86_64-unknown-redox --all-features
+        # - cargo build --target=x86_64-unknown-redox --all-features
         - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
         - cargo xbuild --target=x86_64-unknown-uefi
         # also test minimum dependency versions are usable
@@ -129,7 +130,7 @@ matrix:
         - cargo build --target=x86_64-unknown-freebsd --all-features
         - cargo build --target=x86_64-fuchsia --all-features
         - cargo build --target=x86_64-unknown-netbsd --all-features
-        - cargo build --target=x86_64-unknown-redox --all-features
+        # - cargo build --target=x86_64-unknown-redox --all-features
         - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
         - cargo xbuild --target=x86_64-unknown-uefi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,6 @@ lazy_static = "1.3.0"
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }
 stdweb = { version = "0.4.9", optional = true }
-lazy_static = "1.3.0"
 
 [features]
 std = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,6 @@ log = { version = "0.4", optional = true }
 [target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
 libc = "0.2.54"
 
-# For holding file descriptors
-[target.'cfg(any(unix, target_os = "redox"))'.dependencies]
-lazy_static = "1.3.0"
-
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }
 stdweb = { version = "0.4.9", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = ["tests/wasm_bindgen"]
 [dependencies]
 log = { version = "0.4", optional = true }
 
-[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+[target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
 libc = "0.2.54"
 
 # For holding file descriptors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,11 +142,11 @@ extern crate std;
 
 mod error;
 pub use crate::error::Error;
+
 #[allow(dead_code)]
 mod util;
-
-// These targets need weak linkage to libc randomness functions.
-#[cfg(any(target_os = "macos", target_os = "solaris", target_os = "illumos"))]
+#[cfg(any(unix, target_os = "redox"))]
+#[allow(dead_code)]
 mod util_libc;
 
 // System-specific implementations.

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -14,7 +14,10 @@ use crate::Error;
 use core::mem::ManuallyDrop;
 use core::num::NonZeroU32;
 use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
-use std::{fs::File, io::Read};
+use std::{
+    fs::File,
+    io::{self, Read},
+};
 
 #[cfg(target_os = "redox")]
 const FILE_PATH: &str = "rand:";
@@ -32,7 +35,7 @@ const FILE_PATH: &str = "/dev/random";
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static FD: LazyFd = LazyFd::new();
-    let fd = FD.init(init_file).ok_or(Error::UNKNOWN)?;
+    let fd = FD.init(init_file).ok_or(io::Error::last_os_error())?;
     let file = ManuallyDrop::new(unsafe { File::from_raw_fd(fd) });
     let mut file_ref: &File = &file;
 

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -9,9 +9,11 @@
 //! Implementations that just need to read from a file
 extern crate std;
 
+use crate::util_libc::LazyFd;
 use crate::Error;
+use core::mem::ManuallyDrop;
 use core::num::NonZeroU32;
-use lazy_static::lazy_static;
+use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
 use std::{fs::File, io::Read};
 
 #[cfg(target_os = "redox")]
@@ -29,28 +31,31 @@ const FILE_PATH: &str = "/dev/urandom";
 const FILE_PATH: &str = "/dev/random";
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    lazy_static! {
-        static ref FILE: Result<File, Error> = init_file();
-    }
-    let mut f = FILE.as_ref()?;
+    static FD: LazyFd = LazyFd::new();
+    let fd = FD.init(init_file).ok_or(Error::UNKNOWN)?;
+    let file = ManuallyDrop::new(unsafe { File::from_raw_fd(fd) });
+    let mut file_ref: &File = &file;
 
     if cfg!(target_os = "emscripten") {
         // `Crypto.getRandomValues` documents `dest` should be at most 65536 bytes.
         for chunk in dest.chunks_mut(65536) {
-            f.read_exact(chunk)?;
+            file_ref.read_exact(chunk)?;
         }
     } else {
-        f.read_exact(dest)?;
+        file_ref.read_exact(dest)?;
     }
     Ok(())
 }
 
-fn init_file() -> Result<File, Error> {
+fn init_file() -> Option<RawFd> {
     if FILE_PATH == "/dev/urandom" {
         // read one byte from "/dev/random" to ensure that OS RNG has initialized
-        File::open("/dev/random")?.read_exact(&mut [0u8; 1])?;
+        File::open("/dev/random")
+            .ok()?
+            .read_exact(&mut [0u8; 1])
+            .ok()?;
     }
-    Ok(File::open(FILE_PATH)?)
+    Some(File::open(FILE_PATH).ok()?.into_raw_fd())
 }
 
 #[inline(always)]


### PR DESCRIPTION
EDIT1: We make the following changes:
 - Replace `wasm32-stdweb`'s use of `lazy_static` with `static mut` and `std::sync::Once`
 - Add a `sync_init` method to `LazyUsize` complementing `unsync_init`.
 - Add a `LazyFd` abstraction around `LazyUsize` to work with `Option<i32>` values, were we either have `None` or `Some(x)` with x non-negative.
 - Use the `LazyFd` in `use_file`, eliminating our last use of `lazy_static`.

EDIT2: Note that this does not try to remove all `std` dependencies from `use_file.rs`. That is for a followup CL. 