### PR TITLE
openBSD: Make imports consistent

### DIFF
--- a/src/openbsd_bitrig.rs
+++ b/src/openbsd_bitrig.rs
@@ -10,8 +10,8 @@
 extern crate std;
 
 use crate::Error;
+use core::num::NonZeroU32;
 use std::io;
-use std::num::NonZeroU32;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {


### PR DESCRIPTION
Everywhere else uses `core::num::NonZeroU32`, and it makes `std::` grepping better.