### PR TITLE
Use cfg-if to simplify lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = ["tests/wasm_bindgen"]
 
 [dependencies]
 log = { version = "0.4", optional = true }
+cfg-if = "0.1"
 
 [target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
 libc = "0.2.54"

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,7 +38,7 @@ impl Error {
     }
 
     pub(crate) fn msg(&self) -> Option<&'static str> {
-        if let Some(msg) = super::error_msg_inner(self.0) {
+        if let Some(msg) = crate::imp::error_msg_inner(self.0) {
             Some(msg)
         } else {
             match *self {

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -11,7 +11,6 @@ extern crate std;
 
 use crate::Error;
 use core::num::NonZeroU32;
-use std::io;
 
 // TODO: Make extern once extern_types feature is stabilized. See:
 //   https://github.com/rust-lang/rust/issues/43467
@@ -29,7 +28,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
     if ret == -1 {
         error!("SecRandomCopyBytes call failed");
-        Err(io::Error::last_os_error().into())
+        Err(Error::UNKNOWN)
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -127,17 +127,23 @@
 #![no_std]
 #![cfg_attr(feature = "stdweb", recursion_limit = "128")]
 
-#[cfg(feature = "log")]
 #[macro_use]
-extern crate log;
-#[cfg(not(feature = "log"))]
-#[allow(unused)]
-macro_rules! error {
-    ($($x:tt)*) => {};
+extern crate cfg_if;
+
+cfg_if! {
+    if #[cfg(feature = "log")] {
+        #[allow(unused)]
+        #[macro_use]
+        extern crate log;
+    } else {
+        #[allow(unused)]
+        macro_rules! error {
+            ($($x:tt)*) => {};
+        }
+    }
 }
 
-// temp fix for stdweb
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "std")]
 extern crate std;
 
 mod error;
@@ -149,27 +155,8 @@ mod util;
 #[allow(dead_code)]
 mod util_libc;
 
-// System-specific implementations.
-//
-// These should all provide getrandom_inner with the same signature as getrandom.
-
-macro_rules! mod_use {
-    ($cond:meta, $module:ident) => {
-        #[$cond]
-        mod $module;
-        #[$cond]
-        use crate::$module::{error_msg_inner, getrandom_inner};
-    };
-}
-
-// These targets use std anyway, so we use the std declarations.
-#[cfg(any(
-    feature = "std",
-    windows,
-    unix,
-    target_os = "redox",
-    target_arch = "wasm32",
-))]
+// std-only trait definitions (also need for use_file)
+#[cfg(any(feature = "std", unix, target_os = "redox"))]
 mod error_impls;
 
 // These targets read from a file as a fallback method.
@@ -180,79 +167,69 @@ mod error_impls;
     target_os = "solaris",
     target_os = "illumos",
 ))]
+#[allow(dead_code)]
 mod use_file;
 
-mod_use!(cfg(target_os = "android"), linux_android);
-mod_use!(cfg(target_os = "bitrig"), openbsd_bitrig);
-mod_use!(cfg(target_os = "cloudabi"), cloudabi);
-mod_use!(cfg(target_os = "dragonfly"), use_file);
-mod_use!(cfg(target_os = "emscripten"), use_file);
-mod_use!(cfg(target_os = "freebsd"), freebsd);
-mod_use!(cfg(target_os = "fuchsia"), fuchsia);
-mod_use!(cfg(target_os = "haiku"), use_file);
-mod_use!(cfg(target_os = "illumos"), solaris_illumos);
-mod_use!(cfg(target_os = "ios"), ios);
-mod_use!(cfg(target_os = "linux"), linux_android);
-mod_use!(cfg(target_os = "macos"), macos);
-mod_use!(cfg(target_os = "netbsd"), use_file);
-mod_use!(cfg(target_os = "openbsd"), openbsd_bitrig);
-mod_use!(cfg(target_os = "redox"), use_file);
-mod_use!(cfg(target_os = "solaris"), solaris_illumos);
-mod_use!(cfg(windows), windows);
-mod_use!(cfg(target_env = "sgx"), rdrand);
-mod_use!(cfg(all(target_arch = "x86_64", target_os = "uefi")), rdrand);
-mod_use!(cfg(target_os = "wasi"), wasi);
-
-mod_use!(
-    cfg(all(
-        target_arch = "wasm32",
-        not(target_os = "emscripten"),
-        not(target_os = "wasi"),
-        feature = "wasm-bindgen"
-    )),
-    wasm32_bindgen
-);
-
-mod_use!(
-    cfg(all(
-        target_arch = "wasm32",
-        not(target_os = "emscripten"),
-        not(target_os = "wasi"),
-        not(feature = "wasm-bindgen"),
-        feature = "stdweb",
-    )),
-    wasm32_stdweb
-);
-
-mod_use!(
-    cfg(not(any(
-        target_os = "android",
-        target_os = "bitrig",
-        target_os = "cloudabi",
-        target_os = "dragonfly",
-        target_os = "emscripten",
-        target_os = "freebsd",
-        target_os = "fuchsia",
-        target_os = "haiku",
-        target_os = "illumos",
-        target_os = "ios",
-        target_os = "linux",
-        target_os = "macos",
-        target_os = "netbsd",
-        target_os = "openbsd",
-        target_os = "redox",
-        target_os = "solaris",
-        all(target_arch = "x86_64", target_os = "uefi"),
-        target_os = "wasi",
-        target_env = "sgx",
-        windows,
-        all(
-            target_arch = "wasm32",
-            any(feature = "wasm-bindgen", feature = "stdweb"),
-        ),
-    ))),
-    dummy
-);
+// System-specific implementations.
+//
+// These should all provide getrandom_inner with the same signature as getrandom.
+cfg_if! {
+    if #[cfg(target_os = "android")] {
+        #[path = "linux_android.rs"] mod imp;
+    } else if #[cfg(target_os = "bitrig")] {
+        #[path = "openbsd_bitrig.rs"] mod imp;
+    } else if #[cfg(target_os = "cloudabi")] {
+        #[path = "cloudabi.rs"] mod imp;
+    } else if #[cfg(target_os = "dragonfly")] {
+        #[path = "use_file.rs"] mod imp;
+    } else if #[cfg(target_os = "emscripten")] {
+        #[path = "use_file.rs"] mod imp;
+    } else if #[cfg(target_os = "freebsd")] {
+        #[path = "freebsd.rs"] mod imp;
+    } else if #[cfg(target_os = "fuchsia")] {
+        #[path = "fuchsia.rs"] mod imp;
+    } else if #[cfg(target_os = "haiku")] {
+        #[path = "use_file.rs"] mod imp;
+    } else if #[cfg(target_os = "illumos")] {
+        #[path = "solaris_illumos.rs"] mod imp;
+    } else if #[cfg(target_os = "ios")] {
+        #[path = "ios.rs"] mod imp;
+    } else if #[cfg(target_os = "linux")] {
+        #[path = "linux_android.rs"] mod imp;
+    } else if #[cfg(target_os = "macos")] {
+        #[path = "macos.rs"] mod imp;
+    } else if #[cfg(target_os = "netbsd")] {
+        #[path = "use_file.rs"] mod imp;
+    } else if #[cfg(target_os = "openbsd")] {
+        #[path = "openbsd_bitrig.rs"] mod imp;
+    } else if #[cfg(target_os = "redox")] {
+        #[path = "use_file.rs"] mod imp;
+    } else if #[cfg(target_os = "solaris")] {
+        #[path = "solaris_illumos.rs"] mod imp;
+    } else if #[cfg(target_os = "wasi")] {
+        #[path = "wasi.rs"] mod imp;
+    } else if #[cfg(windows)] {
+        #[path = "windows.rs"] mod imp;
+    } else if #[cfg(target_env = "sgx")] {
+        #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(all(target_arch = "x86_64", target_os = "uefi"))] {
+        #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(target_arch = "wasm32")] {
+        cfg_if! {
+            if #[cfg(feature = "wasm-bindgen")] {
+                #[path = "wasm32_bindgen.rs"] mod imp;
+            } else if #[cfg(feature = "stdweb")] {
+                // temp fix for stdweb
+                extern crate std;
+                #[path = "wasm32_stdweb.rs"] mod imp;
+            } else {
+                #[path = "dummy.rs"] mod imp;
+            }
+        }
+    } else {
+        #[path = "dummy.rs"] mod imp;
+    }
+}
 
 /// Fill `dest` with random bytes from the system's preferred random number
 /// source.
@@ -266,5 +243,5 @@ mod_use!(
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
 pub fn getrandom(dest: &mut [u8]) -> Result<(), error::Error> {
-    getrandom_inner(dest)
+    imp::getrandom_inner(dest)
 }

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -7,6 +7,7 @@
 // except according to those terms.
 
 //! Implementation for SGX using RDRAND instruction
+#[cfg(not(target_feature = "rdrand"))]
 use crate::util::LazyBool;
 use crate::Error;
 use core::arch::x86_64::_rdrand64_step;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -9,16 +9,15 @@
 //! Implementation for WASI
 use crate::Error;
 use core::num::NonZeroU32;
-use std::io;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret =
         unsafe { libc::__wasi_random_get(dest.as_mut_ptr() as *mut libc::c_void, dest.len()) };
-    if ret == libc::__WASI_ESUCCESS {
-        Ok(())
+    if let Some(code) = NonZeroU32::new(ret as u32) {
+        error!("WASI: __wasi_random_get failed with return value {}", code);
+        Err(Error::from(code))
     } else {
-        error!("WASI: __wasi_random_get failed with return value {}", ret);
-        Err(io::Error::last_os_error().into())
+        Ok(()) // Zero means success for WASI
     }
 }
 

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -7,6 +7,8 @@
 // except according to those terms.
 
 //! Implementation for WASM via wasm-bindgen
+extern crate std;
+
 use core::cell::RefCell;
 use core::mem;
 use core::num::NonZeroU32;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,7 +11,6 @@ extern crate std;
 
 use crate::Error;
 use core::num::NonZeroU32;
-use std::io;
 
 extern "system" {
     #[link_name = "SystemFunction036"]
@@ -24,7 +23,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         let ret = unsafe { RtlGenRandom(chunk.as_mut_ptr(), chunk.len() as u32) };
         if ret == 0 {
             error!("RtlGenRandom call failed");
-            return Err(io::Error::last_os_error().into());
+            return Err(Error::UNKNOWN);
         }
     }
     Ok(())


### PR DESCRIPTION
This crate uses `cfg-if` to simplify the target switching in `getrandom`. It's already a dependency of `libstd`, so this does not hurt the goals of https://github.com/rust-lang/rust/pull/62082

This change also stops trying to use `errno` (or equivalent) on Windows and iOS. The docs for these functions make no mention of error indications other than their return values. It also correctly handles errno on WASI (it's just the positive returned value, like `cloudabi`).

This removes the `std::io` dependency for these targets.

It also fixes a few `unused` warnings. 