### PR TITLE
Freebsd: Try getrandom() first

### DIFF
--- a/src/freebsd.rs
+++ b/src/freebsd.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for FreeBSD
-use crate::util_libc::{fill_exact, Weak};
+use crate::util_libc::{sys_fill_exact, Weak};
 use crate::Error;
 use core::num::NonZeroU32;
 use core::{mem, ptr};
@@ -39,9 +39,9 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     if let Some(fptr) = GETRANDOM.ptr() {
         let func: GetRandomFn = unsafe { mem::transmute(fptr) };
-        fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) })
+        sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) })
     } else {
-        fill_exact(dest, kern_arnd)
+        sys_fill_exact(dest, kern_arnd)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! | Windows          | [`RtlGenRandom`][3]
 //! | macOS            | [`getentropy()`][19] if available, otherise [`/dev/random`][20] (identical to `/dev/urandom`)
 //! | iOS              | [`SecRandomCopyBytes`][4]
-//! | FreeBSD          | [`kern.arandom`][5]
+//! | FreeBSD          | [`getrandom()`][21] if available, otherise [`kern.arandom`][5]
 //! | OpenBSD          | [`getentropy`][6]
 //! | NetBSD           | [`/dev/urandom`][7] after reading from `/dev/random` once
 //! | Dragonfly BSD    | [`/dev/random`][8]
@@ -118,6 +118,7 @@
 //! [18]: https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
 //! [19]: https://www.unix.com/man-page/mojave/2/getentropy/
 //! [20]: https://www.unix.com/man-page/mojave/4/random/
+//! [21]: https://www.freebsd.org/cgi/man.cgi?query=getrandom&manpath=FreeBSD+12.0-stable
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,9 +14,9 @@
 //! |------------------|---------------------------------------------------------
 //! | Linux, Android   | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after reading from `/dev/random` once
 //! | Windows          | [`RtlGenRandom`][3]
-//! | macOS            | [`getentropy()`][19] if available, otherise [`/dev/random`][20] (identical to `/dev/urandom`)
+//! | macOS            | [`getentropy()`][19] if available, otherwise [`/dev/random`][20] (identical to `/dev/urandom`)
 //! | iOS              | [`SecRandomCopyBytes`][4]
-//! | FreeBSD          | [`getrandom()`][21] if available, otherise [`kern.arandom`][5]
+//! | FreeBSD          | [`getrandom()`][21] if available, otherwise [`kern.arandom`][5]
 //! | OpenBSD          | [`getentropy`][6]
 //! | NetBSD           | [`/dev/urandom`][7] after reading from `/dev/random` once
 //! | Dragonfly BSD    | [`/dev/random`][8]

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -10,7 +10,7 @@
 extern crate std;
 
 use crate::util::LazyBool;
-use crate::util_libc::fill_exact;
+use crate::util_libc::sys_fill_exact;
 use crate::{use_file, Error};
 use core::num::NonZeroU32;
 use std::io;
@@ -18,7 +18,7 @@ use std::io;
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {
-        fill_exact(dest, |buf| unsafe {
+        sys_fill_exact(dest, |buf| unsafe {
             libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
         })
     } else {

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -10,45 +10,32 @@
 extern crate std;
 
 use crate::util::LazyBool;
+use crate::util_libc::fill_exact;
 use crate::{use_file, Error};
 use core::num::NonZeroU32;
 use std::io;
 
-fn syscall_getrandom(dest: &mut [u8], block: bool) -> Result<usize, io::Error> {
-    let flags = if block { 0 } else { libc::GRND_NONBLOCK };
-    let ret = unsafe { libc::syscall(libc::SYS_getrandom, dest.as_mut_ptr(), dest.len(), flags) };
-    if ret < 0 {
-        let err = io::Error::last_os_error();
-        if err.raw_os_error() == Some(libc::EINTR) {
-            return Ok(0); // Call was interrupted, try again
-        }
-        error!("Linux getrandom syscall failed with return value {}", ret);
-        return Err(err);
-    }
-    Ok(ret as usize)
-}
-
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {
-        let mut start = 0;
-        while start < dest.len() {
-            start += syscall_getrandom(&mut dest[start..], true)?;
-        }
-        Ok(())
+        fill_exact(dest, |buf| unsafe {
+            libc::syscall(libc::SYS_getrandom, buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
+        })
     } else {
         use_file::getrandom_inner(dest)
     }
 }
 
 fn is_getrandom_available() -> bool {
-    match syscall_getrandom(&mut [], false) {
-        Err(err) => match err.raw_os_error() {
+    let res = unsafe { libc::syscall(libc::SYS_getrandom, 0, 0, libc::GRND_NONBLOCK) };
+    if res < 0 {
+        match io::Error::last_os_error().raw_os_error() {
             Some(libc::ENOSYS) => false, // No kernel support
             Some(libc::EPERM) => false,  // Blocked by seccomp
             _ => true,
-        },
-        Ok(_) => true,
+        }
+    } else {
+        true
     }
 }
 

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -17,13 +17,10 @@
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existance of getrandom(2) in libc by calling
 //! libc::dlsym.
-extern crate std;
-
-use crate::util_libc::Weak;
+use crate::util_libc::{fill_exact, Weak};
 use crate::{use_file, Error};
 use core::mem;
 use core::num::NonZeroU32;
-use std::io;
 
 #[cfg(target_os = "illumos")]
 type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
@@ -37,11 +34,9 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         // 256 bytes is the lowest common denominator across all the Solaris
         // derived platforms for atomically obtaining random data.
         for chunk in dest.chunks_mut(256) {
-            let ret = unsafe { func(chunk.as_mut_ptr(), chunk.len(), 0) };
-            if ret != chunk.len() as _ {
-                error!("getrandom syscall failed with ret={}", ret);
-                return Err(io::Error::last_os_error().into());
-            }
+            fill_exact(chunk, |buf| unsafe {
+                func(buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
+            })?
         }
         Ok(())
     } else {

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -17,7 +17,7 @@
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existance of getrandom(2) in libc by calling
 //! libc::dlsym.
-use crate::util_libc::{fill_exact, Weak};
+use crate::util_libc::{sys_fill_exact, Weak};
 use crate::{use_file, Error};
 use core::mem;
 use core::num::NonZeroU32;
@@ -34,7 +34,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         // 256 bytes is the lowest common denominator across all the Solaris
         // derived platforms for atomically obtaining random data.
         for chunk in dest.chunks_mut(256) {
-            fill_exact(chunk, |buf| unsafe {
+            sys_fill_exact(chunk, |buf| unsafe {
                 func(buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
             })?
         }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -12,9 +12,15 @@ use crate::Error;
 use core::ptr::NonNull;
 use std::io;
 
-pub fn fill_exact(mut buf: &mut [u8], f: impl Fn(&mut [u8]) -> libc::ssize_t) -> Result<(), Error> {
+// Fill a buffer by repeatedly invoking a system call. The `sys_fill` function:
+//   - should return -1 and set errno on failure
+//   - should return the number of bytes written on success
+pub fn sys_fill_exact(
+    mut buf: &mut [u8],
+    sys_fill: impl Fn(&mut [u8]) -> libc::ssize_t,
+) -> Result<(), Error> {
     while !buf.is_empty() {
-        let res = f(buf);
+        let res = sys_fill(buf);
         if res < 0 {
             let err = io::Error::last_os_error();
             // We should try again if the call was interrupted.


### PR DESCRIPTION
Depends on #54 fixes #35 

Implementation is quite similar to the Solaris/Illumos implementation. @myfreeweb PTAL

Edit: Also adds a `fill_exact` helper method for making repeated OS calls to fill a buffer. This let's us simplify the Linux/Solaris/FreeBSD code, as well as adding some changes useful for #54 and #58  