### PR TITLE
Remove libstd dependancy for Opening and Reading files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ log = { version = "0.4", optional = true }
 cfg-if = "0.1"
 
 [target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
-libc = "0.2.60"
+libc = { version = "0.2.60", default-features = false }
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A Rust library for retrieving random data from (operating) system source. It is
 assumed that system always provides high-quality cryptographically secure random
 data, ideally backed by hardware entropy sources. This crate derives its name
-from Linux's `getrandom` function, but is cross platform, aiming to support
+from Linux's `getrandom` function, but is cross platform, roughly supporting
 the same set of platforms as Rust's `std` lib.
 
 This is a low-level API. Most users should prefer using high-level random-number

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 A Rust library for retrieving random data from (operating) system source. It is
 assumed that system always provides high-quality cryptographically secure random
 data, ideally backed by hardware entropy sources. This crate derives its name
-from Linux's `getrandom` function, but is cross platform, roughly supporting
+from Linux's `getrandom` function, but is cross platform, aiming to support
 the same set of platforms as Rust's `std` lib.
 
 This is a low-level API. Most users should prefer using high-level random-number
@@ -40,7 +40,10 @@ fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
 
 ## Features
 
-This library is `no_std` compatible, but uses `std` on most platforms.
+This library is `no_std` for every supported target. However, getting randomness
+usually requires calling some external system API. This means most platforms
+will require linking against system libraries (i.e. `libc` for Unix,
+`Advapi32.dll` for Windows, Security framework on iOS, etc...).
 
 The `log` library is supported as an optional dependency. If enabled, error
 reporting will be improved on some platforms.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,22 +152,8 @@ mod util;
 #[allow(dead_code)]
 mod util_libc;
 
-// std-only trait definitions (also need for use_file)
-#[cfg(any(
-    feature = "std",
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-))]
+// std-only trait definitions
+#[cfg(feature = "std")]
 mod error_impls;
 
 // These targets read from a file as a fallback method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,13 +12,13 @@
 //!
 //! | OS               | interface
 //! |------------------|---------------------------------------------------------
-//! | Linux, Android   | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after reading from `/dev/random` once
+//! | Linux, Android   | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after successfully polling `/dev/random`
 //! | Windows          | [`RtlGenRandom`][3]
 //! | macOS            | [`getentropy()`][19] if available, otherwise [`/dev/random`][20] (identical to `/dev/urandom`)
 //! | iOS              | [`SecRandomCopyBytes`][4]
 //! | FreeBSD          | [`getrandom()`][21] if available, otherwise [`kern.arandom`][5]
 //! | OpenBSD          | [`getentropy`][6]
-//! | NetBSD           | [`/dev/urandom`][7] after reading from `/dev/random` once
+//! | NetBSD           | [`/dev/urandom`][7] after successfully polling `/dev/random`
 //! | Dragonfly BSD    | [`/dev/random`][8]
 //! | Solaris, illumos | [`getrandom`][9] system call if available, otherwise [`/dev/random`][10]
 //! | Fuchsia OS       | [`cprng_draw`][11]

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -7,18 +7,13 @@
 // except according to those terms.
 
 //! Implementations that just need to read from a file
-extern crate std;
-
-use crate::util_libc::{last_os_error, LazyFd};
+use crate::util_libc::{last_os_error, open_readonly, sys_fill_exact, LazyFd};
 use crate::Error;
-use core::mem::ManuallyDrop;
-use std::os::unix::io::{FromRawFd, IntoRawFd, RawFd};
-use std::{fs::File, io::Read};
 
 #[cfg(target_os = "redox")]
-const FILE_PATH: &str = "rand:";
+const FILE_PATH: &str = "rand:\0";
 #[cfg(any(target_os = "android", target_os = "linux", target_os = "netbsd"))]
-const FILE_PATH: &str = "/dev/urandom";
+const FILE_PATH: &str = "/dev/urandom\0";
 #[cfg(any(
     target_os = "dragonfly",
     target_os = "emscripten",
@@ -27,32 +22,50 @@ const FILE_PATH: &str = "/dev/urandom";
     target_os = "solaris",
     target_os = "illumos"
 ))]
-const FILE_PATH: &str = "/dev/random";
+const FILE_PATH: &str = "/dev/random\0";
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static FD: LazyFd = LazyFd::new();
     let fd = FD.init(init_file).ok_or(last_os_error())?;
-    let file = ManuallyDrop::new(unsafe { File::from_raw_fd(fd) });
-    let mut file_ref: &File = &file;
+    let read = |buf: &mut [u8]| unsafe { libc::read(fd, buf.as_mut_ptr() as *mut _, buf.len()) };
 
     if cfg!(target_os = "emscripten") {
         // `Crypto.getRandomValues` documents `dest` should be at most 65536 bytes.
         for chunk in dest.chunks_mut(65536) {
-            file_ref.read_exact(chunk)?;
+            sys_fill_exact(chunk, read)?;
         }
     } else {
-        file_ref.read_exact(dest)?;
+        sys_fill_exact(dest, read)?;
     }
     Ok(())
 }
 
-fn init_file() -> Option<RawFd> {
-    if FILE_PATH == "/dev/urandom" {
-        // read one byte from "/dev/random" to ensure that OS RNG has initialized
-        File::open("/dev/random")
-            .ok()?
-            .read_exact(&mut [0u8; 1])
-            .ok()?;
+fn init_file() -> Option<libc::c_int> {
+    if FILE_PATH == "/dev/urandom\0" {
+        // Poll /dev/random to make sure it is ok to read from /dev/urandom.
+        let mut pfd = libc::pollfd {
+            fd: unsafe { open_readonly("/dev/random\0")? },
+            events: libc::POLLIN,
+            revents: 0,
+        };
+
+        let mut res = -1;
+        while res <= 0 {
+            // A negative timeout means an infinite timeout.
+            res = unsafe { libc::poll(&mut pfd, 1, -1) };
+            if res < 0 {
+                match last_os_error().raw_os_error() {
+                    Some(libc::EINTR) | Some(libc::EAGAIN) => {}
+                    _ => break,
+                }
+            }
+        }
+
+        unsafe { libc::close(pfd.fd) };
+        if res != 1 {
+            // We either hard failed, or poll() returned the wrong pfd.
+            return None;
+        }
     }
-    Some(File::open(FILE_PATH).ok()?.into_raw_fd())
+    unsafe { open_readonly(FILE_PATH) }
 }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -116,3 +116,21 @@ impl LazyFd {
         }
     }
 }
+
+cfg_if! {
+    if #[cfg(any(target_os = "linux", target_os = "emscripten"))] {
+        use libc::open64 as open;
+    } else {
+        use libc::open;
+    }
+}
+
+// SAFETY: path must be null terminated, FD must be manually closed.
+pub unsafe fn open_readonly(path: &str) -> Option<libc::c_int> {
+    // We don't care about Linux OSes too old to support O_CLOEXEC.
+    let fd = open(path.as_ptr() as *mut _, libc::O_RDONLY | libc::O_CLOEXEC);
+    if fd < 0 {
+        return None;
+    }
+    Some(fd)
+}

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -127,6 +127,7 @@ cfg_if! {
 
 // SAFETY: path must be null terminated, FD must be manually closed.
 pub unsafe fn open_readonly(path: &str) -> Option<libc::c_int> {
+    debug_assert!(path.as_bytes().last() == Some(&0));
     // We don't care about Linux OSes too old to support O_CLOEXEC.
     let fd = open(path.as_ptr() as *mut _, libc::O_RDONLY | libc::O_CLOEXEC);
     if fd < 0 {

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -135,6 +135,6 @@ pub unsafe fn open_readonly(path: &str) -> Option<libc::c_int> {
     // O_CLOEXEC works on all Unix targets except for older Linux kernels (pre
     // 2.6.23), so we also use an ioctl to make sure FD_CLOEXEC is set.
     #[cfg(target_os = "linux")]
-    libc::ioctl(self.fd, libc::FIOCLEX);
+    libc::ioctl(fd, libc::FIOCLEX);
     Some(fd)
 }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -128,10 +128,13 @@ cfg_if! {
 // SAFETY: path must be null terminated, FD must be manually closed.
 pub unsafe fn open_readonly(path: &str) -> Option<libc::c_int> {
     debug_assert!(path.as_bytes().last() == Some(&0));
-    // We don't care about Linux OSes too old to support O_CLOEXEC.
     let fd = open(path.as_ptr() as *mut _, libc::O_RDONLY | libc::O_CLOEXEC);
     if fd < 0 {
         return None;
     }
+    // O_CLOEXEC works on all Unix targets except for older Linux kernels (pre
+    // 2.6.23), so we also use an ioctl to make sure FD_CLOEXEC is set.
+    #[cfg(target_os = "linux")]
+    libc::ioctl(self.fd, libc::FIOCLEX);
     Some(fd)
 }


### PR DESCRIPTION
Depends on #54 so only look at the last commit if you want to just review this PR.

This PR removes the last part of `libstd` we were depending on (when not using the `std` feature). Specifically:

- We now manually open files with `libc::open(path.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC)`
  - We don't care about Linux kernels too old to support `libc::O_CLOEXEC` (kernel < 2.6.22)
- All the filenames now have to be null-terminated
- Instead of reading one byte from `/dev/random` we now [`poll(2)`](http://man7.org/linux/man-pages/man2/poll.2.html) on the `/dev/random` file descriptor
  - This still lets us know if `/dev/urandom` is safe
  - This avoids ever actually reading from `/dev/random`
  - This is what [libsodium does](https://github.com/jedisct1/libsodium/blob/60f4bc82120626458183cd1f9902908319af3d5d/src/libsodium/randombytes/sysrandom/randombytes_sysrandom.c#L151-L174)
  - See existing discussion in https://github.com/briansmith/ring/issues/558