### PR TITLE
Add support for hermit and l4re

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,6 +123,8 @@ matrix:
         # - cargo build --target=x86_64-unknown-redox --all-features
         - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
         - cargo xbuild --target=x86_64-unknown-uefi
+        - cargo xbuild --target=x86_64-unknown-hermit
+        - cargo xbuild --target=x86_64-unknown-l4re-uclibc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
         - cargo build --target=x86_64-sun-solaris --all-features
@@ -133,6 +135,8 @@ matrix:
         # - cargo build --target=x86_64-unknown-redox --all-features
         - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
         - cargo xbuild --target=x86_64-unknown-uefi
+        - cargo xbuild --target=x86_64-unknown-hermit
+        - cargo xbuild --target=x86_64-unknown-l4re-uclibc
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,12 +152,39 @@ pub use crate::error::Error;
 
 #[allow(dead_code)]
 mod util;
-#[cfg(any(unix, target_os = "redox"))]
+#[cfg(any(
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris",
+))]
 #[allow(dead_code)]
 mod util_libc;
 
 // std-only trait definitions (also need for use_file)
-#[cfg(any(feature = "std", unix, target_os = "redox"))]
+#[cfg(any(
+    feature = "std",
+    target_os = "android",
+    target_os = "dragonfly",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
+    target_os = "linux",
+    target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
+    target_os = "solaris",
+))]
 mod error_impls;
 
 // These targets read from a file as a fallback method.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@
 //! | Redox            | [`rand:`][12]
 //! | CloudABI         | [`cloudabi_sys_random_get`][13]
 //! | Haiku            | `/dev/random` (identical to `/dev/urandom`)
-//! | SGX, UEFI        | [RDRAND][18]
+//! | L4RE, SGX, UEFI  | [RDRAND][18]
+//! | Hermit           | [RDRAND][18] as [`sys_rand`][22] is currently broken.
 //! | Web browsers     | [`Crypto.getRandomValues`][14] (see [Support for WebAssembly and ams.js][14])
 //! | Node.js          | [`crypto.randomBytes`][15] (see [Support for WebAssembly and ams.js][16])
 //! | WASI             | [`__wasi_random_get`][17]
@@ -119,6 +120,7 @@
 //! [19]: https://www.unix.com/man-page/mojave/2/getentropy/
 //! [20]: https://www.unix.com/man-page/mojave/4/random/
 //! [21]: https://www.freebsd.org/cgi/man.cgi?query=getrandom&manpath=FreeBSD+12.0-stable
+//! [22]: https://github.com/hermitcore/libhermit-rs/blob/09c38b0371cee6f56a541400ba453e319e43db53/src/syscalls/random.rs#L21
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,9 +209,12 @@ cfg_if! {
         #[path = "wasi.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;
-    } else if #[cfg(target_env = "sgx")] {
-        #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(all(target_arch = "x86_64", target_os = "uefi"))] {
+    } else if #[cfg(all(target_arch = "x86_64", any(
+                  target_os = "hermit",
+                  target_os = "l4re",
+                  target_os = "uefi",
+                  target_env = "sgx",
+              )))] {
         #[path = "rdrand.rs"] mod imp;
     } else if #[cfg(target_arch = "wasm32")] {
         cfg_if! {


### PR DESCRIPTION
Currently, getrandom supports almost all [targets that rustc can build](https://github.com/rust-lang/rust/blob/0324a2b309cd66cb7bd4a156bd0b84cb136e254f/src/librustc_target/spec/mod.rs#L330-L479). The exceptions are:
  - `target_os = "none"`
  - `target_os = "l4re"`
  - `target_os = "hermit"`

This PR adds support for the later two. Both implementations should just use RDRAND as:
  - [L4RE does not support](https://github.com/kernkonzept/l4re-core/issues/1) a better way to get entropy from the OS.
  - [Hermit has OS bindings for getting randomness](https://github.com/hermitcore/libhermit-rs/blob/09c38b0371cee6f56a541400ba453e319e43db53/src/syscalls/random.rs#L21), but the currently implementation either:
    - [Uses a broken implementation of RDRAND](https://github.com/hermitcore/libhermit-rs/blob/8daf52ce6fc850640fd3ea42f594cadae20baf14/src/arch/x86_64/kernel/processor.rs#L626)
    - Or [falls back ](https://github.com/hermitcore/libhermit-rs/blob/09c38b0371cee6f56a541400ba453e319e43db53/src/syscalls/random.rs#L13)to an insecure implementation
    - So just using the existing RDRAND implementation in `getrandom` seems like the best security-wise.