### PR TITLE
Use wasi-core isntead of libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ cfg-if = "0.1"
 [target.'cfg(any(unix, target_os = "redox"))'.dependencies]
 libc = "0.2.60"
 
-[target.'cfg(any(target_os = "wasi"))'.dependencies]
+[target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.5"
 
 [target.wasm32-unknown-unknown.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,11 @@ members = ["tests/wasm_bindgen"]
 log = { version = "0.4", optional = true }
 cfg-if = "0.1"
 
-[target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
+[target.'cfg(any(unix, target_os = "redox"))'.dependencies]
 libc = "0.2.54"
+
+[target.'cfg(any(target_os = "wasi"))'.dependencies]
+wasi-core = "0.2"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ cfg-if = "0.1"
 libc = "0.2.54"
 
 [target.'cfg(any(target_os = "wasi"))'.dependencies]
-wasi-core = "0.2"
+wasi = "0.5"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -9,12 +9,12 @@
 //! Implementation for WASI
 use crate::Error;
 use core::num::NonZeroU32;
+use wasi_core::wasi_unstable::random_get;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret =
-        unsafe { libc::__wasi_random_get(dest.as_mut_ptr() as *mut libc::c_void, dest.len()) };
+    let ret = random_get(dest);
     if let Some(code) = NonZeroU32::new(ret as u32) {
-        error!("WASI: __wasi_random_get failed with return value {}", code);
+        error!("WASI: random_get failed with return value {}", code);
         Err(Error::from(code))
     } else {
         Ok(()) // Zero means success for WASI

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -9,7 +9,7 @@
 //! Implementation for WASI
 use crate::Error;
 use core::num::NonZeroU32;
-use wasi_core::wasi_unstable::random_get;
+use wasi::wasi_unstable::random_get;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = random_get(dest);


### PR DESCRIPTION
IIUC `wasi-core` will be the main crate for exposing low-level WASI Core API in Rust. We could link to the function directly as with some other targets, but probably we shouldn't do it, as right now `__wasi_random_get` is not considered stable. See: rust-lang/libc#1434