### PR TITLE
Add Windows UWP support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -137,6 +137,7 @@ matrix:
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc
+        - cargo xbuild --target=x86_64-uwp-windows-gnu
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - rust: stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,5 @@ stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
+# enables support for UWP targets, bumps MSRV to Rust 1.33
+uwp = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,5 +30,3 @@ stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
-# enables support for UWP targets, bumps MSRV to Rust 1.33
-uwp = []

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,13 @@ environment:
   matrix:
   - TARGET: x86_64-pc-windows-msvc
   - TARGET: i686-pc-windows-msvc
+  - TARGET: x86_64-uwp-windows-gnu
+    CHANNEL: nightly
+  - TARGET: i686-uwp-windows-gnu
+    CHANNEL: nightly
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
-  - rustup-init.exe -y --default-host %TARGET%
+  - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%
   - set PATH=%PATH%;C:\Users\appveyor\.cargo\bin
   - rustc -V
   - cargo -V
@@ -32,5 +36,5 @@ install:
 build: false
 
 test_script:
-  - cargo test
-  - cargo test --examples
+  - cargo test --features=uwp
+  - cargo test --examples --features=uwp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,12 +20,14 @@ environment:
   CARGO_HTTP_CHECK_REVOKE: false
 
   matrix:
-  - TARGET: x86_64-pc-windows-msvc
-  - TARGET: i686-pc-windows-msvc
   - TARGET: x86_64-uwp-windows-gnu
     CHANNEL: nightly
   - TARGET: i686-uwp-windows-gnu
     CHANNEL: nightly
+  - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: stable
+  - TARGET: i686-pc-windows-msvc
+    CHANNEL: stable
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,14 +21,18 @@ environment:
 
   matrix:
   - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: 1.32.0
+  - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
+  - TARGET: x86_64-pc-windows-msvc
+    CHANNEL: nightly
   - TARGET: i686-pc-windows-msvc
-    CHANNEL: stable
-  # TODO: replace with UWP targets in future
+    CHANNEL: nightly
   - TARGET: x86_64-pc-windows-gnu
     CHANNEL: nightly
   - TARGET: i686-pc-windows-gnu
     CHANNEL: nightly
+
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,5 +39,5 @@ install:
 build: false
 
 test_script:
-  - cargo test --features=uwp
-  - cargo test --examples --features=uwp
+  - cargo test
+  - cargo test --examples

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,15 @@ environment:
   CARGO_HTTP_CHECK_REVOKE: false
 
   matrix:
-  - TARGET: x86_64-uwp-windows-gnu
-    CHANNEL: nightly
-  - TARGET: i686-uwp-windows-gnu
-    CHANNEL: nightly
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
   - TARGET: i686-pc-windows-msvc
     CHANNEL: stable
+  # TODO: replace with UWP targets in future
+  - TARGET: x86_64-pc-windows-gnu
+    CHANNEL: nightly
+  - TARGET: i686-pc-windows-gnu
+    CHANNEL: nightly
 install:
   - appveyor DownloadFile https://win.rustup.rs/ -FileName rustup-init.exe
   - rustup-init.exe -y --default-host %TARGET% --default-toolchain %CHANNEL%

--- a/build.rs
+++ b/build.rs
@@ -4,9 +4,11 @@ use std::env;
 
 fn main() {
     let target = env::var("TARGET").expect("TARGET was not set");
-    if target.contains("uwp") {
+    if target.contains("-uwp-windows-") {
         // for BCryptGenRandom
         println!("cargo:rustc-link-lib=bcrypt");
+        // to work around unavailability of `target_vendor` on Rust 1.33
+        println!("cargo:rustc-cfg=getrandom_uwp");
     } else if target.contains("windows") {
         // for RtlGenRandom (aka SystemFunction036)
         println!("cargo:rustc-link-lib=advapi32");

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,17 @@
+#![deny(warnings)]
+
+use std::env;
+
+fn main() {
+    let target = env::var("TARGET").expect("TARGET was not set");
+    if target.contains("uwp") {
+        // for BCryptGenRandom
+        println!("cargo:rustc-link-lib=bcrypt");
+    } else if target.contains("windows") {
+        // for RtlGenRandom (aka SystemFunction036)
+        println!("cargo:rustc-link-lib=advapi32");
+    } else if target.contains("apple-ios") {
+        // for SecRandomCopyBytes and kSecRandomDefault
+        println!("cargo:rustc-link-lib=framework=Security");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,14 +224,7 @@ cfg_if! {
         #[path = "solaris_illumos.rs"] mod imp;
     } else if #[cfg(target_os = "wasi")] {
         #[path = "wasi.rs"] mod imp;
-    } else if #[cfg(any(
-        // target_vendor was stabilized only in Rust 1.33
-        target = "i686-uwp-windows-gnu",
-        target = "x86_64-uwp-windows-gnu",
-        target = "aarch64-uwp-windows-msvc",
-        target = "x86_64-uwp-windows-msvc",
-        target = "i686-uwp-windows-msvc",
-    ))] {
+    } else if #[cfg(all(feature = "uwp", target_vendor = "uwp"))] {
         #[path = "windows_uwp.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,7 +224,7 @@ cfg_if! {
         #[path = "solaris_illumos.rs"] mod imp;
     } else if #[cfg(target_os = "wasi")] {
         #[path = "wasi.rs"] mod imp;
-    } else if #[cfg(all(feature = "uwp", target_vendor = "uwp"))] {
+    } else if #[cfg(all(windows, getrandom_uwp))] {
         #[path = "windows_uwp.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,14 @@ cfg_if! {
         macro_rules! error {
             ($($x:tt)*) => {};
         }
+        #[allow(unused)]
+        macro_rules! warn {
+            ($($x:tt)*) => {};
+        }
+        #[allow(unused)]
+        macro_rules! info {
+            ($($x:tt)*) => {};
+        }
     }
 }
 
@@ -216,6 +224,15 @@ cfg_if! {
         #[path = "solaris_illumos.rs"] mod imp;
     } else if #[cfg(target_os = "wasi")] {
         #[path = "wasi.rs"] mod imp;
+    } else if #[cfg(any(
+        // target_vendor was stabilized only in Rust 1.33
+        target = "i686-uwp-windows-gnu",
+        target = "x86_64-uwp-windows-gnu",
+        target = "aarch64-uwp-windows-msvc",
+        target = "x86_64-uwp-windows-msvc",
+        target = "i686-uwp-windows-msvc",
+    ))] {
+        #[path = "windows_uwp.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;
     } else if #[cfg(all(target_arch = "x86_64", any(

--- a/src/windows_uwp.rs
+++ b/src/windows_uwp.rs
@@ -33,15 +33,15 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
                 BCRYPT_USE_SYSTEM_PREFERRED_RNG,
             )
         };
-        // NTSTATUS codes use two highest bits for severity codes
+        // NTSTATUS codes use two highest bits for severity status
         match ret >> 30 {
             0b01 => info!("BCryptGenRandom: information code 0x{:08X}", ret),
             0b10 => warn!("BCryptGenRandom: warning code 0x{:08X}", ret),
             0b11 => {
                 error!("BCryptGenRandom: failed with 0x{:08X}", ret);
                 // We zeroize the highest bit, so the error code will reside
-                // inside the range designated for OS codes.
-                let code = ret & (u32::MAX >> 1);
+                // inside the range of designated for OS codes.
+                let code = ret ^ (1 << 31);
                 // SAFETY: the second highest bit is always equal to one,
                 // so it's impossible to get zero. Unfortunately compiler
                 // is not smart enough to figure out it yet.

--- a/src/windows_uwp.rs
+++ b/src/windows_uwp.rs
@@ -1,0 +1,55 @@
+// Copyright 2018 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation for Windows UWP targets. After deprecation of Windows XP
+//! and Vista, this can superseed the `RtlGenRandom`-based implementation.
+use crate::Error;
+use core::{ffi::c_void, num::NonZeroU32, ptr, u32};
+
+const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
+
+extern "system" {
+    fn BCryptGenRandom(
+        hAlgorithm: *mut c_void,
+        pBuffer: *mut u8,
+        cbBuffer: u32,
+        dwFlags: u32,
+    ) -> u32;
+}
+
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+    // Prevent overflow of u32
+    for chunk in dest.chunks_mut(u32::max_value() as usize) {
+        let ret = unsafe {
+            BCryptGenRandom(
+                ptr::null_mut(),
+                chunk.as_mut_ptr(),
+                chunk.len() as u32,
+                BCRYPT_USE_SYSTEM_PREFERRED_RNG,
+            )
+        };
+        // NTSTATUS codes use two highest bits for severity codes
+        match ret >> 30 {
+            0b01 => info!("BCryptGenRandom: information code 0x{:08X}", ret),
+            0b10 => warn!("BCryptGenRandom: warning code 0x{:08X}", ret),
+            0b11 => {
+                error!("BCryptGenRandom: failed with 0x{:08X}", ret);
+                // We zeroize the highest bit, so the error code will reside
+                // inside the range designated for OS codes.
+                let code = ret & (u32::MAX >> 1);
+                // SAFETY: the second highest bit is always equal to one,
+                // so it's impossible to get zero. Unfortunately compiler
+                // is not smart enough to figure out it yet.
+                let code = unsafe { NonZeroU32::new_unchecked(code) };
+                return Err(Error::from(code));
+            }
+            _ => (),
+        }
+    }
+    Ok(())
+}

--- a/src/windows_uwp.rs
+++ b/src/windows_uwp.rs
@@ -9,7 +9,7 @@
 //! Implementation for Windows UWP targets. After deprecation of Windows XP
 //! and Vista, this can superseed the `RtlGenRandom`-based implementation.
 use crate::Error;
-use core::{ffi::c_void, num::NonZeroU32, ptr, u32};
+use core::{ffi::c_void, num::NonZeroU32, ptr};
 
 const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
 

--- a/src/windows_uwp.rs
+++ b/src/windows_uwp.rs
@@ -35,8 +35,12 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         };
         // NTSTATUS codes use two highest bits for severity status
         match ret >> 30 {
-            0b01 => info!("BCryptGenRandom: information code 0x{:08X}", ret),
-            0b10 => warn!("BCryptGenRandom: warning code 0x{:08X}", ret),
+            0b01 => {
+                info!("BCryptGenRandom: information code 0x{:08X}", ret);
+            }
+            0b10 => {
+                warn!("BCryptGenRandom: warning code 0x{:08X}", ret);
+            }
             0b11 => {
                 error!("BCryptGenRandom: failed with 0x{:08X}", ret);
                 // We zeroize the highest bit, so the error code will reside


### PR DESCRIPTION
`RtlGenRandom` is not accessible on UWP targets, so we have to handle them separately right now.

cc @chouquette