### PR TITLE
Add dummy feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,7 @@ stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
+# enables dummy implementation for wasm32-unknown-unknown
+wasm_dummy = []
+# enables dummy implementation for unsupported targets
+dummy = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,5 @@ stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
-# enables dummy implementation for wasm32-unknown-unknown
-wasm_dummy = []
 # enables dummy implementation for unsupported targets
 dummy = []

--- a/README.md
+++ b/README.md
@@ -59,9 +59,7 @@ for such target, you can either:
 - Use [`[replace]`][replace] or [`[patch]`][patch] section in your `Cargo.toml`
 to switch to a custom implementation with a support of your target.
 - Enable the `dummy` feature to have getrandom use an implementation that always
-fails on unsupported targets.
-
-We also accept pull requests to support additional targets.
+fails at run-time on unsupported targets.
 
 [replace]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-replace-section
 [patch]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-patch-section

--- a/README.md
+++ b/README.md
@@ -45,11 +45,16 @@ This library is `no_std` compatible, but uses `std` on most platforms.
 The `log` library is supported as an optional dependency. If enabled, error
 reporting will be improved on some platforms.
 
-For WebAssembly (`wasm32`), WASI and Emscripten targets are supported directly; otherwise
-one of the following features must be enabled:
+For `wasm32-unknown-unknown` target one of the following features must be
+enabled:
 
 -   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)
 -   [`stdweb`](https://crates.io/crates/stdweb)
+
+By default compiling crate for an unsupported platform will result in a
+compilation error. You may either replace this crate with a custom one, which
+will include support for your target, or enable `dummy` feature to use an
+always erroring dummy implementation.
 
 ## Minimum Supported Rust Version
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ library like [`rand`].
 
 [`rand`]: https://crates.io/crates/rand
 
-
 ## Usage
 
 Add this to your `Cargo.toml`:
@@ -45,21 +44,28 @@ This library is `no_std` compatible, but uses `std` on most platforms.
 The `log` library is supported as an optional dependency. If enabled, error
 reporting will be improved on some platforms.
 
-For `wasm32-unknown-unknown` target one of the following features must be
+For the `wasm32-unknown-unknown` target, one of the following features should be
 enabled:
 
 -   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)
 -   [`stdweb`](https://crates.io/crates/stdweb)
 
-By default compiling crate for an unsupported platform will result in a
-compilation error. You may either replace this crate with a custom one, which
-will include support for your target, or enable `dummy` feature to use an
-always erroring dummy implementation.
+By default, compiling `getrandom` for an unsupported target will result in
+a compilation error. If want to build an application which uses `getrandom` for
+such target, you can either:
+- Use [`[replace]`][replace] or [`[patch]`][patch] section in your `Cargo.toml`
+to switch to a custom implementation with a support of your target.
+- Enable the `dummy` feature to have getrandom use an implementation that always
+fails on unsupported targets.
+
+We also accept pull requests to support additional targets.
+
+[replace]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-replace-section
+[patch]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-patch-section
 
 ## Minimum Supported Rust Version
 
 This crate requires Rust 1.32.0 or later.
-
 
 # License
 
@@ -69,4 +75,3 @@ The `getrandom` library is distributed under either of
  * [MIT license](LICENSE-MIT)
 
 at your option.
-

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ enabled:
 -   [`stdweb`](https://crates.io/crates/stdweb)
 
 By default, compiling `getrandom` for an unsupported target will result in
-a compilation error. If want to build an application which uses `getrandom` for
-such target, you can either:
+a compilation error. If you want to build an application which uses `getrandom`
+for such target, you can either:
 - Use [`[replace]`][replace] or [`[patch]`][patch] section in your `Cargo.toml`
 to switch to a custom implementation with a support of your target.
 - Enable the `dummy` feature to have getrandom use an implementation that always

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 //! features are activated for this crate. Note that if both features are
 //! enabled `wasm-bindgen` will be used. If neither feature is enabled,
 //! compiling `getrandom` will result in a compilation error. It can be disabled
-//! by enabling `wasm_dummy` feature, with which `getrandom` will use an always
-//! erroring dummy implementation.
+//! by enabling the `dummy` feature, with which `getrandom` will use an always
+//! failing implementation.
 //!
 //! The WASI target `wasm32-wasi` uses the `__wasi_random_get` function defined
 //! by the WASI standard.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,18 @@
 //! systems are using the recommended interface and respect maximum buffer
 //! sizes.
 //!
+//! ## Unsupported targets
+//! By default, compiling `getrandom` for an unsupported target will result in
+//! a compilation error. If you want to build an application which uses `getrandom`
+//! for such target, you can either:
+//! - Use [`[replace]`][replace] or [`[patch]`][patch] section in your `Cargo.toml`
+//! to switch to a custom implementation with a support of your target.
+//! - Enable the `dummy` feature to have getrandom use an implementation that always
+//! fails at run-time on unsupported targets.
+//!
+//! [replace]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-replace-section
+//! [patch]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-patch-section
+//!
 //! ## Support for WebAssembly and asm.js
 //!
 //! The three Emscripten targets `asmjs-unknown-emscripten`,
@@ -46,7 +58,7 @@
 //! methods directly, using either `stdweb` or `wasm-bindgen` depending on what
 //! features are activated for this crate. Note that if both features are
 //! enabled `wasm-bindgen` will be used. If neither feature is enabled,
-//! compiling `getrandom` will result in a compilation error. It can be disabled
+//! compiling `getrandom` will result in a compilation error. It can be avoided
 //! by enabling the `dummy` feature, which will make `getrandom` to use an
 //! always failing implementation.
 //!
@@ -224,10 +236,8 @@ cfg_if! {
         #[path = "dummy.rs"] mod imp;
     } else {
         compile_error!("\
-            target is not supported, you may enable dummy implementation \
-            using the `dummy` feature or overwrite `getrandom` crate with \
-            a custom one which supports your target using `[replace]` or \
-            `[patch]` section in your `Cargo.toml`\
+            target is not supported, for more information see: \
+            https://docs.rs/getrandom/#unsupported-targets\
         ");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,20 +227,17 @@ cfg_if! {
                   target_env = "sgx",
               )))] {
         #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(target_arch = "wasm32")] {
+    } else if #[cfg(all(
+        target_arch = "wasm32",
+        target_os = "unknown",
+        target_env="unknown",
+        any(feature = "wasm-bindgen", feature = "stdweb"),
+    ))] {
         cfg_if! {
             if #[cfg(feature = "wasm-bindgen")] {
                 #[path = "wasm32_bindgen.rs"] mod imp;
-            } else if #[cfg(feature = "stdweb")] {
-                #[path = "wasm32_stdweb.rs"] mod imp;
-            } else if #[cfg(any(feature = "wasm_dummy", feature = "dummy"))] {
-                #[path = "dummy.rs"] mod imp;
             } else {
-                compile_error!("\
-                    wasm32-unknown-unknown target requires one of the following
-                    features to be enabled: `stdweb`, `wasm-bindgen` or
-                    `dummy`/`wasm_dummy`\
-                ");
+                #[path = "wasm32_stdweb.rs"] mod imp;
             }
         }
     } else if #[cfg(feature = "dummy")] {
@@ -248,8 +245,9 @@ cfg_if! {
     } else {
         compile_error!("\
             target is not supported, you may enable dummy implementation \
-            using `dummy` feature or replace `getrandom` crate with a custom \
-            crate which supports your target\
+            using the `dummy` feature or overwrite `getrandom` crate with \
+            a custom one which supports your target using `[replace]` or \
+            `[patch]` section in your `Cargo.toml`\
         ");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@
 //! features are activated for this crate. Note that if both features are
 //! enabled `wasm-bindgen` will be used. If neither feature is enabled,
 //! compiling `getrandom` will result in a compilation error. It can be disabled
-//! by enabling the `dummy` feature, with which `getrandom` will use an always
-//! failing implementation.
+//! by enabling the `dummy` feature, which will make `getrandom` to use an
+//! always failing implementation.
 //!
 //! The WASI target `wasm32-wasi` uses the `__wasi_random_get` function defined
 //! by the WASI standard.
@@ -227,21 +227,13 @@ cfg_if! {
                   target_env = "sgx",
               )))] {
         #[path = "rdrand.rs"] mod imp;
-    // ideally we would like to use `target = "wasm32-unknown-unknown"`,
-    // but unfortunately it does not work, see:
-    // https://github.com/rust-lang/rust/issues/63217
-    } else if #[cfg(all(
-        target_arch = "wasm32",
-        target_os = "unknown",
-        any(feature = "wasm-bindgen", feature = "stdweb"),
-    ))] {
-        cfg_if! {
-            if #[cfg(feature = "wasm-bindgen")] {
-                #[path = "wasm32_bindgen.rs"] mod imp;
-            } else {
-                #[path = "wasm32_stdweb.rs"] mod imp;
-            }
-        }
+    // the following two branches are intended only for `wasm32-unknown-unknown`
+    // target and may not work or work inefficiently on targets which may be
+    // added in future
+    } else if #[cfg(all(target_arch = "wasm32", feature = "wasm-bindgen"))] {
+        #[path = "wasm32_bindgen.rs"] mod imp;
+    } else if #[cfg(all(target_arch = "wasm32", feature = "stdweb"))] {
+        #[path = "wasm32_stdweb.rs"] mod imp;
     } else if #[cfg(feature = "dummy")] {
         #[path = "dummy.rs"] mod imp;
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,10 +227,12 @@ cfg_if! {
                   target_env = "sgx",
               )))] {
         #[path = "rdrand.rs"] mod imp;
+    // ideally we would like to use `target = "wasm32-unknown-unknown"`,
+    // but unfortunately it does not work, see:
+    // https://github.com/rust-lang/rust/issues/63217
     } else if #[cfg(all(
         target_arch = "wasm32",
         target_os = "unknown",
-        target_env="unknown",
         any(feature = "wasm-bindgen", feature = "stdweb"),
     ))] {
         cfg_if! {


### PR DESCRIPTION
Closes #49 

Strictly speaking it may be considered a breaking change. We could make `dummy` feature enabled-by-default, but I am not sure if we should.