### PR TITLE
use arguments of the right type for getrandom syscall

### DIFF
--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -23,7 +23,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 }
 
 fn is_getrandom_available() -> bool {
-    let res = unsafe { libc::syscall(libc::SYS_getrandom, 0, 0, libc::GRND_NONBLOCK) };
+    let res = unsafe { libc::syscall(libc::SYS_getrandom, 0usize, 0usize, libc::GRND_NONBLOCK) };
     if res < 0 {
         match last_os_error().raw_os_error() {
             Some(libc::ENOSYS) => false, // No kernel support


### PR DESCRIPTION
"0" is a 32-bit 0, but we need pointer-sized 0s here.

Found by Miri.