### PR TITLE
Add rustc-dep-of-std feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ matrix:
 
     - rust: nightly
       env: DESCRIPTION="cross-platform build only"
-      # Redox: wait for https://github.com/rust-lang/rust/issues/60139
+      # libc on Redox is broken: see https://github.com/rust-lang/libc/pull/1450
       install:
         - rustup target add x86_64-sun-solaris
         - rustup target add x86_64-unknown-cloudabi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - cargo test --examples
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
-        - cargo doc --no-deps --all --all-features
+        - cargo doc --no-deps --all --features=std
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
@@ -64,7 +64,7 @@ matrix:
         - cargo test --examples
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
-        - cargo doc --no-deps --all --all-features
+        - cargo doc --no-deps --all --features=std
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
@@ -115,25 +115,25 @@ matrix:
         - rustup component add rust-src
         - cargo install cargo-xbuild || true
       script:
-        - cargo build --target=x86_64-sun-solaris --all-features
-        - cargo build --target=x86_64-unknown-cloudabi --all-features
-        - cargo build --target=x86_64-unknown-freebsd --all-features
-        - cargo build --target=x86_64-fuchsia --all-features
-        - cargo build --target=x86_64-unknown-netbsd --all-features
-        # - cargo build --target=x86_64-unknown-redox --all-features
-        - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
+        - cargo build --target=x86_64-sun-solaris
+        - cargo build --target=x86_64-unknown-cloudabi
+        - cargo build --target=x86_64-unknown-freebsd
+        - cargo build --target=x86_64-fuchsia
+        - cargo build --target=x86_64-unknown-netbsd
+        # - cargo build --target=x86_64-unknown-redox
+        - cargo build --target=x86_64-fortanix-unknown-sgx
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
-        - cargo build --target=x86_64-sun-solaris --all-features
-        - cargo build --target=x86_64-unknown-cloudabi --all-features
-        - cargo build --target=x86_64-unknown-freebsd --all-features
-        - cargo build --target=x86_64-fuchsia --all-features
-        - cargo build --target=x86_64-unknown-netbsd --all-features
-        # - cargo build --target=x86_64-unknown-redox --all-features
-        - cargo build --target=x86_64-fortanix-unknown-sgx --all-features
+        - cargo build --target=x86_64-sun-solaris
+        - cargo build --target=x86_64-unknown-cloudabi
+        - cargo build --target=x86_64-unknown-freebsd
+        - cargo build --target=x86_64-fuchsia
+        - cargo build --target=x86_64-unknown-netbsd
+        # - cargo build --target=x86_64-unknown-redox
+        - cargo build --target=x86_64-fortanix-unknown-sgx
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
         - cargo test --examples
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
-        - cargo doc --no-deps --all --features=std
+        - cargo doc --no-deps --all --features=std,log
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
@@ -64,7 +64,7 @@ matrix:
         - cargo test --examples
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
-        - cargo doc --no-deps --all --features=std
+        - cargo doc --no-deps --all --features=std,log
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ members = ["tests/wasm_bindgen"]
 log = { version = "0.4", optional = true }
 cfg-if = "0.1"
 
+# When built as part of libstd
+compiler_builtins = { version = "0.1", optional = true }
+core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
+
 [target.'cfg(any(unix, target_os = "redox", target_os = "wasi"))'.dependencies]
 libc = "0.2.60"
 
@@ -30,3 +34,5 @@ stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
+# Unstable feature to support being a libstd dependancy
+rustc-dep-of-std = ["compiler_builtins", "core"]


### PR DESCRIPTION
This is how `libc` and `hashbrown` support being dependancies of `libstd`.
This allows `getrandom` to use `core` normally, and use the sysroot `core`
when building `libstd`.

This PR and #58 should be enough to get rust-lang/rust#62082 building without errors. 