### PR TITLE
Add warnings for rust_2018_idioms violations

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -76,7 +76,7 @@ fn os_err_desc(_errno: i32, _buf: &mut [u8]) -> Option<&str> {
 }
 
 impl fmt::Debug for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut dbg = f.debug_struct("Error");
         if let Some(errno) = self.raw_os_error() {
             dbg.field("os_error", &errno);
@@ -95,7 +95,7 @@ impl fmt::Debug for Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(errno) = self.raw_os_error() {
             let mut buf = [0u8; 128];
             match os_err_desc(errno, &mut buf) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,6 +112,7 @@
 )]
 #![no_std]
 #![cfg_attr(feature = "stdweb", recursion_limit = "128")]
+#![warn(rust_2018_idioms, unused_lifetimes)]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
As part of rust-lang/rust#62082, we need to make sure `getrandom` compiles without warnings when using the Rust warning configuration. Checking for `rust_2018_idioms` and `unused_lifetimes` seems to fix things.

I checked the CI and we don't have any warnings on any targets.