### PR TITLE
Make the documentation for WASM targets clearer

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,10 @@
 //! by enabling the `dummy` feature, which will make `getrandom` to use an
 //! always failing implementation.
 //!
+//! If you are seeing this compiler error even though your crate doesn't directly
+//! depend on getrandom (one of your dependencies pulls it in), you can still solve
+//! this by adding getrandom as a dependency to your `Cargo.toml` with the correct feature.
+//!
 //! The WASI target `wasm32-wasi` uses the `__wasi_random_get` function defined
 //! by the WASI standard.
 //!


### PR DESCRIPTION
For people who run in a compile error because `wasm-bindgen` and `stdweb` features are not enabled, clarify that they can enable them even if getrandom gets pulled in by one of their dependencies.

I think this isn't necessarily obvious. I didn't realize that I could set features for indirect dependencies. 

What I do wonder about though is if this is the desired workflow, why does the `rand` crate forward this feature? And should a user specify `getrandom` with say `wasm-bindgen` in their Cargo.toml, or should they set the feature on `rand`.

Note also that library authors might have to set this at least in `dev-dependencies` to make tests and examples run.