### PR TITLE
Add back in std-only trait definitions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,27 +159,21 @@ pub use crate::error::Error;
 
 #[allow(dead_code)]
 mod util;
-// Unlike the other Unix, Fuchsia and iOS don't use the libc to make any calls.
-#[cfg(any(
-    target_os = "android",
-    target_os = "dragonfly",
-    target_os = "emscripten",
-    target_os = "freebsd",
-    target_os = "haiku",
-    target_os = "illumos",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "netbsd",
-    target_os = "openbsd",
-    target_os = "redox",
-    target_os = "solaris",
-))]
-#[allow(dead_code)]
-mod util_libc;
 
-// std-only trait definitions
-#[cfg(feature = "std")]
-mod error_impls;
+cfg_if! {
+    // Unlike the other Unix, Fuchsia and iOS don't use the libc to make any calls.
+    if #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "emscripten",
+                 target_os = "freebsd", target_os = "haiku",     target_os = "illumos",
+                 target_os = "linux",   target_os = "macos",     target_os = "netbsd",
+                 target_os = "openbsd", target_os = "redox",     target_os = "solaris"))] {
+        #[allow(dead_code)]
+        mod util_libc;
+        // Keep std-only trait definitions for backwards compatiblity
+        mod error_impls;
+    } else if #[cfg(feature = "std")] {
+        mod error_impls;
+    }
+}
 
 // These targets read from a file as a fallback method.
 #[cfg(any(


### PR DESCRIPTION
Fixes #94

Note that if we merge this we should release 0.1.11 and yank 0.1.10, to prevent an incorrect use of semvar.