### PR TITLE
Disable unneeded features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,8 +32,8 @@ libc = { version = "0.2.62", default-features = false }
 wasi = "0.5"
 
 [target.wasm32-unknown-unknown.dependencies]
-wasm-bindgen = { version = "0.2.29", optional = true }
-stdweb = { version = "0.4.18", optional = true }
+wasm-bindgen = { version = "0.2.29", default-features = false, optional = true }
+stdweb = { version = "0.4.18", default-features = false, optional = true }
 
 [features]
 std = []


### PR DESCRIPTION
Hi,
Fist the default features both these crates give are unneeded here.
Second this is a step towards making `wasm-bindgen` works with `no-std`.

The question is, is there a way to replace `thread_local` with something that can work without std?