### PR TITLE
Update wasi dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.62", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.5"
+wasi = "0.6"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }


### PR DESCRIPTION
cc https://github.com/rust-lang/rust/pull/63806
It failed with 
```
invalid license Apache-2.0 WITH LLVM-exception in /checkout/obj/build/tmp/distcheck/src/../vendor/wasi/Cargo.toml
```
It could be worked around by adding exception for `wasi` but since it's license has been changed more optimal solution is to just update `wasi`.