### PR TITLE
Proposal for bindgen changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,14 @@ wasi = "0.5"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }
+js-sys = { version = "0.3.27", optional = true }
+web-sys = { version = "0.3.27", optional = true, features = ["Window", "WorkerGlobalScope", "Crypto"] }
 stdweb = { version = "0.4.18", optional = true }
 
 [features]
 std = []
 # enables dummy implementation for unsupported targets
 dummy = []
+bindgen = ["wasm-bindgen", "js-sys", "web-sys"]
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["compiler_builtins", "core"]

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ reporting will be improved on some platforms.
 For the `wasm32-unknown-unknown` target, one of the following features should be
 enabled:
 
--   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)
+-   [`bindgen`](https://crates.io/crates/wasm_bindgen)
 -   [`stdweb`](https://crates.io/crates/stdweb)
 
 By default, compiling `getrandom` for an unsupported target will result in

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,10 +134,11 @@ pub(crate) const SEC_RANDOM_FAILED: Error = internal_error!(3);
 pub(crate) const RTL_GEN_RANDOM_FAILED: Error = internal_error!(4);
 pub(crate) const FAILED_RDRAND: Error = internal_error!(5);
 pub(crate) const NO_RDRAND: Error = internal_error!(6);
-pub(crate) const BINDGEN_CRYPTO_UNDEF: Error = internal_error!(7);
-pub(crate) const BINDGEN_GRV_UNDEF: Error = internal_error!(8);
-pub(crate) const STDWEB_NO_RNG: Error = internal_error!(9);
-pub(crate) const STDWEB_RNG_FAILED: Error = internal_error!(10);
+pub(crate) const BINDGEN_WEB_CRYPTO: Error = internal_error!(7);
+pub(crate) const BINDGEN_WEB_FAILED: Error = internal_error!(8);
+pub(crate) const BINDGEN_NODE_FAILED: Error = internal_error!(9);
+pub(crate) const STDWEB_NO_RNG: Error = internal_error!(10);
+pub(crate) const STDWEB_RNG_FAILED: Error = internal_error!(11);
 
 fn internal_desc(error: Error) -> Option<&'static str> {
     match error {
@@ -148,8 +149,9 @@ fn internal_desc(error: Error) -> Option<&'static str> {
         RTL_GEN_RANDOM_FAILED => Some("RtlGenRandom: call failed"),
         FAILED_RDRAND => Some("RDRAND: failed multiple times: CPU issue likely"),
         NO_RDRAND => Some("RDRAND: instruction not supported"),
-        BINDGEN_CRYPTO_UNDEF => Some("wasm-bindgen: self.crypto is undefined"),
-        BINDGEN_GRV_UNDEF => Some("wasm-bindgen: crypto.getRandomValues is undefined"),
+        BINDGEN_WEB_CRYPTO => Some("wasm-bindgen: self.crypto is unavalible"),
+        BINDGEN_WEB_FAILED => Some("wasm-bindgen: crypto.getRandomValues failed"),
+        BINDGEN_NODE_FAILED => Some("wasm-bindgen: Node.js crypto.randomFillSync failed"),
         STDWEB_NO_RNG => Some("stdweb: no randomness source available"),
         STDWEB_RNG_FAILED => Some("stdweb: failed to get randomness"),
         _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,8 @@
 //! Getrandom also supports `wasm32-unknown-unknown` by directly calling
 //! JavaScript methods. Rust currently has two ways to do this: [bindgen] and
 //! [stdweb]. Getrandom supports using either one by enabling the
-//! `wasm-bindgen` or `stdweb` crate features. Note that if both features are
-//! enabled, `wasm-bindgen` will be used. If neither feature is enabled, calls
+//! `bindgen` or `stdweb` crate features. Note that if both features are
+//! enabled, `bindgen` will be used. If neither feature is enabled, calls
 //! to `getrandom` will always fail at runtime.
 //!
 //! [bindgen]: https://github.com/rust-lang/rust-bindgen
@@ -234,7 +234,7 @@ cfg_if! {
         #[path = "rdrand.rs"] mod imp;
     } else if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {
         cfg_if! {
-            if #[cfg(feature = "wasm-bindgen")] {
+            if #[cfg(feature = "bindgen")] {
                 #[path = "wasm32_bindgen.rs"] mod imp;
             } else if #[cfg(feature = "stdweb")] {
                 #[path = "wasm32_stdweb.rs"] mod imp;

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -7,107 +7,54 @@
 // except according to those terms.
 
 //! Implementation for WASM via wasm-bindgen
-extern crate std;
+use js_sys::global;
+use wasm_bindgen::{prelude::*, JsCast};
+use web_sys::{window, Crypto, WorkerGlobalScope};
 
-use core::cell::RefCell;
-use core::mem;
-use std::thread_local;
-
-use wasm_bindgen::prelude::*;
-
-use crate::error::{BINDGEN_CRYPTO_UNDEF, BINDGEN_GRV_UNDEF};
-use crate::Error;
-
-#[derive(Clone, Debug)]
-enum RngSource {
-    Node(NodeCrypto),
-    Browser(BrowserCrypto),
-}
-
-// JsValues are always per-thread, so we initialize RngSource for each thread.
-//   See: https://github.com/rustwasm/wasm-bindgen/pull/955
-thread_local!(
-    static RNG_SOURCE: RefCell<Option<RngSource>> = RefCell::new(None);
-);
+use crate::util::LazyBool;
+use crate::{error, Error};
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    assert_eq!(mem::size_of::<usize>(), 4);
-
-    RNG_SOURCE.with(|f| {
-        let mut source = f.borrow_mut();
-        if source.is_none() {
-            *source = Some(getrandom_init()?);
+    static IS_NODE: LazyBool = LazyBool::new();
+    if IS_NODE.unsync_init(|| node_crypto().is_some()) {
+        if node_crypto().unwrap().random_fill_sync(dest).is_err() {
+            return Err(error::BINDGEN_NODE_FAILED);
         }
-
-        match source.as_ref().unwrap() {
-            RngSource::Node(n) => n.random_fill_sync(dest),
-            RngSource::Browser(n) => {
-                // see https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
-                //
-                // where it says:
-                //
-                // > A QuotaExceededError DOMException is thrown if the
-                // > requested length is greater than 65536 bytes.
-                for chunk in dest.chunks_mut(65536) {
-                    n.get_random_values(chunk)
-                }
+    } else {
+        let crypto = browser_crypto().ok_or(error::BINDGEN_WEB_CRYPTO)?;
+        // https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+        // > A QuotaExceededError DOMException is thrown if the
+        // > requested length is greater than 65536 bytes.
+        for chunk in dest.chunks_mut(65536) {
+            if crypto.get_random_values_with_u8_array(chunk).is_err() {
+                return Err(error::BINDGEN_WEB_FAILED);
             }
-        };
-        Ok(())
-    })
+        }
+    }
+    Ok(())
 }
 
-fn getrandom_init() -> Result<RngSource, Error> {
-    if let Ok(self_) = Global::get_self() {
-        // If `self` is defined then we're in a browser somehow (main window
-        // or web worker). Here we want to try to use
-        // `crypto.getRandomValues`, but if `crypto` isn't defined we assume
-        // we're in an older web browser and the OS RNG isn't available.
+fn node_crypto() -> Option<NodeCrypto> {
+    node_require("crypto").ok()
+}
 
-        let crypto = self_.crypto();
-        if crypto.is_undefined() {
-            return Err(BINDGEN_CRYPTO_UNDEF);
-        }
-
-        // Test if `crypto.getRandomValues` is undefined as well
-        let crypto: BrowserCrypto = crypto.into();
-        if crypto.get_random_values_fn().is_undefined() {
-            return Err(BINDGEN_GRV_UNDEF);
-        }
-
-        return Ok(RngSource::Browser(crypto));
+fn browser_crypto() -> Option<Crypto> {
+    // Support calling self.crypto in the main window or a Web Worker.
+    if let Some(window) = window() {
+        return window.crypto().ok();
     }
-
-    return Ok(RngSource::Node(node_require("crypto")));
+    let worker = global().dyn_into::<WorkerGlobalScope>().ok()?;
+    worker.crypto().ok()
 }
 
 #[wasm_bindgen]
 extern "C" {
-    type Global;
-    #[wasm_bindgen(getter, catch, static_method_of = Global, js_class = self, js_name = self)]
-    fn get_self() -> Result<Self_, JsValue>;
-
-    type Self_;
-    #[wasm_bindgen(method, getter, structural)]
-    fn crypto(me: &Self_) -> JsValue;
-
-    #[derive(Clone, Debug)]
-    type BrowserCrypto;
-
-    // TODO: these `structural` annotations here ideally wouldn't be here to
-    // avoid a JS shim, but for now with feature detection they're
-    // unavoidable.
-    #[wasm_bindgen(method, js_name = getRandomValues, structural, getter)]
-    fn get_random_values_fn(me: &BrowserCrypto) -> JsValue;
-    #[wasm_bindgen(method, js_name = getRandomValues, structural)]
-    fn get_random_values(me: &BrowserCrypto, buf: &mut [u8]);
-
-    #[wasm_bindgen(js_name = require)]
-    fn node_require(s: &str) -> NodeCrypto;
+    #[wasm_bindgen(catch, js_name = require)]
+    fn node_require(s: &str) -> Result<NodeCrypto, JsValue>;
 
     #[derive(Clone, Debug)]
     type NodeCrypto;
 
-    #[wasm_bindgen(method, js_name = randomFillSync, structural)]
-    fn random_fill_sync(me: &NodeCrypto, buf: &mut [u8]);
+    #[wasm_bindgen(catch, method, js_name = randomFillSync)]
+    fn random_fill_sync(me: &NodeCrypto, buf: &mut [u8]) -> Result<(), JsValue>;
 }

--- a/tests/wasm_bindgen/Cargo.toml
+++ b/tests/wasm_bindgen/Cargo.toml
@@ -10,6 +10,6 @@ license = "MIT/Apache-2.0"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { path = "../..", features = ["wasm-bindgen"] }
+getrandom = { path = "../..", features = ["bindgen"] }
 wasm-bindgen = "0.2"
 wasm-bindgen-test = "0.2"


### PR DESCRIPTION
This is my idea for improving the `wasm32-unknown-unknown` with `bindgen` target. 

Note: This is a Work in Progress and contains many ideas for improving the bindgen target. We don't necessarily have to do all of them.

### Changes and Motivation
#### Using `js-sys` and `web-sys`

These crates are maintained [by the same group that maintains `wasm-bindgen`](https://github.com/rustwasm/wasm-bindgen) and are intended to work similar to how the `libc` crate works today. Strictly speaking, the `libc` crate is never necessary. You could always just declare `extern "C"` functions yourself; however, having the `libc` crate ensures that these bindings are correct for your platform.

Similarly, you could always declare interfaces to the JS APIs and Browser APIs manually via `wasm-bindgen`. However, using these binding crates makes our job easier:

- It allows us to properly obtain the global object (doing this correctly [is quite complex](https://docs.rs/js-sys/0.3.27/src/js_sys/lib.rs.html#4450-4523)). See #92 
- When host bindings are supported, we don't have to do the work of wiring everything up.
- These bindings are extremely subtle (even more so than `libc`) due to the complex mapping between Rust and JS types. It's better to just have someone else deal with them and have them fix `bindgen` bugs.

Furthermore, the `web-sys` crate is configurable, so you only need to build what you need to use (we only need `Crypto`, `Window`, and `WorkerGlobalScope`).

I think that if we're OK depending on crates like `libc` that are maintained by the Rust team and just declare platform bindings, we should be OK with using a similar crate for wasm.

#### Better error handling with `catch` bindings

This change also moves to using `catch` bindings (the default in `js-sys` and `web-sys`) for all of our bindings. This allows us to properly return an error when certain APIs fail (or fail to exist) at runtime. 

This also means we no longer need things like `get_random_values_fn`. If the API is not there, the function will just return an error (`undefined` I think). This change does not depend on using `web-sys`/`js-sys`.

#### Removing `std::thread_local`

Right now, the `stdweb` implementation only checks if we are in Node vs a Browser in its `init` function. This does the same for `bindgen`. Given that the cost of retrieving these objects is mostly just the `bindgen` overhead (which we incur regardless), it doesn't make a whole lot of sense to hold onto a `thread_local` `NodeCrypto`. We can just get the object each time we need it.

#### Future changes

We could additionally add `error!` calls to actually print out the underlying JS errors.

We could also try to reduce the duplication between the `stdweb` and `bindgen` code, but that's better for a future PR.