### PR TITLE
Handle ZST

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -258,7 +258,9 @@ cfg_if! {
 /// source.
 ///
 /// This function returns an error on any failure, including partial reads. We
-/// make no guarantees regarding the contents of `dest` on error.
+/// make no guarantees regarding the contents of `dest` on error. If `dest` is
+/// empty, `getrandom` immediately returns success, making no calls to the
+/// underlying operating system.
 ///
 /// Blocking is possible, at least during early boot; see module documentation.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -266,5 +266,8 @@ cfg_if! {
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
 pub fn getrandom(dest: &mut [u8]) -> Result<(), error::Error> {
+    if dest.is_empty() {
+        return Ok(())
+    }
     imp::getrandom_inner(dest)
 }


### PR DESCRIPTION
Almost all zst passes to FFI is undefined behavior
(i.e. `memcpy(NULL,NULL,0)` is UB, same for `getrandom`)

This checks that the slice isn't a ZST. otherwise rust doesn't promise anything about the pointer from `slice.as_mut_ptr()`

I do not think this is actually a vulnerability/deserve advisory, but if someone disagrees I would report this to https://github.com/RustSec/advisory-db (@tarcieri)
because most implementations will probably be fine with it. though I had problems in the past with Intel's libraries that passing NULL+0 to `memset` resulted in SEGFAULT.