### PR TITLE
Fix building issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2019-08-18
+### Changed
+- Use the dummy implementation on `wasm32-unknown-unknown` even with the
+disabled `dummy` feature. [#90]
+
+### Fixed
+- Fix CSP error for `wasm-bindgen`. [#92]
+
+[#90]: https://github.com/rust-random/getrandom/pull/90
+[#92]: https://github.com/rust-random/getrandom/pull/92
+
 ## [0.1.9] - 2019-08-14
 ### Changed
 - Remove `std` dependency for opening and reading files. [#58]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -166,14 +166,12 @@ cfg_if! {
     if #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "emscripten",
                  target_os = "freebsd", target_os = "haiku",     target_os = "illumos",
                  target_os = "linux",   target_os = "macos",     target_os = "netbsd",
-                 target_os = "openbsd", target_os = "redox",     target_os = "solaris"))] {
+                 target_os = "openbsd", target_os = "redox",     target_os = "solaris",
+                 target_os = "vxworks"))] {
         #[allow(dead_code)]
         mod util_libc;
         // Keep std-only trait definitions for backwards compatiblity
         mod error_impls;
-    } else if #[cfg(target_os = "vxworks")] {
-        #[allow(dead_code)]
-        mod util_libc;
     } else if #[cfg(feature = "std")] {
         mod error_impls;
     }

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -58,54 +58,38 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 }
 
 fn getrandom_init() -> Result<RngSource, Error> {
-    // First up we need to detect if we're running in node.js or a
-    // browser. To do this we get ahold of the `this` object (in a bit
-    // of a roundabout fashion).
-    //
-    // Once we have `this` we look at its `self` property, which is
-    // only defined on the web (either a main window or web worker).
-    let this = Function::new("return this").call(&JsValue::undefined());
-    assert!(this != JsValue::undefined());
-    let this = This::from(this);
-    let is_browser = this.self_() != JsValue::undefined();
+    if let Ok(self_) = Global::get_self() {
+        // If `self` is defined then we're in a browser somehow (main window
+        // or web worker). Here we want to try to use
+        // `crypto.getRandomValues`, but if `crypto` isn't defined we assume
+        // we're in an older web browser and the OS RNG isn't available.
 
-    if !is_browser {
-        return Ok(RngSource::Node(node_require("crypto")));
+        let crypto = self_.crypto();
+        if crypto.is_undefined() {
+            return Err(BINDGEN_CRYPTO_UNDEF);
+        }
+
+        // Test if `crypto.getRandomValues` is undefined as well
+        let crypto: BrowserCrypto = crypto.into();
+        if crypto.get_random_values_fn().is_undefined() {
+            return Err(BINDGEN_GRV_UNDEF);
+        }
+
+        return Ok(RngSource::Browser(crypto));
     }
 
-    // If `self` is defined then we're in a browser somehow (main window
-    // or web worker). Here we want to try to use
-    // `crypto.getRandomValues`, but if `crypto` isn't defined we assume
-    // we're in an older web browser and the OS RNG isn't available.
-    let crypto = this.crypto();
-    if crypto.is_undefined() {
-        return Err(BINDGEN_CRYPTO_UNDEF);
-    }
-
-    // Test if `crypto.getRandomValues` is undefined as well
-    let crypto: BrowserCrypto = crypto.into();
-    if crypto.get_random_values_fn().is_undefined() {
-        return Err(BINDGEN_GRV_UNDEF);
-    }
-
-    // Ok! `self.crypto.getRandomValues` is a defined value, so let's
-    // assume we can do browser crypto.
-    Ok(RngSource::Browser(crypto))
+    return Ok(RngSource::Node(node_require("crypto")));
 }
 
 #[wasm_bindgen]
 extern "C" {
-    type Function;
-    #[wasm_bindgen(constructor)]
-    fn new(s: &str) -> Function;
-    #[wasm_bindgen(method)]
-    fn call(this: &Function, self_: &JsValue) -> JsValue;
+    type Global;
+    #[wasm_bindgen(getter, catch, static_method_of = Global, js_class = self, js_name = self)]
+    fn get_self() -> Result<Self_, JsValue>;
 
-    type This;
-    #[wasm_bindgen(method, getter, structural, js_name = self)]
-    fn self_(me: &This) -> JsValue;
+    type Self_;
     #[wasm_bindgen(method, getter, structural)]
-    fn crypto(me: &This) -> JsValue;
+    fn crypto(me: &Self_) -> JsValue;
 
     #[derive(Clone, Debug)]
     type BrowserCrypto;


### PR DESCRIPTION
I saw this error when building rust for vxWorks targets:
/folk/prj-rust-dev/bpang/ala-diab-pb19l/latest/latest/.cargo/registry/src/github.com-1ecc6299db9ec823/rand_core-0.5.1/src/err\
or.rs:150:28
    |
150 |             Error { inner: Box::new(error) }
    |                            ^^^^^^^^^^^^^^^ the trait `std::error::Error` is not implemented for `getrandom::error::Error`
    |
    = note: required for the cast to the object type `dyn std::error::Error + std::marker::Send + std::marker::Sync`

And after adding "mod error_impls;" the issue disappears.

r? @newpavlov 
cc @n-salim