### PR TITLE
cfg-if 0.1.2 is minimal version of dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ appveyor = { repository = "rust-random/getrandom" }
 
 [dependencies]
 log = { version = "0.4", optional = true }
-cfg-if = "0.1"
+cfg-if = "0.1.2"
 
 # When built as part of libstd
 compiler_builtins = { version = "0.1", optional = true }


### PR DESCRIPTION
Some external minimal version testing (incl. rust 1.32.0 and recent nightly) suggests that any getrandom release since 0.1.7 actually requires cfg-if 0.1.2. Otherwise it will fail to build with errors like:

```
  --> /home/david/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.1.7/src/util_libc.rs:25:6
   |
25 |     }
   |      ^ missing tokens in macro arguments

error[E0425]: cannot find function `errno_location` in this scope
  --> /home/david/.cargo/registry/src/github.com-1ecc6299db9ec823/getrandom-0.1.7/src/util_libc.rs:29:27
   |
29 |     let errno = unsafe { *errno_location() };
   |                           ^^^^^^^^^^^^^^ not found in this scope

error: aborting due to 2 previous errors
```

This just updates the dependency to the minimum required.
