### PR TITLE
Fix typos and bad doc links.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -40,7 +40,7 @@ impl Error {
     ///
     /// This method is identical to `std::io::Error::raw_os_error()`, except
     /// that it works in `no_std` contexts. If this method returns `None`, the
-    /// error value can still be formatted via the `Diplay` implementation.
+    /// error value can still be formatted via the `Display` implementation.
     #[inline]
     pub fn raw_os_error(self) -> Option<i32> {
         if self.0.get() < Self::INTERNAL_START {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,8 +28,8 @@
 //! | L4RE, SGX, UEFI  | [RDRAND][18]
 //! | Hermit           | [RDRAND][18] as [`sys_rand`][22] is currently broken.
 //! | VxWorks          | `randABytes` after checking entropy pool initialization with `randSecure`
-//! | Web browsers     | [`Crypto.getRandomValues`][14] (see [Support for WebAssembly and ams.js][14])
-//! | Node.js          | [`crypto.randomBytes`][15] (see [Support for WebAssembly and ams.js][16])
+//! | Web browsers     | [`Crypto.getRandomValues`][14] (see [Support for WebAssembly and asm.js][16])
+//! | Node.js          | [`crypto.randomBytes`][15] (see [Support for WebAssembly and asm.js][16])
 //! | WASI             | [`__wasi_random_get`][17]
 //!
 //! Getrandom doesn't have a blanket implementation for all Unix-like operating
@@ -83,7 +83,7 @@
 //! A few, Linux, NetBSD and Solaris, offer a choice between blocking and
 //! getting an error; in these cases we always choose to block.
 //!
-//! On Linux (when the `genrandom` system call is not available) and on NetBSD
+//! On Linux (when the `getrandom` system call is not available) and on NetBSD
 //! reading from `/dev/urandom` never blocks, even when the OS hasn't collected
 //! enough entropy yet. To avoid returning low-entropy bytes, we first read from
 //! `/dev/random` and only switch to `/dev/urandom` once this has succeeded.
@@ -114,7 +114,7 @@
 //! [13]: https://github.com/nuxinl/cloudabi#random_get
 //! [14]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
 //! [15]: https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
-//! [16]: #support-for-webassembly-and-amsjs
+//! [16]: #support-for-webassembly-and-asmjs
 //! [17]: https://github.com/WebAssembly/WASI/blob/master/design/WASI-core.md#__wasi_random_get
 //! [18]: https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
 //! [19]: https://www.unix.com/man-page/mojave/2/getentropy/
@@ -173,7 +173,7 @@ cfg_if! {
                  target_os = "openbsd", target_os = "redox",     target_os = "solaris"))] {
         #[allow(dead_code)]
         mod util_libc;
-        // Keep std-only trait definitions for backwards compatiblity
+        // Keep std-only trait definitions for backwards compatibility
         mod error_impls;
     } else if #[cfg(feature = "std")] {
         mod error_impls;

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -26,7 +26,7 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
         let mut el = mem::zeroed();
         if _rdrand64_step(&mut el) == 1 {
             // AMD CPUs from families 14h to 16h (pre Ryzen) sometimes fail to
-            // set CF on bogus random data, so we check these values explictly.
+            // set CF on bogus random data, so we check these values explicitly.
             // See https://github.com/systemd/systemd/issues/11810#issuecomment-489727505
             // We perform this check regardless of target to guard against
             // any implementation that incorrectly fails to set CF.

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -15,7 +15,7 @@
 //!
 //! Since Solaris 11.3 and mid-2015 illumos, the `getrandom` syscall is available.
 //! To make sure we can compile on both Solaris and its derivatives, as well as
-//! function, we check for the existance of getrandom(2) in libc by calling
+//! function, we check for the existence of getrandom(2) in libc by calling
 //! libc::dlsym.
 use crate::util_libc::{sys_fill_exact, Weak};
 use crate::{use_file, Error};

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,8 +8,8 @@
 
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
-// This structure represents a laziliy initialized static usize value. Useful
-// when it is perferable to just rerun initialization instead of locking.
+// This structure represents a lazily initialized static usize value. Useful
+// when it is preferable to just rerun initialization instead of locking.
 // Both unsync_init and sync_init will invoke an init() function until it
 // succeeds, then return the cached value for future calls.
 //
@@ -25,7 +25,7 @@ use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 //          v
 //      }
 // the effects of c() or writes to shared memory will not necessarily be
-// observed and additional syncronization methods with be needed.
+// observed and additional synchronization methods with be needed.
 pub struct LazyUsize(AtomicUsize);
 
 impl LazyUsize {

--- a/src/windows_uwp.rs
+++ b/src/windows_uwp.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for Windows UWP targets. After deprecation of Windows XP
-//! and Vista, this can superseed the `RtlGenRandom`-based implementation.
+//! and Vista, this can supersede the `RtlGenRandom`-based implementation.
 use crate::Error;
 use core::{ffi::c_void, num::NonZeroU32, ptr};
 


### PR DESCRIPTION
I just ran my local code spellchecker and ignored words that were not in it's dictionary.