### PR TITLE
Improve src/lib.rs cfgs

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![allow(dead_code)]
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 // This structure represents a lazily initialized static usize value. Useful

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -5,6 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![allow(dead_code)]
 use crate::error::ERRNO_NOT_POSITIVE;
 use crate::util::LazyUsize;
 use crate::Error;


### PR DESCRIPTION
Suggested by @newpavlov here: https://github.com/rust-random/getrandom/pull/116#discussion_r338433563

Right now for each of `util_libc` and `use_file` we have a list of
`target_os` configs to determine if we build the module.

This PR moves these mod declarations into the main `cfg_if` statement
(the one that selects which implementation we use). This way, the mod
statements are kept in-sync with the implementations that use them.

Also, I merged together `target_os` cfgs that have the same
implementation. The downside to this is that the targets are no longer
in alphabetical order.

Also, this is only being applied to `0.2` as the `0.1` cfgs still have
to keep `std` around.