### PR TITLE
0.2: Error and Testing improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ matrix:
         - rustup target add aarch64-apple-ios
       script:
         - cargo test
-        - cargo test --examples
         - cargo build --target aarch64-apple-ios
 
     - name: "Linux, beta"
@@ -40,11 +39,11 @@ matrix:
         # Get latest geckodriver
         - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
         - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/$VERSION/geckodriver-$VERSION-linux64.tar.gz
-        - tar -xzf geckodriver.tar.gz
+        - tar -xzf geckodriver.tar.gz -C $HOME
         # Get latest chromedirver
         - export VERSION=$(wget -q -O - https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
         - wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip
-        - unzip chromedriver.zip
+        - unzip chromedriver.zip -d $HOME
         # Get cargo-web
         - export VERSION=0.6.26 # Pin version for stability
         - wget -O cargo-web.gz https://github.com/koute/cargo-web/releases/download/$VERSION/cargo-web-x86_64-unknown-linux-gnu.gz
@@ -76,44 +75,34 @@ matrix:
         - cargo web test --target=wasm32-unknown-unknown --features=stdweb
         # wasm-bindgen tests (Node, Firefox, Chrome)
         - cargo test --target wasm32-unknown-unknown --features=wasm-bindgen
-        - GECKODRIVER=$PWD/geckodriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
-        - CHROMEDRIVER=$PWD/chromedriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
+        - GECKODRIVER=$HOME/geckodriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
+        - CHROMEDRIVER=$HOME/chromedriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
 
-    - name: "Linux, nightly, docs"
+    - &nightly_and_docs
+      name: "Linux, nightly, docs"
       rust: nightly
       os: linux
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
         - cargo deadlinks -V
       script:
+        # Check that our tests pass in the default configuration
         - cargo test
         - cargo test --benches
-        - cargo test --examples
+        # Check that setting various features does not break the build
+        - cargo build --features=std
+        - cargo build --features=log
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
-        - cargo doc --no-deps --all --features=std,log
+        - cargo doc --no-deps --features=std
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
-        - cargo test
+        - cargo test --features=std,log
 
-    - name: "OSX, nightly, docs"
-      rust: nightly
+    - <<: *nightly_and_docs
+      name: "OSX, nightly, docs"
       os: osx
-      install:
-        - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
-        - cargo deadlinks -V
-      script:
-        - cargo test
-        - cargo test --benches
-        - cargo test --examples
-        # remove cached documentation, otherwise files from previous PRs can get included
-        - rm -rf target/doc
-        - cargo doc --no-deps --all --features=std,log
-        - cargo deadlinks --dir target/doc
-        # also test minimum dependency versions are usable
-        - cargo generate-lockfile -Z minimal-versions
-        - cargo test
 
     - name: "cross-platform build only"
       rust: nightly
@@ -139,6 +128,7 @@ matrix:
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc
+        - cargo xbuild --target=x86_64-uwp-windows-gnu
         - cargo xbuild --target=x86_64-wrs-vxworks
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
@@ -153,6 +143,7 @@ matrix:
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc
         - cargo xbuild --target=x86_64-uwp-windows-gnu
+        - cargo xbuild --target=x86_64-wrs-vxworks
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - name: "Linux (MIPS, big-endian)"
@@ -199,7 +190,6 @@ before_script:
 
 script:
   - cargo test
-  - cargo test --examples
 
 after_script: set +e
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.1.12"
+version = "0.2.0"
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ std = []
 rustc-dep-of-std = ["compiler_builtins", "core"]
 # Unstable feature for testing
 test-in-browser = ["wasm-bindgen"]
+
+[package.metadata.docs.rs]
+features = ["std"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,12 +20,6 @@ use core::num::NonZeroU32;
 pub struct Error(NonZeroU32);
 
 impl Error {
-    #[deprecated(since = "0.1.7")]
-    /// Unknown error.
-    pub const UNKNOWN: Error = UNSUPPORTED;
-    #[deprecated(since = "0.1.7")]
-    /// System entropy source is unavailable.
-    pub const UNAVAILABLE: Error = UNSUPPORTED;
 
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are

--- a/src/error.rs
+++ b/src/error.rs
@@ -156,7 +156,7 @@ fn internal_desc(error: Error) -> Option<&'static str> {
         BINDGEN_GRV_UNDEF => Some("wasm-bindgen: crypto.getRandomValues is undefined"),
         STDWEB_NO_RNG => Some("stdweb: no randomness source available"),
         STDWEB_RNG_FAILED => Some("stdweb: failed to get randomness"),
-        RAND_SECURE_FATAL => Some("randSecure: random number generator module is not initialized"),
+        RAND_SECURE_FATAL => Some("randSecure: VxWorks RNG module is not initialized"),
         _ => None,
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,9 +38,11 @@ impl Error {
 
     /// Extract the raw OS error code (if this error came from the OS)
     ///
-    /// This method is identical to `std::io::Error::raw_os_error()`, except
+    /// This method is identical to [`std::io::Error::raw_os_error()`][1], except
     /// that it works in `no_std` contexts. If this method returns `None`, the
     /// error value can still be formatted via the `Display` implementation.
+    ///
+    /// [1]: https://doc.rust-lang.org/std/io/struct.Error.html#method.raw_os_error
     #[inline]
     pub fn raw_os_error(self) -> Option<i32> {
         if self.0.get() < Self::INTERNAL_START {

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,10 +31,10 @@ impl Error {
     pub const UNSUPPORTED: Error = internal_error!(0);
     /// The platform-specific `errno` returned a non-positive value.
     pub const ERRNO_NOT_POSITIVE: Error = internal_error!(1);
-    /// Call to [`SecRandomCopyBytes`](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes) failed.
-    pub const SEC_RANDOM_FAILED: Error = internal_error!(3);
-    /// Call to [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom) failed.
-    pub const RTL_GEN_RANDOM_FAILED: Error = internal_error!(4);
+    /// Call to iOS [`SecRandomCopyBytes`](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes) failed.
+    pub const IOS_SEC_RANDOM: Error = internal_error!(3);
+    /// Call to Windows [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom) failed.
+    pub const WINDOWS_RTL_GEN_RANDOM: Error = internal_error!(4);
     /// RDRAND instruction failed due to a hardware issue.
     pub const FAILED_RDRAND: Error = internal_error!(5);
     /// RDRAND instruction unsupported on this target.
@@ -47,8 +47,8 @@ impl Error {
     pub const STDWEB_NO_RNG: Error = internal_error!(9);
     /// Using `stdweb`, invoking a cryptographic RNG failed.
     pub const STDWEB_RNG_FAILED: Error = internal_error!(10);
-    /// On VxWorks, random number generator is not yet initialized.
-    pub const RAND_SECURE_FATAL: Error = internal_error!(11);
+    /// On VxWorks, call to `randSecure` failed (random number generator is not yet initialized).
+    pub const VXWORKS_RAND_SECURE: Error = internal_error!(11);
 
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are
@@ -155,15 +155,15 @@ fn internal_desc(error: Error) -> Option<&'static str> {
     match error {
         Error::UNSUPPORTED => Some("getrandom: this target is not supported"),
         Error::ERRNO_NOT_POSITIVE => Some("errno: did not return a positive value"),
-        Error::SEC_RANDOM_FAILED => Some("SecRandomCopyBytes: call failed"),
-        Error::RTL_GEN_RANDOM_FAILED => Some("RtlGenRandom: call failed"),
+        Error::IOS_SEC_RANDOM => Some("SecRandomCopyBytes: iOS Secuirty framework failure"),
+        Error::WINDOWS_RTL_GEN_RANDOM => Some("RtlGenRandom: Windows system function failure"),
         Error::FAILED_RDRAND => Some("RDRAND: failed multiple times: CPU issue likely"),
         Error::NO_RDRAND => Some("RDRAND: instruction not supported"),
         Error::BINDGEN_CRYPTO_UNDEF => Some("wasm-bindgen: self.crypto is undefined"),
         Error::BINDGEN_GRV_UNDEF => Some("wasm-bindgen: crypto.getRandomValues is undefined"),
         Error::STDWEB_NO_RNG => Some("stdweb: no randomness source available"),
         Error::STDWEB_RNG_FAILED => Some("stdweb: failed to get randomness"),
-        Error::RAND_SECURE_FATAL => Some("randSecure: VxWorks RNG module is not initialized"),
+        Error::VXWORKS_RAND_SECURE => Some("randSecure: VxWorks RNG module is not initialized"),
         _ => None,
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,8 +31,6 @@ impl Error {
     pub const UNSUPPORTED: Error = internal_error!(0);
     /// The platform-specific `errno` returned a non-positive value.
     pub const ERRNO_NOT_POSITIVE: Error = internal_error!(1);
-    /// Invalid conversion from a non-standard [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html)
-    pub const UNKNOWN_IO_ERROR: Error = internal_error!(2);
     /// Call to [`SecRandomCopyBytes`](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes) failed.
     pub const SEC_RANDOM_FAILED: Error = internal_error!(3);
     /// Call to [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom) failed.
@@ -157,7 +155,6 @@ fn internal_desc(error: Error) -> Option<&'static str> {
     match error {
         Error::UNSUPPORTED => Some("getrandom: this target is not supported"),
         Error::ERRNO_NOT_POSITIVE => Some("errno: did not return a positive value"),
-        Error::UNKNOWN_IO_ERROR => Some("Unknown std::io::Error"),
         Error::SEC_RANDOM_FAILED => Some("SecRandomCopyBytes: call failed"),
         Error::RTL_GEN_RANDOM_FAILED => Some("RtlGenRandom: call failed"),
         Error::FAILED_RDRAND => Some("RDRAND: failed multiple times: CPU issue likely"),

--- a/src/error_impls.rs
+++ b/src/error_impls.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 extern crate std;
 
-use crate::{error::UNKNOWN_IO_ERROR, Error};
+use crate::Error;
 use core::convert::From;
 use core::num::NonZeroU32;
 use std::io;
@@ -19,7 +19,7 @@ impl From<io::Error> for Error {
                 return Error::from(code);
             }
         }
-        UNKNOWN_IO_ERROR
+        Error::UNKNOWN_IO_ERROR
     }
 }
 

--- a/src/error_impls.rs
+++ b/src/error_impls.rs
@@ -9,19 +9,7 @@ extern crate std;
 
 use crate::Error;
 use core::convert::From;
-use core::num::NonZeroU32;
 use std::io;
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        if let Some(errno) = err.raw_os_error() {
-            if let Some(code) = NonZeroU32::new(errno as u32) {
-                return Error::from(code);
-            }
-        }
-        Error::UNKNOWN_IO_ERROR
-    }
-}
 
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for iOS
-use crate::{error::SEC_RANDOM_FAILED, Error};
+use crate::Error;
 
 // TODO: Make extern once extern_types feature is stabilized. See:
 //   https://github.com/rust-lang/rust/issues/43467
@@ -24,7 +24,7 @@ extern "C" {
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
     if ret == -1 {
-        Err(SEC_RANDOM_FAILED)
+        Err(Error::SEC_RANDOM_FAILED)
     } else {
         Ok(())
     }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -24,7 +24,7 @@ extern "C" {
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
     if ret == -1 {
-        Err(Error::SEC_RANDOM_FAILED)
+        Err(Error::IOS_SEC_RANDOM)
     } else {
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,7 +243,7 @@ cfg_if! {
 /// In general, `getrandom` will be fast enough for interactive usage, though
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
-pub fn getrandom(dest: &mut [u8]) -> Result<(), error::Error> {
+pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
     if dest.is_empty() {
         return Ok(());
     }

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 
 //! Implementation for SGX using RDRAND instruction
-use crate::error::{FAILED_RDRAND, NO_RDRAND};
 #[cfg(not(target_feature = "rdrand"))]
 use crate::util::LazyBool;
 use crate::Error;
@@ -37,7 +36,7 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
             // Keep looping in case this was a false positive.
         }
     }
-    Err(FAILED_RDRAND)
+    Err(Error::FAILED_RDRAND)
 }
 
 // "rdrand" target feature requires "+rdrnd" flag, see https://github.com/rust-lang/rust/issues/49653.
@@ -64,7 +63,7 @@ fn is_rdrand_supported() -> bool {
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     if !is_rdrand_supported() {
-        return Err(NO_RDRAND);
+        return Err(Error::NO_RDRAND);
     }
 
     // SAFETY: After this point, rdrand is supported, so calling the rdrand

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![allow(dead_code)]
-use crate::error::ERRNO_NOT_POSITIVE;
 use crate::util::LazyUsize;
 use crate::Error;
 use core::num::NonZeroU32;
@@ -34,7 +33,7 @@ pub fn last_os_error() -> Error {
     if errno > 0 {
         Error::from(NonZeroU32::new(errno as u32).unwrap())
     } else {
-        ERRNO_NOT_POSITIVE
+        Error::ERRNO_NOT_POSITIVE
     }
 }
 

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for VxWorks
-use crate::error::{Error, RAND_SECURE_FATAL};
+use crate::error::Error;
 use crate::util_libc::last_os_error;
 use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
@@ -16,7 +16,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };
         if ret < 0 {
-            return Err(RAND_SECURE_FATAL);
+            return Err(Error::RAND_SECURE_FATAL);
         } else if ret > 0 {
             RNG_INIT.store(true, Relaxed);
             break;

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -16,7 +16,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };
         if ret < 0 {
-            return Err(Error::RAND_SECURE_FATAL);
+            return Err(Error::VXWORKS_RAND_SECURE);
         } else if ret > 0 {
             RNG_INIT.store(true, Relaxed);
             break;

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -7,8 +7,8 @@
 // except according to those terms.
 
 //! Implementation for VxWorks
-use crate::error::Error;
 use crate::util_libc::last_os_error;
+use crate::Error;
 use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {

--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -15,7 +15,6 @@ use std::thread_local;
 
 use wasm_bindgen::prelude::*;
 
-use crate::error::{BINDGEN_CRYPTO_UNDEF, BINDGEN_GRV_UNDEF};
 use crate::Error;
 
 #[derive(Clone, Debug)]
@@ -66,13 +65,13 @@ fn getrandom_init() -> Result<RngSource, Error> {
 
         let crypto = self_.crypto();
         if crypto.is_undefined() {
-            return Err(BINDGEN_CRYPTO_UNDEF);
+            return Err(Error::BINDGEN_CRYPTO_UNDEF);
         }
 
         // Test if `crypto.getRandomValues` is undefined as well
         let crypto: BrowserCrypto = crypto.into();
         if crypto.get_random_values_fn().is_undefined() {
-            return Err(BINDGEN_GRV_UNDEF);
+            return Err(Error::BINDGEN_GRV_UNDEF);
         }
 
         return Ok(RngSource::Browser(crypto));

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -15,7 +15,6 @@ use stdweb::js;
 use stdweb::unstable::TryInto;
 use stdweb::web::error::Error as WebError;
 
-use crate::error::{STDWEB_NO_RNG, STDWEB_RNG_FAILED};
 use crate::Error;
 use std::sync::Once;
 
@@ -71,7 +70,7 @@ fn getrandom_init() -> Result<RngSource, Error> {
     } else {
         let _err: WebError = js! { return @{ result }.error }.try_into().unwrap();
         error!("getrandom unavailable: {}", _err);
-        Err(STDWEB_NO_RNG)
+        Err(Error::STDWEB_NO_RNG)
     }
 }
 
@@ -107,7 +106,7 @@ fn getrandom_fill(source: RngSource, dest: &mut [u8]) -> Result<(), Error> {
         if js! { return @{ result.as_ref() }.success } != true {
             let _err: WebError = js! { return @{ result }.error }.try_into().unwrap();
             error!("getrandom failed: {}", _err);
-            return Err(STDWEB_RNG_FAILED);
+            return Err(Error::STDWEB_RNG_FAILED);
         }
     }
     Ok(())

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -10,13 +10,13 @@
 extern crate std;
 
 use core::mem;
+use std::sync::Once;
 
 use stdweb::js;
 use stdweb::unstable::TryInto;
 use stdweb::web::error::Error as WebError;
 
 use crate::Error;
-use std::sync::Once;
 
 #[derive(Clone, Copy, Debug)]
 enum RngSource {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -19,7 +19,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(u32::max_value() as usize) {
         let ret = unsafe { RtlGenRandom(chunk.as_mut_ptr(), chunk.len() as u32) };
         if ret == 0 {
-            return Err(Error::RTL_GEN_RANDOM_FAILED);
+            return Err(Error::WINDOWS_RTL_GEN_RANDOM);
         }
     }
     Ok(())

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 //! Implementation for Windows
-use crate::{error::RTL_GEN_RANDOM_FAILED, Error};
+use crate::Error;
 
 extern "system" {
     #[link_name = "SystemFunction036"]
@@ -19,7 +19,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(u32::max_value() as usize) {
         let ret = unsafe { RtlGenRandom(chunk.as_mut_ptr(), chunk.len() as u32) };
         if ret == 0 {
-            return Err(RTL_GEN_RANDOM_FAILED);
+            return Err(Error::RTL_GEN_RANDOM_FAILED);
         }
     }
     Ok(())


### PR DESCRIPTION
#109 contains a lot of fixes to the `Error` class and to our testing infrastructure that makes it harder to focus on the important changes in that PR.

I split out the changes unrelated to Custom RNGs into this PR. I also fixed up the commits/messages to explain these changes (we should be sure to "merge" this PR not "squash" it). Also, this PR should be merged before #109

This PR:

- Improves the `Error` struct
  - Removes deprecated constants
  - Exposes new `Error` constants
  - Some other minor nits
- Improves our Testing code
  - Remove use of `--examples`, we do not have examples
  - Install drivers to $HOME
  - Use YAML expansion to avoid repeating testing configs
  - Ensure crates build with each feature set individually
  - Add missing targets to cross-platform build step
  - Check minimum version compatiblity with features _on_
  - Gerate docs with "std" feature set
- Makes sure that the `std` feature will be enabled when using [docs.rs](https://docs.rs/).