### PR TITLE
wasi: Update and Fix Travis failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
         - gunzip cargo-web.gz
         - chmod +x cargo-web
         # Get wasmtime
-        - export VERSION=v0.3.0 # Pin version for stability
+        - export VERSION=v0.8.0 # Pin version for stability
         - wget -O wasmtime.tar.xz https://github.com/CraneStation/wasmtime/releases/download/$VERSION/wasmtime-$VERSION-x86_64-linux.tar.xz
         - tar -xf wasmtime.tar.xz --strip-components=1
         # Get wasm-bindgen-test-runner which matches our wasm-bindgen version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.64", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.7"
+wasi = "0.9"
 
 [target.wasm32-unknown-unknown.dependencies]
 wasm-bindgen = { version = "0.2.29", optional = true }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -8,12 +8,12 @@
 
 //! Implementation for WASI
 use crate::Error;
-use core::num;
-use wasi::wasi_unstable::random_get;
+use core::num::NonZeroU32;
+use wasi::random_get;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    random_get(dest).map_err(|e: num::NonZeroU16| {
-        // convert wasi's NonZeroU16 error into getrandom's NonZeroU32 error
-        num::NonZeroU32::new(e.get() as u32).unwrap().into()
+    unsafe { random_get(dest.as_mut_ptr(), dest.len()) }.map_err(|e: wasi::Error| {
+        // convert wasi's Error into getrandom's NonZeroU32 error
+        NonZeroU32::new(e.raw_error() as u32).unwrap().into()
     })
 }


### PR DESCRIPTION
It looks like Rust is now shipping a different version of the WASI toolchain. This toolchain now requires the corresponding runner to have `wasi_snapshot_preview1` as part of its environment.

Updating the version of the wasi runner to `0.8` allows us to run the binaries created by newer Rust toolchains. See: https://github.com/bytecodealliance/wasi/issues/37

We also update the `wasi` version to `0.9` to get on a stable interface. This requires us to use `unsafe` again (as the current API does not have slice-based helpers anymore). The new API also gets ride of `error_str`, so we have to go though `wasi::Error`.  

CC: @sunfishcode

Signed-off-by: Joe Richey <joerichey@google.com>