### PR TITLE
Make fallback to /dev/random optional when getrandom(2) is available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,10 @@ stdweb = { version = "0.4.18", optional = true }
 wasm-bindgen-test = "0.2"
 
 [features]
+default = ["file-fallback"]
 std = []
+# Enables falling back to file-based implementations
+file-fallback = []
 # Enables dummy implementation for unsupported targets
 dummy = []
 # Unstable feature to support being a libstd dependency

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,6 +45,7 @@ build: false
 test_script:
   - set RUSTFLAGS=-D warnings
   - cargo test
+  - cargo test --no-default-features
   - cargo test --examples
 
 branches:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -181,12 +181,15 @@ cfg_if! {
 }
 
 // These targets read from a file as a fallback method.
-#[cfg(any(
-    target_os = "android",
-    target_os = "linux",
-    target_os = "macos",
-    target_os = "solaris",
-    target_os = "illumos",
+#[cfg(all(
+    feature = "file-fallback",
+    any(
+        target_os = "android",
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "solaris",
+        target_os = "illumos",
+    )
 ))]
 mod use_file;
 

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -7,11 +7,13 @@
 // except according to those terms.
 
 //! Implementation for Linux / Android
+#[cfg(not(feature = "file-fallback"))]
+use crate::error;
 #[cfg(feature = "file-fallback")]
 use crate::use_file;
 use crate::util::LazyBool;
 use crate::util_libc::{last_os_error, sys_fill_exact};
-use crate::{error, Error};
+use crate::Error;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static HAS_GETRANDOM: LazyBool = LazyBool::new();

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -27,8 +27,12 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         }
         Ok(())
     } else {
-        // We fallback to reading from /dev/random instead of SecRandomCopyBytes
-        // to avoid high startup costs and linking the Security framework.
-        use_file::getrandom_inner(dest)
+        cfg_if! {
+            if #[cfg(feature = "file-fallback")] {
+                use_file::getrandom_inner(dest)
+            } else {
+                Err(error::UNSUPPORTED)
+            }
+        }
     }
 }

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -7,8 +7,12 @@
 // except according to those terms.
 
 //! Implementation for macOS
+#[cfg(not(feature = "file-fallback"))]
+use crate::error;
+#[cfg(feature = "file-fallback")]
+use crate::use_file;
 use crate::util_libc::{last_os_error, Weak};
-use crate::{use_file, Error};
+use crate::Error;
 use core::mem;
 
 type GetEntropyFn = unsafe extern "C" fn(*mut u8, libc::size_t) -> libc::c_int;

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -17,8 +17,12 @@
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existence of getrandom(2) in libc by calling
 //! libc::dlsym.
+#[cfg(not(feature = "file-fallback"))]
+use crate::error;
+#[cfg(feature = "file-fallback")]
+use crate::use_file;
 use crate::util_libc::{sys_fill_exact, Weak};
-use crate::{use_file, Error};
+use crate::Error;
 use core::mem;
 
 #[cfg(target_os = "illumos")]

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -39,6 +39,12 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         }
         Ok(())
     } else {
-        use_file::getrandom_inner(dest)
+        cfg_if! {
+            if #[cfg(feature = "file-fallback")] {
+                use_file::getrandom_inner(dest)
+            } else {
+                Err(error::UNSUPPORTED)
+            }
+        }
     }
 }


### PR DESCRIPTION
The fallback to a character file is now gated on the `file-fallback`
feature (enabled by default); affects Linux/Android, macOS, and Solaris/Illumos.

Disabling this feature can be advantageous for reduced code size.

Moreover, some users may prefer to guarantee using `getrandom(2)` on Linux
rather than have to reason about Linux's blocking behaviour for `random(4)` and
`urandom(4)`.