### PR TITLE
log: Remove optional log dependancy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,14 +91,13 @@ matrix:
         - cargo test --benches
         # Check that setting various features does not break the build
         - cargo build --features=std
-        - cargo build --features=log
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
         - cargo doc --no-deps --features=std
         - cargo deadlinks --dir target/doc
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
-        - cargo test --features=std,log
+        - cargo test --features=std
 
     - <<: *nightly_and_docs
       name: "OSX, nightly, docs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ travis-ci = { repository = "rust-random/getrandom" }
 appveyor = { repository = "rust-random/getrandom" }
 
 [dependencies]
-log = { version = "0.4", optional = true }
 cfg-if = "0.1.2"
 
 # When built as part of libstd

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-getrandom = "0.1"
+getrandom = "0.2"
 ```
 
 Then invoke the `getrandom` function:
@@ -43,9 +43,6 @@ This library is `no_std` for every supported target. However, getting randomness
 usually requires calling some external system API. This means most platforms
 will require linking against system libraries (i.e. `libc` for Unix,
 `Advapi32.dll` for Windows, Security framework on iOS, etc...).
-
-The `log` library is supported as an optional dependency. If enabled, error
-reporting will be improved on some platforms.
 
 For the `wasm32-unknown-unknown` target, one of the following features should be
 enabled:

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -25,7 +25,6 @@ fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
         )
     };
     if ret == -1 {
-        error!("sysctl kern.arandom: syscall failed");
         -1
     } else {
         len as libc::ssize_t

--- a/src/cloudabi.rs
+++ b/src/cloudabi.rs
@@ -17,7 +17,6 @@ extern "C" {
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let errno = unsafe { cloudabi_sys_random_get(dest.as_mut_ptr(), dest.len()) };
     if let Some(code) = NonZeroU32::new(errno as u32) {
-        error!("cloudabi_sys_random_get: failed with {}", errno);
         Err(Error::from(code))
     } else {
         Ok(()) // Zero means success for CloudABI

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,27 +132,6 @@
 #[macro_use]
 extern crate cfg_if;
 
-cfg_if! {
-    if #[cfg(feature = "log")] {
-        #[allow(unused)]
-        #[macro_use]
-        extern crate log;
-    } else {
-        #[allow(unused)]
-        macro_rules! error {
-            ($($x:tt)*) => {};
-        }
-        #[allow(unused)]
-        macro_rules! warn {
-            ($($x:tt)*) => {};
-        }
-        #[allow(unused)]
-        macro_rules! info {
-            ($($x:tt)*) => {};
-        }
-    }
-}
-
 mod error;
 mod util;
 

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -20,9 +20,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         for chunk in dest.chunks_mut(256) {
             let ret = unsafe { func(chunk.as_mut_ptr(), chunk.len()) };
             if ret != 0 {
-                let err = last_os_error();
-                error!("getentropy syscall failed");
-                return Err(err);
+                return Err(last_os_error());
             }
         }
         Ok(())

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -14,9 +14,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
         if ret == -1 {
-            let err = last_os_error();
-            error!("libc::getentropy call failed");
-            return Err(err);
+            return Err(last_os_error());
         }
     }
     Ok(())

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -32,7 +32,6 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
             if el != 0 && el != !0 {
                 return Ok(el.to_ne_bytes());
             }
-            error!("RDRAND returned {:X}, CPU RNG may be broken", el);
             // Keep looping in case this was a false positive.
         }
     }

--- a/src/wasm32_stdweb.rs
+++ b/src/wasm32_stdweb.rs
@@ -13,8 +13,6 @@ use core::mem;
 use std::sync::Once;
 
 use stdweb::js;
-use stdweb::unstable::TryInto;
-use stdweb::web::error::Error as WebError;
 
 use crate::Error;
 
@@ -68,8 +66,6 @@ fn getrandom_init() -> Result<RngSource, Error> {
             unreachable!()
         }
     } else {
-        let _err: WebError = js! { return @{ result }.error }.try_into().unwrap();
-        error!("getrandom unavailable: {}", _err);
         Err(Error::STDWEB_NO_RNG)
     }
 }
@@ -104,8 +100,6 @@ fn getrandom_fill(source: RngSource, dest: &mut [u8]) -> Result<(), Error> {
         };
 
         if js! { return @{ result.as_ref() }.success } != true {
-            let _err: WebError = js! { return @{ result }.error }.try_into().unwrap();
-            error!("getrandom failed: {}", _err);
             return Err(Error::STDWEB_RNG_FAILED);
         }
     }


### PR DESCRIPTION
This feature isn't enabled by rand/rand_core and provides very little
error information that isn't already conveyed through our Error values.

This also simplifies the supported configuration space for getrandom.

See this comment by @newpavlov: https://github.com/rust-random/getrandom/issues/98#issuecomment-546977404