### PR TITLE
Update docs for 0.2 Release 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ jobs:
         - cargo doc --no-deps --features=std,custom
         - cargo deadlinks --dir target/doc
         # Check that our tests pass in the default/minimal configuration
-        - cargo test --tests --benches
+        - cargo test --tests --benches --features=std,custom
         - cargo generate-lockfile -Z minimal-versions
         - cargo test --tests --benches
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,9 @@ wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }
 wasm-bindgen-test = "0.3.12"
 
 [features]
+# Implement std-only traits for getrandom::Error
 std = []
-# Feature to enable fallback RDRAND-based implementation
+# Feature to enable fallback RDRAND-based implementation on x86/x86_64
 rdrand = []
 # Feature to enable JavaScript bindings on wasm32-unknown-unknown
 js = ["stdweb", "wasm-bindgen"]
@@ -44,8 +45,7 @@ js = ["stdweb", "wasm-bindgen"]
 custom = []
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["compiler_builtins", "core"]
-
-# Test/wasm-bindgen only feature to run tests in a browser
+# Unstable/test-only feature to run wasm-bindgen tests in a browser
 test-in-browser = []
 
 [package.metadata.docs.rs]

--- a/README.md
+++ b/README.md
@@ -37,27 +37,10 @@ fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
 }
 ```
 
-## Features
-
-This library is `no_std` for every supported target. However, getting randomness
-usually requires calling some external system API. This means most platforms
-will require linking against system libraries (i.e. `libc` for Unix,
-`Advapi32.dll` for Windows, Security framework on iOS, etc...).
-
-For the `wasm32-unknown-unknown` target, one of the following features should be
-enabled:
-
--   [`wasm-bindgen`](https://crates.io/crates/wasm_bindgen)
--   [`stdweb`](https://crates.io/crates/stdweb)
-
-By default, compiling `getrandom` for an unsupported target will result in
-a compilation error. If you want to build an application which uses `getrandom`
-for such target, you can either:
-- Use [`[replace]`][replace] or [`[patch]`][patch] section in your `Cargo.toml`
-to switch to a custom implementation with a support of your target.
-
-[replace]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-replace-section
-[patch]: https://doc.rust-lang.org/cargo/reference/manifest.html#the-patch-section
+For more information about supported targets, entropy sources, `no_std` targets,
+crate features, WASM support and Custom RNGs see the
+[`getrandom` documentation](https://docs.rs/getrandom/latest) and
+[`getrandom::Error` documentation](https://docs.rs/getrandom/latest/getrandom/struct.Error.html).
 
 ## Minimum Supported Rust Version
 

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -78,8 +78,9 @@ macro_rules! register_custom_getrandom {
         // We use an extern "C" function to get the guarantees of a stable ABI.
         #[no_mangle]
         extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
+            let f: fn(&mut [u8]) -> Result<(), ::getrandom::Error> = $path;
             let slice = unsafe { ::core::slice::from_raw_parts_mut(dest, len) };
-            match $path(slice) {
+            match f(slice) {
                 Ok(()) => 0,
                 Err(e) => e.code().get(),
             }

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -25,12 +25,12 @@ use core::num::NonZeroU32;
 /// [dependencies]
 /// getrandom = { version = "0.2", features = ["custom"] }
 /// ```
-/// 
+///
 /// Next, in `dummy-getrandom/src/lib.rs`, we define our custom implementation and register it:
 /// ```rust
 /// use core::num::NonZeroU32;
 /// use getrandom::{Error, register_custom_getrandom};
-/// 
+///
 /// const MY_CUSTOM_ERROR_CODE: u32 = Error::CUSTOM_START + 42;
 /// fn always_fail(buf: &mut [u8]) -> Result<(), Error> {
 ///     let code = NonZeroU32::new(MY_CUSTOM_ERROR_CODE).unwrap();
@@ -43,10 +43,9 @@ use core::num::NonZeroU32;
 /// [`getrandom::getrandom`](crate::getrandom).
 ///
 /// Now any user of `getrandom` (direct or indirect) on this target will use the
-/// above custom implementation. Note that if you are using a helper-crate, some
-/// crate in the build needs to depend on `dummy-getrandom` via a
-/// `use dummy_getrandom;` statement. Failure to do this will result
-/// in linker errors.
+/// above custom implementation. See the
+/// [usage documentation](index.html#use-a-custom-implementation) for information about
+/// _using_ such a custom implementation.
 #[macro_export]
 macro_rules! register_custom_getrandom {
     ($path:path) => {

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -53,9 +53,11 @@ use core::num::NonZeroU32;
 /// where helper crates define handlers/allocators but only the binary crate
 /// actually _uses_ the functionality.
 ///
-/// To register the function, we first depend on `getrandom` in `Cargo.toml`:
+/// To register the function, we first depend on `failure-getrandom` _and_
+/// `getrandom` in `Cargo.toml`:
 /// ```toml
 /// [dependencies]
+/// failure-getrandom = "0.1"
 /// getrandom = { version = "0.2", features = ["custom"] }
 /// ```
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 use core::{fmt, num::NonZeroU32};
 
-/// A small and `no_std` compatible error type.
+/// A small and `no_std` compatible error type
 ///
 /// The [`Error::raw_os_error()`] will indicate if the error is from the OS, and
 /// if so, which error code the OS gave the application. If such an error is
@@ -15,6 +15,12 @@ use core::{fmt, num::NonZeroU32};
 ///
 /// Internally this type is a NonZeroU32, with certain values reserved for
 /// certain purposes, see [`Error::INTERNAL_START`] and [`Error::CUSTOM_START`].
+///
+/// *If this crate's `"std"` Cargo feature is enabled*, then:
+/// - [`getrandom::Error`][Error] implements
+///   [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html)
+/// - [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) implements
+///   [`From<getrandom::Error>`](https://doc.rust-lang.org/std/convert/trait.From.html).
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Error(NonZeroU32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,10 +215,8 @@ cfg_if! {
     } else if #[cfg(feature = "custom")] {
         use custom as imp;
     } else {
-        compile_error!("\
-            target is not supported, for more information see: \
-            https://docs.rs/getrandom/#unsupported-targets\
-        ");
+        compile_error!("target is not supported, for more information see: \
+                        https://docs.rs/getrandom/#unsupported-targets");
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,30 +75,17 @@
 //!
 //! This feature has no effect on targets other than `wasm32-unknown-unknown`.
 //!
-//! ### Use a custom implementation
+//! ### Custom implementations
 //!
-//! Some external crates define `getrandom` implementations for specific
-//! unsupported targets. If you depend on one of these external crates and you
-//! are building for an unsupported target, `getrandom` will use this external
-//! implementation instead of failing to compile.
+//! The [`register_custom_getrandom!`] macro allows a user to mark their own
+//! function as the backing implementation for [`getrandom`]. See the macro's
+//! documentation for more information about writing and registering your own
+//! custom implementations.
 //!
-//! Using such an external implementation requires depending on it in your
-//! `Cargo.toml` _and_ using it in your binary crate with:
-//! ```ignore
-//! use some_custom_getrandom_crate;
-//! ```
-//! (failure to do this will cause linker errors).
-//!
-//! Other than [dev-dependencies](https://doc.rust-lang.org/stable/rust-by-example/testing/dev_dependencies.html),
-//! library crates should **not** depend on external implementation crates.
-//! Only binary crates should depend/use such crates. This is similar to
-//! [`#[panic_handler]`](https://doc.rust-lang.org/nomicon/panic-handler.html) or
-//! [`#[global_allocator]`](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html),
-//! where helper crates define handlers/allocators but only the binary crate
-//! actually _uses_ the functionality.
-//!
-//! See [`register_custom_getrandom!`] for information about writing your own
-//! custom `getrandom` implementation for an unsupported target.
+//! Note that registering a custom implementation only has an effect on targets
+//! that would otherwise not compile. Any supported targets (including those
+//! using `"rdrand"` and `"js"` Cargo features) continue using their normal
+//! implementations even if a function is registered.
 //!
 //! ### Indirect Dependencies
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,8 @@
 //! | VxWorks          | `randABytes` after checking entropy pool initialization with `randSecure`
 //! | Emscripten       | `/dev/random` (identical to `/dev/urandom`)
 //! | WASI             | [`__wasi_random_get`][17]
-//! | Web Browser      | [`Crypto.getRandomValues()`][14], see [support for WebAssembly][16]
-//! | Node.js          | [`crypto.randomBytes`][15], see [support for WebAssembly][16]
+//! | Web Browser      | [`Crypto.getRandomValues()`][14], see [WebAssembly support][16]
+//! | Node.js          | [`crypto.randomBytes`][15], see [WebAssembly support][16]
 //!
 //! There is no blanket implementation on `unix` targets that reads from
 //! `/dev/urandom`. This ensures all supported targets are using the recommended
@@ -56,7 +56,7 @@
 //! the [`RDRAND`][18] instruction to get randomness on `no_std` `x86`/`x86_64`
 //! targets. This feature has no effect on other CPU architectures.
 //!
-//! ### Support for WebAssembly
+//! ### WebAssembly support
 //!
 //! This crate fully supports the
 //! [`wasm32-wasi`](https://github.com/CraneStation/wasi) and
@@ -149,7 +149,7 @@
 //! [13]: https://github.com/nuxinl/cloudabi#random_get
 //! [14]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
 //! [15]: https://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback
-//! [16]: #support-for-webassembly
+//! [16]: #webassembly-support
 //! [17]: https://github.com/WebAssembly/WASI/blob/master/design/WASI-core.md#__wasi_random_get
 //! [18]: https://software.intel.com/en-us/articles/intel-digital-random-number-generator-drng-software-implementation-guide
 //! [19]: https://www.unix.com/man-page/mojave/2/getentropy/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,21 @@
 //! are building for an unsupported target, `getrandom` will use this external
 //! implementation instead of failing to compile.
 //!
+//! Using such an external implementation requires depending on it in your
+//! `Cargo.toml` _and_ using it in your binary crate with:
+//! ```ignore
+//! use some_custom_getrandom_crate;
+//! ```
+//! (failure to do this will cause linker errors).
+//!
+//! Other than [dev-dependencies](https://doc.rust-lang.org/stable/rust-by-example/testing/dev_dependencies.html),
+//! library crates should **not** depend on external implementation crates.
+//! Only binary crates should depend/use such crates. This is similar to
+//! [`#[panic_handler]`](https://doc.rust-lang.org/nomicon/panic-handler.html) or
+//! [`#[global_allocator]`](https://doc.rust-lang.org/edition-guide/rust-2018/platform-and-target-support/global-allocators.html),
+//! where helper crates define handlers/allocators but only the binary crate
+//! actually _uses_ the functionality.
+//!
 //! See [`register_custom_getrandom!`] for information about writing your own
 //! custom `getrandom` implementation for an unsupported target.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,28 +10,28 @@
 //!
 //! # Supported targets
 //!
-//! | Target           | Implementation
-//! |------------------|---------------------------------------------------------
-//! | Linux, Android   | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after successfully polling `/dev/random`
-//! | Windows          | [`RtlGenRandom`][3]
-//! | [Windows UWP][22]| [`BCryptGenRandom`][23]
-//! | macOS            | [`getentropy()`][19] if available, otherwise [`/dev/random`][20] (identical to `/dev/urandom`)
-//! | iOS              | [`SecRandomCopyBytes`][4]
-//! | FreeBSD          | [`getrandom()`][21] if available, otherwise [`kern.arandom`][5]
-//! | OpenBSD          | [`getentropy`][6]
-//! | NetBSD           | [`kern.arandom`][7]
-//! | Dragonfly BSD    | [`/dev/random`][8]
-//! | Solaris, illumos | [`getrandom`][9] system call if available, otherwise [`/dev/random`][10]
-//! | Fuchsia OS       | [`cprng_draw`][11]
-//! | Redox            | [`rand:`][12]
-//! | CloudABI         | [`cloudabi_sys_random_get`][13]
-//! | Haiku            | `/dev/random` (identical to `/dev/urandom`)
-//! | SGX              | [RDRAND][18]
-//! | VxWorks          | `randABytes` after checking entropy pool initialization with `randSecure`
-//! | Emscripten       | `/dev/random` (identical to `/dev/urandom`)
-//! | WASI             | [`__wasi_random_get`][17]
-//! | Web Browser      | [`Crypto.getRandomValues()`][14], see [WebAssembly support][16]
-//! | Node.js          | [`crypto.randomBytes`][15], see [WebAssembly support][16]
+//! | Target            | Target Triple      | Implementation
+//! | ----------------- | ------------------ | --------------
+//! | Linux, Android    | `*‑linux‑*`        | [`getrandom`][1] system call if available, otherwise [`/dev/urandom`][2] after successfully polling `/dev/random` |
+//! | Windows           | `*‑pc‑windows‑*`   | [`RtlGenRandom`][3] |
+//! | [Windows UWP][22] | `*‑uwp‑windows‑*`  | [`BCryptGenRandom`][23] |
+//! | macOS             | `*‑apple‑darwin`   | [`getentropy()`][19] if available, otherwise [`/dev/random`][20] (identical to `/dev/urandom`)
+//! | iOS               | `*‑apple‑ios`      | [`SecRandomCopyBytes`][4]
+//! | FreeBSD           | `*‑freebsd`        | [`getrandom()`][21] if available, otherwise [`kern.arandom`][5]
+//! | OpenBSD           | `*‑openbsd`        | [`getentropy`][6]
+//! | NetBSD            | `*‑netbsd`         | [`kern.arandom`][7]
+//! | Dragonfly BSD     | `*‑dragonfly`      | [`/dev/random`][8]
+//! | Solaris, illumos  | `*‑solaris`, `*‑illumos` | [`getrandom()`][9] if available, otherwise [`/dev/random`][10]
+//! | Fuchsia OS        | `*‑fuchsia`        | [`cprng_draw`][11]
+//! | Redox             | `*‑cloudabi`       | [`rand:`][12]
+//! | CloudABI          | `*‑redox`          | [`cloudabi_sys_random_get`][13]
+//! | Haiku             | `*‑haiku`          | `/dev/random` (identical to `/dev/urandom`)
+//! | SGX               | `x86_64‑*‑sgx`     | [RDRAND][18]
+//! | VxWorks           | `*‑wrs‑vxworks‑*`  | `randABytes` after checking entropy pool initialization with `randSecure`
+//! | Emscripten        | `*‑emscripten`     | `/dev/random` (identical to `/dev/urandom`)
+//! | WASI              | `wasm32‑wasi`      | [`__wasi_random_get`][17]
+//! | Web Browser       | `wasm32‑*‑unknown` | [`Crypto.getRandomValues()`][14], see [WebAssembly support][16]
+//! | Node.js           | `wasm32‑*‑unknown` | [`crypto.randomBytes`][15], see [WebAssembly support][16]
 //!
 //! There is no blanket implementation on `unix` targets that reads from
 //! `/dev/urandom`. This ensures all supported targets are using the recommended

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,19 +58,22 @@
 //!
 //! ### Support for WebAssembly
 //!
-//! This crate fully supports the `wasm32-wasi` and `wasm32-unknown-emscripten`
-//! targets. However, the `wasm32-unknown-unknown` target is not supported since,
-//! from the target name alone, we cannot deduce which JavaScript interface is
-//! in use (or if JavaScript is available at all).
+//! This crate fully supports the
+//! [`wasm32-wasi`](https://github.com/CraneStation/wasi) and
+//! [`wasm32-unknown-emscripten`](https://www.hellorust.com/setup/emscripten/)
+//! targets. However, the `wasm32-unknown-unknown` target is not automatically
+//! supported since, from the target name alone, we cannot deduce which
+//! JavaScript interface is in use (or if JavaScript is available at all).
 //!
 //! Instead, *if the `"js"` Cargo feature is enabled*, this crate will assume
 //! that you are building for an environment containing JavaScript, and will
-//! call the appropriate methods. Both Browser and Node.js environments are
-//! supported (see above), and both [wasm-bindgen] and [stdweb] toolchains are
-//! supported.
+//! call the appropriate methods. Both web browser (main window and Web Workers)
+//! and Node.js environments are supported, invoking the methods
+//! [described above](#supported-targets). This crate can be built with either
+//! the [wasm-bindgen](https://github.com/rust-lang/rust-bindgen) or
+//! [cargo-web](https://github.com/koute/cargo-web) toolchains.
 //!
-//! [wasm-bindgen]: https://github.com/rust-lang/rust-bindgen
-//! [stdweb]: https://github.com/koute/stdweb
+//! This feature has no effect on targets other than `wasm32-unknown-unknown`.
 //!
 //! ### Use a custom implementation
 //!
@@ -85,10 +88,11 @@
 //! ### Indirect Dependencies
 //!
 //! If `getrandom` is not a direct dependency of your crate, you can still
-//! enable any of above fallback behaviors by simply enabling the relevant
-//! feature in your root crate's `[dependencies]` section:
+//! enable any of the above fallback behaviors by enabling the relevant
+//! feature in your root crate's `Cargo.toml`:
 //! ```toml
-//! getrandom = { version = "0.2", features = ["rdrand"] }
+//! [dependencies]
+//! getrandom = { version = "0.2", features = ["js"] }
 //! ```
 //!
 //! ## Early boot


### PR DESCRIPTION
Final PR for 0.2 adding all the docs about the `"rdrand"`, `"js"`, and `"custom"` features.

To preview what will go up on [crates.io](https://crates.io), run:
```bash
git clone --single-branch --branch docs https://github.com/josephlr/getrandom.git
cd getrandom
cargo doc --no-deps --features=std,custom --open`
```
Signed-off-by: Joe Richey <joerichey@google.com>