### PR TITLE
Minor Cleanups for 0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ env:
 
 jobs:
   include:
-    - name: "Linux, 1.32.0"
-      rust: 1.32.0
+    - name: "Linux, 1.33.0"
+      rust: 1.33.0
 
-    - name: "OSX, 1.32.0"
-      rust: 1.32.0
+    - name: "OSX, 1.33.0"
+      rust: 1.33.0
       os: osx
 
     - name: "Linux, stable"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to switch to a custom implementation with a support of your target.
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.32.0 or later.
+This crate requires Rust 1.33.0 or later.
 
 # License
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    CHANNEL: 1.32.0
+    CHANNEL: 1.33.0
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc

--- a/build.rs
+++ b/build.rs
@@ -7,8 +7,6 @@ fn main() {
     if target.contains("-uwp-windows-") {
         // for BCryptGenRandom
         println!("cargo:rustc-link-lib=bcrypt");
-        // to work around unavailability of `target_vendor` on Rust 1.33
-        println!("cargo:rustc-cfg=getrandom_uwp");
     } else if target.contains("windows") {
         // for RtlGenRandom (aka SystemFunction036)
         println!("cargo:rustc-link-lib=advapi32");

--- a/custom/stdweb/src/lib.rs
+++ b/custom/stdweb/src/lib.rs
@@ -10,7 +10,6 @@
 #[cfg(not(all(target_arch = "wasm32", target_os = "unknown")))]
 compile_error!("This crate is only for the `wasm32-unknown-unknown` target");
 
-use core::mem;
 use std::sync::Once;
 
 use stdweb::js;
@@ -26,7 +25,6 @@ enum RngSource {
 register_custom_getrandom!(getrandom_inner);
 
 fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    assert_eq!(mem::size_of::<usize>(), 4);
     static ONCE: Once = Once::new();
     static mut RNG_SOURCE: Result<RngSource, Error> = Ok(RngSource::Node);
 

--- a/custom/wasm-bindgen/src/lib.rs
+++ b/custom/wasm-bindgen/src/lib.rs
@@ -10,7 +10,6 @@
 compile_error!("This crate is only for the `wasm32-unknown-unknown` target");
 
 use core::cell::RefCell;
-use core::mem;
 use std::thread_local;
 
 use wasm_bindgen::prelude::*;
@@ -32,8 +31,6 @@ thread_local!(
 register_custom_getrandom!(getrandom_inner);
 
 fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    assert_eq!(mem::size_of::<usize>(), 4);
-
     RNG_SOURCE.with(|f| {
         let mut source = f.borrow_mut();
         if source.is_none() {

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -7,8 +7,7 @@
 // except according to those terms.
 
 //! Implementation for FreeBSD and NetBSD
-use crate::util_libc::sys_fill_exact;
-use crate::Error;
+use crate::{util_libc::sys_fill_exact, Error};
 use core::ptr;
 
 fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,36 +19,35 @@ use core::num::NonZeroU32;
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Error(NonZeroU32);
 
-// TODO: Convert to a function when min_version >= 1.33
-macro_rules! internal_error {
-    ($n:expr) => {
-        Error(unsafe { NonZeroU32::new_unchecked(Error::INTERNAL_START + $n as u16 as u32) })
-    };
+const fn internal_error(n: u16) -> Error {
+    // SAFETY: code > 0 as INTERNAL_START > 0 and adding n won't overflow a u32.
+    let code = Error::INTERNAL_START + (n as u32);
+    Error(unsafe { NonZeroU32::new_unchecked(code) })
 }
 
 impl Error {
     /// This target/platform is not supported by `getrandom`.
-    pub const UNSUPPORTED: Error = internal_error!(0);
+    pub const UNSUPPORTED: Error = internal_error(0);
     /// The platform-specific `errno` returned a non-positive value.
-    pub const ERRNO_NOT_POSITIVE: Error = internal_error!(1);
+    pub const ERRNO_NOT_POSITIVE: Error = internal_error(1);
     /// Call to iOS [`SecRandomCopyBytes`](https://developer.apple.com/documentation/security/1399291-secrandomcopybytes) failed.
-    pub const IOS_SEC_RANDOM: Error = internal_error!(3);
+    pub const IOS_SEC_RANDOM: Error = internal_error(3);
     /// Call to Windows [`RtlGenRandom`](https://docs.microsoft.com/en-us/windows/win32/api/ntsecapi/nf-ntsecapi-rtlgenrandom) failed.
-    pub const WINDOWS_RTL_GEN_RANDOM: Error = internal_error!(4);
+    pub const WINDOWS_RTL_GEN_RANDOM: Error = internal_error(4);
     /// RDRAND instruction failed due to a hardware issue.
-    pub const FAILED_RDRAND: Error = internal_error!(5);
+    pub const FAILED_RDRAND: Error = internal_error(5);
     /// RDRAND instruction unsupported on this target.
-    pub const NO_RDRAND: Error = internal_error!(6);
+    pub const NO_RDRAND: Error = internal_error(6);
     /// Using `wasm-bindgen`, browser does not support `self.crypto`.
-    pub const BINDGEN_CRYPTO_UNDEF: Error = internal_error!(7);
+    pub const BINDGEN_CRYPTO_UNDEF: Error = internal_error(7);
     /// Using `wasm-bindgen`, browser does not support `crypto.getRandomValues`.
-    pub const BINDGEN_GRV_UNDEF: Error = internal_error!(8);
+    pub const BINDGEN_GRV_UNDEF: Error = internal_error(8);
     /// Using `stdweb`, no cryptographic RNG is available.
-    pub const STDWEB_NO_RNG: Error = internal_error!(9);
+    pub const STDWEB_NO_RNG: Error = internal_error(9);
     /// Using `stdweb`, invoking a cryptographic RNG failed.
-    pub const STDWEB_RNG_FAILED: Error = internal_error!(10);
+    pub const STDWEB_RNG_FAILED: Error = internal_error(10);
     /// On VxWorks, call to `randSecure` failed (random number generator is not yet initialized).
-    pub const VXWORKS_RAND_SECURE: Error = internal_error!(11);
+    pub const VXWORKS_RAND_SECURE: Error = internal_error(11);
 
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are
@@ -80,7 +79,7 @@ impl Error {
     /// This code can either come from the underlying OS, or be a custom error.
     /// Use [`Error::raw_os_error()`] to disambiguate.
     #[inline]
-    pub fn code(self) -> NonZeroU32 {
+    pub const fn code(self) -> NonZeroU32 {
         self.0
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,8 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-use core::fmt;
-use core::num::NonZeroU32;
+use core::{fmt, num::NonZeroU32};
 
 /// A small and `no_std` compatible error type.
 ///

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -8,21 +8,16 @@
 
 //! Implementation for iOS
 use crate::Error;
-
-// TODO: Make extern once extern_types feature is stabilized. See:
-//   https://github.com/rust-lang/rust/issues/43467
-#[repr(C)]
-struct SecRandom([u8; 0]);
+use core::{ffi::c_void, ptr::null};
 
 #[link(name = "Security", kind = "framework")]
 extern "C" {
-    static kSecRandomDefault: *const SecRandom;
-
-    fn SecRandomCopyBytes(rnd: *const SecRandom, count: usize, bytes: *mut u8) -> i32;
+    fn SecRandomCopyBytes(rnd: *const c_void, count: usize, bytes: *mut u8) -> i32;
 }
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe { SecRandomCopyBytes(kSecRandomDefault, dest.len(), dest.as_mut_ptr()) };
+    // Apple's documentation guarantees kSecRandomDefault is a synonym for NULL.
+    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr()) };
     if ret == -1 {
         Err(Error::IOS_SEC_RANDOM)
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ cfg_if! {
     } else if #[cfg(target_os = "vxworks")] {
         mod util_libc;
         #[path = "vxworks.rs"] mod imp;
-    } else if #[cfg(all(windows, getrandom_uwp))] {
+    } else if #[cfg(all(windows, target_vendor = "uwp"))] {
         #[path = "windows_uwp.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -7,9 +7,11 @@
 // except according to those terms.
 
 //! Implementation for Linux / Android
-use crate::util::LazyBool;
-use crate::util_libc::{last_os_error, sys_fill_exact};
-use crate::{use_file, Error};
+use crate::{
+    util::LazyBool,
+    util_libc::{last_os_error, sys_fill_exact},
+    {use_file, Error},
+};
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     static HAS_GETRANDOM: LazyBool = LazyBool::new();

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -7,8 +7,11 @@
 // except according to those terms.
 
 //! Implementation for macOS
-use crate::util_libc::{last_os_error, Weak};
-use crate::{use_file, Error};
+use crate::{
+    use_file,
+    util_libc::{last_os_error, Weak},
+    Error,
+};
 use core::mem;
 
 type GetEntropyFn = unsafe extern "C" fn(*mut u8, libc::size_t) -> libc::c_int;

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -7,8 +7,7 @@
 // except according to those terms.
 
 //! Implementation for OpenBSD
-use crate::util_libc::last_os_error;
-use crate::Error;
+use crate::{util_libc::last_os_error, Error};
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -17,8 +17,11 @@
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existence of getrandom(2) in libc by calling
 //! libc::dlsym.
-use crate::util_libc::{sys_fill_exact, Weak};
-use crate::{use_file, Error};
+use crate::{
+    use_file,
+    util_libc::{sys_fill_exact, Weak},
+    Error,
+};
 use core::mem;
 
 #[cfg(target_os = "illumos")]

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -7,11 +7,15 @@
 // except according to those terms.
 
 //! Implementations that just need to read from a file
-use crate::util::LazyUsize;
-use crate::util_libc::{open_readonly, sys_fill_exact};
-use crate::Error;
-use core::cell::UnsafeCell;
-use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use crate::{
+    util::LazyUsize,
+    util_libc::{open_readonly, sys_fill_exact},
+    Error,
+};
+use core::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+};
 
 #[cfg(target_os = "redox")]
 const FILE_PATH: &str = "rand:\0";

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -99,7 +99,7 @@ fn wait_until_rng_ready() -> Result<(), Error> {
         // A negative timeout means an infinite timeout.
         let res = unsafe { libc::poll(&mut pfd, 1, -1) };
         if res >= 0 {
-            assert_eq!(res, 1); // We only used one fd, and cannot timeout.
+            debug_assert_eq!(res, 1); // We only used one fd, and cannot timeout.
             return Ok(());
         }
         let err = crate::util_libc::last_os_error();

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -108,7 +108,7 @@ cfg_if! {
 
 // SAFETY: path must be null terminated, FD must be manually closed.
 pub unsafe fn open_readonly(path: &str) -> Result<libc::c_int, Error> {
-    debug_assert!(path.as_bytes().last() == Some(&0));
+    debug_assert_eq!(path.as_bytes().last(), Some(&0));
     let fd = open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
     if fd < 0 {
         return Err(last_os_error());

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -6,10 +6,8 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![allow(dead_code)]
-use crate::util::LazyUsize;
-use crate::Error;
-use core::num::NonZeroU32;
-use core::ptr::NonNull;
+use crate::{util::LazyUsize, Error};
+use core::{num::NonZeroU32, ptr::NonNull};
 
 cfg_if! {
     if #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android"))] {

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -7,8 +7,7 @@
 // except according to those terms.
 
 //! Implementation for VxWorks
-use crate::util_libc::last_os_error;
-use crate::Error;
+use crate::{util_libc::last_os_error, Error};
 use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
- Increase Rust Minimum version to 1.33. This lets us:
  - Remove  `cfg(getrandom_uwp)` and just use `target_vendor`
  - Turn a macro into a function
- Use a consistent include style
- Use asserts consistently
- Simplify iOS implementation, remove `SecRandom` type (as it's not part of the iOS API)

See the individual commits for more information