### PR TITLE
Fixing Webpack require warning when using wasm-bindgen

### DIFF
--- a/src/wasm32_bindgen.rs
+++ b/src/wasm32_bindgen.rs
@@ -78,7 +78,7 @@ fn getrandom_init() -> Result<RngSource, Error> {
         return Ok(RngSource::Browser(crypto));
     }
 
-    return Ok(RngSource::Node(node_require("crypto")));
+    return Ok(RngSource::Node(MODULE.require("crypto")));
 }
 
 #[wasm_bindgen]
@@ -102,12 +102,17 @@ extern "C" {
     #[wasm_bindgen(method, js_name = getRandomValues, structural)]
     fn get_random_values(me: &BrowserCrypto, buf: &mut [u8]);
 
-    #[wasm_bindgen(js_name = require)]
-    fn node_require(s: &str) -> NodeCrypto;
-
     #[derive(Clone, Debug)]
     type NodeCrypto;
 
     #[wasm_bindgen(method, js_name = randomFillSync, structural)]
     fn random_fill_sync(me: &NodeCrypto, buf: &mut [u8]);
+
+    type NodeModule;
+
+    #[wasm_bindgen(js_name = module)]
+    static MODULE: NodeModule;
+
+    #[wasm_bindgen(method)]
+    fn require(this: &NodeModule, s: &str) -> NodeCrypto;
 }


### PR DESCRIPTION
When using the getrandom library with wasm-bindgen + Webpack it uses `require("crypto")` in order to load the NodeJS crypto module. However, Webpack does not like that, so it gives a warning.

This PR fixes that warning by instead using `module.require("crypto")`.

You can see more details here:

https://github.com/rustwasm/wasm-pack/issues/822

https://github.com/webpack/webpack/issues/8826