### PR TITLE
travis: Fix wasm32 CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,13 @@ jobs:
     - name: "Linux, beta"
       rust: beta
 
-    - name: "WASM via emscripten, stdweb, wasm-bindgen and WASI"
-      rust: nightly
+    - name: "WASM via stdweb, wasm-bindgen and WASI"
+      rust: stable
       addons:
         firefox: latest
         chrome: stable
       install:
         - rustup target add wasm32-unknown-unknown
-        - rustup target add wasm32-unknown-emscripten
-        - rustup target add asmjs-unknown-emscripten
         - rustup target add wasm32-wasi
         # Get latest geckodriver
         - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
@@ -66,15 +64,7 @@ jobs:
         - tar -xzf wasm-bindgen.tar.gz --strip-components=1
         # Place the runner binaries in our PATH
         - mv cargo-web wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
-        # Download and setup emscripten
-        - cargo web prepare-emscripten
-      env: EMCC_CFLAGS="-s ERROR_ON_UNDEFINED_SYMBOLS=0"
       script:
-        # We cannot run emscripten test binaries (see rust-lang/rust#63649).
-        # However, we can still build and link all tests to make sure that works.
-        # This is actually useful as it finds stuff such as rust-random/rand#669
-        - cargo web test --target wasm32-unknown-emscripten --no-run
-        - cargo web test --target asmjs-unknown-emscripten --no-run
         - cargo test --target wasm32-wasi
         # stdweb (wasm32-unknown-unknown) tests (Node, Chrome)
         - cargo web test --package stdweb-getrandom
@@ -88,6 +78,25 @@ jobs:
         - CHROMEDRIVER=$HOME/chromedriver
           cargo test --package wasm-bindgen-getrandom
           --target wasm32-unknown-unknown --test web
+
+    - name: "WASM via Emscripten"
+      rust: stable
+      env:
+        - CARGO_TARGET_WASM32_UNKNOWN_EMSCRIPTEN_RUNNER=node
+        - CARGO_TARGET_ASMJS_UNKNOWN_EMSCRIPTEN_RUNNER=node
+      install:
+        - rustup target add wasm32-unknown-emscripten
+        - rustup target add asmjs-unknown-emscripten
+        - export VERSION=1.39.13 # Pin version for stability
+        - git clone https://github.com/emscripten-core/emsdk.git
+        - ./emsdk/emsdk install $VERSION
+        - ./emsdk/emsdk activate $VERSION
+        - source ./emsdk/emsdk_env.sh
+      script:
+        - cargo test --target wasm32-unknown-emscripten
+        # Prevent 'wasm2js does not support source maps yet' error.
+        - RUSTFLAGS='-C debuginfo=0' cargo test --target asmjs-unknown-emscripten
+
 
     - &nightly_and_docs
       name: "Linux, nightly, docs"


### PR DESCRIPTION
Split emscripten stuff into its own target and stop relying on `cargo web`
to download/manage then emscripten toolchain. We can just get it
ourselves.

We now use `stable` for all WASM32 tests and are now running the emscripten tests.

Fixes #140 

Signed-off-by: Joe Richey <joerichey@google.com>