### PR TITLE
travis: Allow nightly builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -184,6 +184,9 @@ jobs:
   allow_failures:
     # Formatting errors should appear in Travis, but not break the build.
     - name: "rustfmt"
+    # The nightly toolchain is unstable, don't let it break our build
+    - name: "Linux, nightly, docs"
+    - name: "OSX, nightly, docs"
 
 before_install:
   - set -e


### PR DESCRIPTION
https://github.com/rust-lang/rust/issues/70924 is causing all of the Linux nightly builds to fail (everything else is fine).  Similar to what we did for `rustfmt`, we can still run these tests, but avoid having them break the CI.