### PR TITLE
cpu: Have "rdrand" feature take precedence over "custom"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -145,11 +145,11 @@ jobs:
       script:
         # We test that getrandom builds for all targets
         - echo $STD_TARGETS | xargs -t -n1 cargo build --target
-        - echo $NO_STD_TARGETS | xargs -t -n1 cargo xbuild --features=cpu --target
+        - echo $NO_STD_TARGETS | xargs -t -n1 cargo xbuild --features=rdrand --target
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
         - echo $STD_TARGETS | xargs -t -n1 cargo build --target
-        - echo $NO_STD_TARGETS | xargs -t -n1 cargo xbuild --features=cpu --target
+        - echo $NO_STD_TARGETS | xargs -t -n1 cargo xbuild --features=rdrand --target
 
     # Trust cross-built/emulated targets. We must repeat all non-default values.
     - name: "Linux (MIPS, big-endian)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ wasi = "0.9"
 
 [features]
 std = []
-# Feature to enable fallback CPU-based implementation
-cpu = []
+# Feature to enable fallback RDRAND-based implementation
+rdrand = []
 # Feature to enable custom RNG implementations
 custom = []
 # Unstable feature to support being a libstd dependency

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ cfg_if! {
         #[path = "windows.rs"] mod imp;
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
         #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(all(feature = "cpu",
+    } else if #[cfg(all(feature = "rdrand",
                         any(target_arch = "x86_64", target_arch = "x86")))] {
         #[path = "rdrand.rs"] mod imp;
     } else if #[cfg(feature = "custom")] {
@@ -219,4 +219,4 @@ pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
 #[cfg(test)]
 mod test_common;
 #[cfg(test)]
-mod test_cpu;
+mod test_rdrand;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,11 +183,11 @@ cfg_if! {
         #[path = "windows.rs"] mod imp;
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
         #[path = "rdrand.rs"] mod imp;
-    } else if #[cfg(feature = "custom")] {
-        use custom as imp;
     } else if #[cfg(all(feature = "cpu",
                         any(target_arch = "x86_64", target_arch = "x86")))] {
         #[path = "rdrand.rs"] mod imp;
+    } else if #[cfg(feature = "custom")] {
+        use custom as imp;
     } else {
         compile_error!("\
             target is not supported, for more information see: \

--- a/src/test_rdrand.rs
+++ b/src/test_rdrand.rs
@@ -1,4 +1,4 @@
-// We only test the CPU-based RNG source on supported architectures.
+// We only test the RDRAND-based RNG source on supported architectures.
 #![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 
 #[path = "rdrand.rs"]


### PR DESCRIPTION
Right now, features are always enabled across all targets. This means
that if _any_ Custom RNG is used _anywhere_ in a crate's dependancy
graph on _any_ target. The "custom" feature will be active on all
targets.

This old code made it impossible to have a bare metal target that uses "rdrand" on
x86_64 and a Custom RNG on aarch64. This change fixes this issue, and makes
sure that any implementation `getrandom` itself provides cannot be overridden.

I proposed the old precedence order in https://github.com/rust-random/getrandom/issues/84#issuecomment-587180349, but I think part of that was a mistake, given how Cargo treats features.

This also renames the "cpu" feature to "rdrand". While other CPU architectures have RNG intrinsic, they can behave differently than x86's, so it doesn't make sense to group them.

Signed-off-by: Joe Richey <joerichey@google.com>