### PR TITLE
stdweb: Remove CI runs with cargo-web

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,7 +110,6 @@ jobs:
         # remove cached documentation, otherwise files from previous PRs can get included
         - rm -rf target/doc
         - cargo doc --no-deps --features=std,custom
-        - cargo doc --no-deps --package wasm-bindgen-getrandom --target=wasm32-unknown-unknown
         - cargo deadlinks --dir target/doc
         # Check that our tests pass in the default/minimal configuration
         - cargo test --tests --benches

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,10 @@ jobs:
         - mv cargo-web wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
       script:
         - cargo test --target wasm32-wasi
-        # stdweb (wasm32-unknown-unknown) tests (Node, Chrome)
-        - cargo web test --features js --nodejs
-        - cargo web test --features js
+        # stdweb (wasm32-unknown-unknown) tests are currently broken (see https://github.com/koute/cargo-web/issues/243)
+        # - cargo web test --features js --nodejs
+        # - cargo web test --features js
+        - cargo build --features js
         # wasm-bindgen (wasm32-unknown-unknown) tests (Node, Firefox, Chrome)
         - cargo test --target wasm32-unknown-unknown --features js
         - GECKODRIVER=$HOME/geckodriver


### PR DESCRIPTION
Right now "cargo web test" is broken due to upstream changes. We will
disable stdweb tests until the stdweb project fixes things.

See: https://github.com/koute/cargo-web/issues/243

Fixes CI issues noticed in #153

Signed-off-by: Joe Richey <joerichey@google.com>