### PR TITLE
bsd_arandom: Read only 256 bytes at a time

### DIFF
--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -43,5 +43,10 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
             return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
         }
     }
-    sys_fill_exact(dest, kern_arnd)
+    // Both FreeBSD and NetBSD will only return up to 256 bytes at a time, and
+    // older NetBSD kernels will fail on longer buffers.
+    for chunk in dest.chunks_mut(256) {
+        sys_fill_exact(chunk, kern_arnd)?
+    }
+    Ok(())
 }


### PR DESCRIPTION
Fixes #151 CC: @newpavlov @niacat 

Older NetBSD kernels cannot handle buffers bigger than 256 bytes, and
all FreeBSD and NetBSD kernels only return up to 256 bytes per call.

Signed-off-by: Joe Richey <joerichey@google.com>