### PR TITLE
travis: Update pinned dependancies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ matrix:
         - RUSTFLAGS='-C debuginfo=0' cargo test --target asmjs-unknown-emscripten
 
     - name: "Linux, nightly, docs"
-      rust: nightly-2020-09-08
+      rust: nightly
       os: linux
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
@@ -109,7 +109,7 @@ matrix:
         - cargo test
 
     - name: "OSX, nightly, docs"
-      rust: nightly-2020-09-08
+      rust: nightly
       os: osx
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
@@ -127,7 +127,7 @@ matrix:
         - cargo test
 
     - name: "cross-platform build only"
-      rust: nightly-2020-09-08
+      rust: nightly
       install:
         - rustup target add x86_64-sun-solaris
         - rustup target add x86_64-unknown-freebsd

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,15 +31,15 @@ matrix:
     - name: "WASM via stdweb, wasm-bindgen and WASI"
       rust: stable
       addons:
-        firefox: latest
+        # firefox: latest
         chrome: stable
       install:
         - rustup target add wasm32-unknown-unknown
         - rustup target add wasm32-wasi
         # Get latest geckodriver
-        - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
-        - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/$VERSION/geckodriver-$VERSION-linux64.tar.gz
-        - tar -xzf geckodriver.tar.gz
+        # - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
+        # - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/$VERSION/geckodriver-$VERSION-linux64.tar.gz
+        # - tar -xzf geckodriver.tar.gz
         # Get latest chromedirver
         - export VERSION=$(wget -q -O - https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
         - wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip
@@ -68,7 +68,8 @@ matrix:
         # - cargo web test --target=wasm32-unknown-unknown --features=stdweb
         # wasm-bindgen tests (Node, Firefox, Chrome)
         - cargo test --target wasm32-unknown-unknown --features=wasm-bindgen
-        - GECKODRIVER=$PWD/geckodriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
+        # Firefox is broken, see https://github.com/rustwasm/wasm-bindgen/issues/2261
+        # - GECKODRIVER=$PWD/geckodriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
         - CHROMEDRIVER=$PWD/chromedriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
 
     - name: "WASM via Emscripten"
@@ -129,7 +130,6 @@ matrix:
       rust: nightly-2020-09-08
       install:
         - rustup target add x86_64-sun-solaris
-        - rustup target add x86_64-unknown-cloudabi
         - rustup target add x86_64-unknown-freebsd
         - rustup target add x86_64-fuchsia
         - rustup target add x86_64-unknown-netbsd
@@ -140,12 +140,12 @@ matrix:
         - cargo install cargo-xbuild || true
       script:
         - cargo build --target=x86_64-sun-solaris
-        - cargo build --target=x86_64-unknown-cloudabi
         - cargo build --target=x86_64-unknown-freebsd
         - cargo build --target=x86_64-fuchsia
         - cargo build --target=x86_64-unknown-netbsd
         - cargo build --target=x86_64-unknown-redox
         - cargo build --target=x86_64-fortanix-unknown-sgx
+        - cargo xbuild --target=x86_64-unknown-cloudabi
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc
@@ -153,12 +153,12 @@ matrix:
         # also test minimum dependency versions are usable
         - cargo generate-lockfile -Z minimal-versions
         - cargo build --target=x86_64-sun-solaris
-        - cargo build --target=x86_64-unknown-cloudabi
         - cargo build --target=x86_64-unknown-freebsd
         - cargo build --target=x86_64-fuchsia
         - cargo build --target=x86_64-unknown-netbsd
         - cargo build --target=x86_64-unknown-redox
         - cargo build --target=x86_64-fortanix-unknown-sgx
+        - cargo xbuild --target=x86_64-unknown-cloudabi
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 sudo: false
+dist: focal
 
 matrix:
   include:
@@ -44,12 +45,12 @@ matrix:
         - wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip
         - unzip chromedriver.zip
         # Get cargo-web
-        - export VERSION=0.6.26 # Pin version for stability
-        - wget -O cargo-web.gz https://github.com/koute/cargo-web/releases/download/$VERSION/cargo-web-x86_64-unknown-linux-gnu.gz
-        - gunzip cargo-web.gz
-        - chmod +x cargo-web
+        # - export VERSION=0.6.26 # Pin version for stability
+        # - wget -O cargo-web.gz https://github.com/koute/cargo-web/releases/download/$VERSION/cargo-web-x86_64-unknown-linux-gnu.gz
+        # - gunzip cargo-web.gz
+        # - chmod +x cargo-web
         # Get wasmtime
-        - export VERSION=v0.8.0 # Pin version for stability
+        - export VERSION=v0.19.0 # Pin version for stability
         - wget -O wasmtime.tar.xz https://github.com/CraneStation/wasmtime/releases/download/$VERSION/wasmtime-$VERSION-x86_64-linux.tar.xz
         - tar -xf wasmtime.tar.xz --strip-components=1
         # Get wasm-bindgen-test-runner which matches our wasm-bindgen version
@@ -57,13 +58,14 @@ matrix:
         - wget -O wasm-bindgen.tar.gz https://github.com/rustwasm/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz
         - tar -xzf wasm-bindgen.tar.gz --strip-components=1
         # Place the runner binaries in our PATH
-        - mv cargo-web wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
+        - mv wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
       script:
         # wasi tests
         - cargo test --target wasm32-wasi
         # stdweb tests (Node, Chrome)
-        - cargo web test --nodejs --target=wasm32-unknown-unknown --features=stdweb
-        - cargo web test --target=wasm32-unknown-unknown --features=stdweb
+        # stdweb (wasm32-unknown-unknown) tests are currently broken (see https://github.com/koute/cargo-web/issues/243)
+        # - cargo web test --nodejs --target=wasm32-unknown-unknown --features=stdweb
+        # - cargo web test --target=wasm32-unknown-unknown --features=stdweb
         # wasm-bindgen tests (Node, Firefox, Chrome)
         - cargo test --target wasm32-unknown-unknown --features=wasm-bindgen
         - GECKODRIVER=$PWD/geckodriver cargo test --target wasm32-unknown-unknown --features=test-in-browser
@@ -77,7 +79,7 @@ matrix:
       install:
         - rustup target add wasm32-unknown-emscripten
         - rustup target add asmjs-unknown-emscripten
-        - export VERSION=1.39.13 # Pin version for stability
+        - export VERSION=2.0.2 # Pin version for stability
         - git clone https://github.com/emscripten-core/emsdk.git
         - ./emsdk/emsdk install $VERSION
         - ./emsdk/emsdk activate $VERSION
@@ -88,7 +90,7 @@ matrix:
         - RUSTFLAGS='-C debuginfo=0' cargo test --target asmjs-unknown-emscripten
 
     - name: "Linux, nightly, docs"
-      rust: nightly
+      rust: nightly-2020-09-08
       os: linux
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
@@ -106,7 +108,7 @@ matrix:
         - cargo test
 
     - name: "OSX, nightly, docs"
-      rust: nightly
+      rust: nightly-2020-09-08
       os: osx
       install:
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
@@ -124,7 +126,7 @@ matrix:
         - cargo test
 
     - name: "cross-platform build only"
-      rust: nightly
+      rust: nightly-2020-09-08
       install:
         - rustup target add x86_64-sun-solaris
         - rustup target add x86_64-unknown-cloudabi
@@ -197,9 +199,6 @@ matrix:
   allow_failures:
     # Formatting errors should appear in Travis, but not break the build.
     - name: "rustfmt"
-    # The nightly toolchain is unstable, don't let it break our build
-    - name: "Linux, nightly, docs"
-    - name: "OSX, nightly, docs"
 
 before_install:
   - set -e


### PR DESCRIPTION
Also, pin the version of rustc, so that nightly updates don't break
our build. This means that we can add the nightlies back into the
blocking set of tests.

Move cloudabi to `cargo xbuild` as it is now a Teir 3 target

Disable Firefox testing due to https://github.com/rustwasm/wasm-bindgen/issues/2261

Signed-off-by: Joe Richey <joerichey@google.com>