### PR TITLE
travis: Apply #157 to 0.2 branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: rust
 os: linux
+dist: focal
 
 env:
   global:
     # All of the supported x86 Linux targets
     - LINUX_TARGETS="x86_64-unknown-linux-gnu x86_64-unknown-linux-musl i686-unknown-linux-gnu i686-unknown-linux-musl"
     # Targets that we just build (rather than run and test)
-    - STD_TARGETS="x86_64-sun-solaris x86_64-unknown-cloudabi x86_64-unknown-freebsd x86_64-fuchsia x86_64-unknown-netbsd x86_64-unknown-redox x86_64-fortanix-unknown-sgx"
-    - NO_STD_TARGETS="x86_64-unknown-uefi x86_64-unknown-hermit x86_64-unknown-l4re-uclibc x86_64-uwp-windows-gnu x86_64-wrs-vxworks"
+    - STD_TARGETS="x86_64-sun-solaris x86_64-unknown-freebsd x86_64-fuchsia x86_64-unknown-netbsd x86_64-unknown-redox x86_64-fortanix-unknown-sgx"
+    - NO_STD_TARGETS="x86_64-unknown-cloudabi x86_64-unknown-uefi x86_64-unknown-hermit x86_64-unknown-l4re-uclibc x86_64-uwp-windows-gnu x86_64-wrs-vxworks"
 
 jobs:
   include:
@@ -36,26 +37,26 @@ jobs:
     - name: "WASM via stdweb, wasm-bindgen and WASI"
       rust: stable
       addons:
-        firefox: latest
+        # firefox: latest
         chrome: stable
       install:
         - rustup target add wasm32-unknown-unknown
         - rustup target add wasm32-wasi
         # Get latest geckodriver
-        - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
-        - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/$VERSION/geckodriver-$VERSION-linux64.tar.gz
-        - tar -xzf geckodriver.tar.gz -C $HOME
+        # - export VERSION=$(curl -s https://api.github.com/repos/mozilla/geckodriver/releases/latest | jq -r ".tag_name")
+        # - wget -O geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/$VERSION/geckodriver-$VERSION-linux64.tar.gz
+        # - tar -xzf geckodriver.tar.gz -C $HOME
         # Get latest chromedirver
         - export VERSION=$(wget -q -O - https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
         - wget -O chromedriver.zip https://chromedriver.storage.googleapis.com/$VERSION/chromedriver_linux64.zip
         - unzip chromedriver.zip -d $HOME
         # Get cargo-web
-        - export VERSION=0.6.26 # Pin version for stability
-        - wget -O cargo-web.gz https://github.com/koute/cargo-web/releases/download/$VERSION/cargo-web-x86_64-unknown-linux-gnu.gz
-        - gunzip cargo-web.gz
-        - chmod +x cargo-web
+        # - export VERSION=0.6.26 # Pin version for stability
+        # - wget -O cargo-web.gz https://github.com/koute/cargo-web/releases/download/$VERSION/cargo-web-x86_64-unknown-linux-gnu.gz
+        # - gunzip cargo-web.gz
+        # - chmod +x cargo-web
         # Get wasmtime
-        - export VERSION=v0.8.0 # Pin version for stability
+        - export VERSION=v0.19.0 # Pin version for stability
         - wget -O wasmtime.tar.xz https://github.com/CraneStation/wasmtime/releases/download/$VERSION/wasmtime-$VERSION-x86_64-linux.tar.xz
         - tar -xf wasmtime.tar.xz --strip-components=1
         # Get wasm-bindgen-test-runner which matches our wasm-bindgen version
@@ -63,7 +64,7 @@ jobs:
         - wget -O wasm-bindgen.tar.gz https://github.com/rustwasm/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz
         - tar -xzf wasm-bindgen.tar.gz --strip-components=1
         # Place the runner binaries in our PATH
-        - mv cargo-web wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
+        - mv wasmtime wasm-bindgen-test-runner $HOME/.cargo/bin
       script:
         - cargo test --target wasm32-wasi
         # stdweb (wasm32-unknown-unknown) tests are currently broken (see https://github.com/koute/cargo-web/issues/243)
@@ -72,8 +73,9 @@ jobs:
         - cargo build --features js
         # wasm-bindgen (wasm32-unknown-unknown) tests (Node, Firefox, Chrome)
         - cargo test --target wasm32-unknown-unknown --features js
-        - GECKODRIVER=$HOME/geckodriver
-          cargo test --target wasm32-unknown-unknown --features js,test-in-browser
+        # Firefox's geckodriver is currently broken in travis
+        # - GECKODRIVER=$HOME/geckodriver
+        #   cargo test --target wasm32-unknown-unknown --features js,test-in-browser
         - CHROMEDRIVER=$HOME/chromedriver
           cargo test --target wasm32-unknown-unknown --features js,test-in-browser
 
@@ -85,7 +87,7 @@ jobs:
       install:
         - rustup target add wasm32-unknown-emscripten
         - rustup target add asmjs-unknown-emscripten
-        - export VERSION=1.39.13 # Pin version for stability
+        - export VERSION=2.0.2 # Pin version for stability
         - git clone https://github.com/emscripten-core/emsdk.git
         - ./emsdk/emsdk install $VERSION
         - ./emsdk/emsdk activate $VERSION
@@ -98,7 +100,7 @@ jobs:
 
     - &nightly_and_docs
       name: "Linux, nightly, docs"
-      rust: nightly
+      rust: nightly-2020-09-08
       install:
         - rustup target add wasm32-unknown-unknown
         - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
@@ -121,7 +123,7 @@ jobs:
       os: osx
 
     - name: "cross-platform tests"
-      rust: nightly
+      rust: nightly-2020-09-08
       addons:
         apt:
           packages:
@@ -133,7 +135,7 @@ jobs:
         - echo $LINUX_TARGETS | xargs -t -n1 cargo test --target
 
     - name: "cross-platform build only"
-      rust: nightly
+      rust: nightly-2020-09-08
       install:
         - echo $STD_TARGETS | xargs -n1 rustup target add
         # For no_std targets
@@ -181,9 +183,6 @@ jobs:
   allow_failures:
     # Formatting errors should appear in Travis, but not break the build.
     - name: "rustfmt"
-    # The nightly toolchain is unstable, don't let it break our build
-    - name: "Linux, nightly, docs"
-    - name: "OSX, nightly, docs"
 
 before_install:
   - set -e


### PR DESCRIPTION
Note that Firefox testing had to be disabled due to https://github.com/rustwasm/wasm-bindgen/issues/2261, we need them to cut another release before we can start testing on Firefox again.