### PR TITLE
Update MSRV to 1.34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,11 @@ env:
 
 jobs:
   include:
-    - name: "Linux, 1.33.0"
-      rust: 1.33.0
+    - name: "Linux, 1.34.0"
+      rust: 1.34.0
 
-    - name: "OSX, 1.33.0"
-      rust: 1.33.0
+    - name: "OSX, 1.34.0"
+      rust: 1.34.0
       os: osx
 
     - name: "Linux, stable"

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ to switch to a custom implementation with a support of your target.
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.33.0 or later.
+This crate requires Rust 1.34.0 or later.
 
 # License
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ environment:
 
   matrix:
   - TARGET: x86_64-pc-windows-msvc
-    CHANNEL: 1.33.0
+    CHANNEL: 1.34.0
   - TARGET: x86_64-pc-windows-msvc
     CHANNEL: stable
   - TARGET: x86_64-pc-windows-msvc


### PR DESCRIPTION
Per the discussion in #98, we can update the MSRV as far as 1.36 if we want (as that's `rand 0.8`'s MSRV). However, Debian Buster (aka Debian 10, aka Debian Stable) is only at 1.34. As we don't need any features released between 1.34 and 1.36, only bumping the MSRV to 1.34 seems fine.