### PR TITLE
Fix multithreaded wasm crash (solves #164)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ jobs:
       rust: nightly
       install:
         - rustup target add wasm32-unknown-unknown
-        - cargo --list | egrep "^\s*deadlinks$" -q || cargo install cargo-deadlinks
+        - cargo install cargo-deadlinks
         - cargo deadlinks -V
       script:
         # Check that setting various features does not break the build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ wasi = "0.10"
 stdweb = { version = "0.4.18", default-features = false, optional = true }
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown", not(cargo_web)))'.dependencies]
 wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }
+js-sys = { version = "0.3", optional = true }
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown", not(cargo_web)))'.dev-dependencies]
 wasm-bindgen-test = "0.3.18"
 
@@ -40,7 +41,7 @@ std = []
 # Feature to enable fallback RDRAND-based implementation on x86/x86_64
 rdrand = []
 # Feature to enable JavaScript bindings on wasm32-unknown-unknown
-js = ["stdweb", "wasm-bindgen"]
+js = ["stdweb", "wasm-bindgen", "js-sys"]
 # Feature to enable custom RNG implementations
 custom = []
 # Unstable feature to support being a libstd dependency

--- a/src/wasm-bindgen.rs
+++ b/src/wasm-bindgen.rs
@@ -38,17 +38,16 @@ pub(crate) fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
                 }
             }
             RngSource::Browser(crypto, buf) => {
-                // getRandomValues does not work with all types of WASM memory, so
-                // we initially write to browser memory (buf) to avoid an exception.
+                // getRandomValues does not work with all types of WASM memory,
+                // so we initially write to browser memory to avoid exceptions.
                 for chunk in dest.chunks_mut(BROWSER_CRYPTO_BUFFER_SIZE) {
-                    // chunk can be smaller than buf length
-                    // this creates a smaller view to the buf memory without allocation
+                    // The chunk can be smaller than buf's length, so we call to
+                    // JS to create a smaller view of buf without allocation.
                     let sub_buf = buf.subarray(0, chunk.len() as u32);
 
                     if crypto.get_random_values(&sub_buf).is_err() {
                         return Err(Error::WEB_GET_RANDOM_VALUES);
                     }
-
                     sub_buf.copy_to(chunk);
                 }
             }
@@ -71,7 +70,6 @@ fn getrandom_init() -> Result<RngSource, Error> {
         };
 
         let buf = Uint8Array::new_with_length(BROWSER_CRYPTO_BUFFER_SIZE as u32);
-
         return Ok(RngSource::Browser(crypto, buf));
     }
 


### PR DESCRIPTION
This solves #164 by using a preallocated `Uint8Array` for calling `crypto.getRandomValues`.

The `stdweb` implementation seems fine, as it already uses `Uint8Array`.

Should this fix be backported to `0.15`? There are a lot of crates that still use that version.