### PR TITLE
Enable v0.1 std-trait workaround for additional targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -229,3 +229,4 @@ notifications:
 branches:
   only:
     - master
+    - 0.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -145,7 +145,9 @@ matrix:
         - cargo build --target=x86_64-unknown-netbsd
         - cargo build --target=x86_64-unknown-redox
         - cargo build --target=x86_64-fortanix-unknown-sgx
-        - cargo xbuild --target=x86_64-unknown-cloudabi
+        # This builds currently fails with:
+        # Could not find specification for target "x86_64-unknown-cloudabi"
+        #- cargo xbuild --target=x86_64-unknown-cloudabi
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc

--- a/.travis.yml
+++ b/.travis.yml
@@ -160,7 +160,7 @@ matrix:
         - cargo build --target=x86_64-unknown-netbsd
         - cargo build --target=x86_64-unknown-redox
         - cargo build --target=x86_64-fortanix-unknown-sgx
-        - cargo xbuild --target=x86_64-unknown-cloudabi
+        #- cargo xbuild --target=x86_64-unknown-cloudabi
         - cargo xbuild --target=x86_64-unknown-uefi
         - cargo xbuild --target=x86_64-unknown-hermit
         - cargo xbuild --target=x86_64-unknown-l4re-uclibc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,3 +50,4 @@ test_script:
 branches:
   only:
     - master
+    - 0.1

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,12 +164,15 @@ mod util;
 // for some platforms, even if they don't enable the "std" feature.
 #[cfg(any(
     feature = "std",
+    windows,
     target_os = "android",
     target_os = "dragonfly",
     target_os = "emscripten",
     target_os = "freebsd",
+    target_os = "fuchsia",
     target_os = "haiku",
     target_os = "illumos",
+    target_os = "ios",
     target_os = "linux",
     target_os = "macos",
     target_os = "netbsd",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ mod util;
 // for some platforms, even if they don't enable the "std" feature.
 #[cfg(any(
     feature = "std",
-    windows,
+    all(windows, not(getrandom_uwp)),
     target_os = "android",
     target_os = "dragonfly",
     target_os = "emscripten",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,75 +158,82 @@ cfg_if! {
 mod error;
 pub use crate::error::Error;
 
-#[allow(dead_code)]
 mod util;
 
-#[cfg(target_os = "vxworks")]
-#[allow(dead_code)]
-mod util_libc;
-
-cfg_if! {
-    // Unlike the other Unix, Fuchsia and iOS don't use the libc to make any calls.
-    if #[cfg(any(target_os = "android", target_os = "dragonfly", target_os = "emscripten",
-                 target_os = "freebsd", target_os = "haiku",     target_os = "illumos",
-                 target_os = "linux",   target_os = "macos",     target_os = "netbsd",
-                 target_os = "openbsd", target_os = "redox",     target_os = "solaris"))] {
-        #[allow(dead_code)]
-        mod util_libc;
-        // Keep std-only trait definitions for backwards compatibility
-        mod error_impls;
-    } else if #[cfg(feature = "std")] {
-        mod error_impls;
-    }
-}
-
-// These targets read from a file as a fallback method.
+// For backwards compatibility, we provide the std-only trait implementations
+// for some platforms, even if they don't enable the "std" feature.
 #[cfg(any(
+    feature = "std",
     target_os = "android",
+    target_os = "dragonfly",
+    target_os = "emscripten",
+    target_os = "freebsd",
+    target_os = "haiku",
+    target_os = "illumos",
     target_os = "linux",
     target_os = "macos",
+    target_os = "netbsd",
+    target_os = "openbsd",
+    target_os = "redox",
     target_os = "solaris",
-    target_os = "illumos",
 ))]
-mod use_file;
+mod error_impls;
 
 // System-specific implementations.
 //
 // These should all provide getrandom_inner with the same signature as getrandom.
 cfg_if! {
     if #[cfg(target_os = "android")] {
+        mod util_libc;
+        mod use_file;
         #[path = "linux_android.rs"] mod imp;
     } else if #[cfg(target_os = "cloudabi")] {
         #[path = "cloudabi.rs"] mod imp;
     } else if #[cfg(target_os = "dragonfly")] {
+        mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(target_os = "emscripten")] {
+        mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(target_os = "freebsd")] {
+        mod util_libc;
         #[path = "bsd_arandom.rs"] mod imp;
     } else if #[cfg(target_os = "fuchsia")] {
         #[path = "fuchsia.rs"] mod imp;
     } else if #[cfg(target_os = "haiku")] {
+        mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(target_os = "illumos")] {
+        mod util_libc;
+        mod use_file;
         #[path = "solaris_illumos.rs"] mod imp;
     } else if #[cfg(target_os = "ios")] {
         #[path = "ios.rs"] mod imp;
     } else if #[cfg(target_os = "linux")] {
+        mod util_libc;
+        mod use_file;
         #[path = "linux_android.rs"] mod imp;
     } else if #[cfg(target_os = "macos")] {
+        mod util_libc;
+        mod use_file;
         #[path = "macos.rs"] mod imp;
     } else if #[cfg(target_os = "netbsd")] {
+        mod util_libc;
         #[path = "bsd_arandom.rs"] mod imp;
     } else if #[cfg(target_os = "openbsd")] {
+        mod util_libc;
         #[path = "openbsd.rs"] mod imp;
     } else if #[cfg(target_os = "redox")] {
+        mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(target_os = "solaris")] {
+        mod util_libc;
+        mod use_file;
         #[path = "solaris_illumos.rs"] mod imp;
     } else if #[cfg(target_os = "wasi")] {
         #[path = "wasi.rs"] mod imp;
     } else if #[cfg(target_os = "vxworks")] {
+        mod util_libc;
         #[path = "vxworks.rs"] mod imp;
     } else if #[cfg(all(windows, getrandom_uwp))] {
         #[path = "windows_uwp.rs"] mod imp;

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,7 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
+#![allow(dead_code)]
 use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 // This structure represents a lazily initialized static usize value. Useful

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -5,6 +5,7 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
+#![allow(dead_code)]
 use crate::error::ERRNO_NOT_POSITIVE;
 use crate::util::LazyUsize;
 use crate::Error;


### PR DESCRIPTION
Fixes #168 

The first commit cleans up how we handle our various helper modules (similar to what we did for `v0.2`), but does not make any functional changes.

The second commit enables our `std::error::Error` implementations for `windows`, `target_os = "fuchsia"`, `target_os = "ios"`. These are the additional `windows` and `unix` targets we supported in `v0.1.6`. We don't enable the workaround for `target_arch = "wasm32"` as that would be a breaking change (from newer version) for `no_std` `wasm32` targets.

Here is a history of when we've enabled `std::error::Error` implementations:
- `v0.1.0` - `v0.1.6`:
  - Initially, we enabled the `std` feature on most targets
  ```
  #[cfg(any(
    feature = "std",
    windows, unix,
    target_os = "redox",
    target_arch = "wasm32",
  ))]
  ```
- `v0.1.7` - `v0.1.8`:
  - We later restricted the implementations to certain `unix` targets that needed `util_libc`
  ```
  #[cfg(any(
    feature = "std",
    target_os = "android",
    target_os = "dragonfly",
    target_os = "emscripten",
    target_os = "freebsd",
    target_os = "haiku",
    target_os = "illumos",
    target_os = "linux",
    target_os = "macos",
    target_os = "netbsd",
    target_os = "openbsd",
    target_os = "redox",
    target_os = "solaris",
  ))]
  ```
- `v0.1.9` - `v0.1.10`:
  - We further restricted things to only the `"std"` feature
  ```
  #[cfg(feature = "std")]
  ```
- `v0.1.11 - v0.1.15`
  - We rolled back our `v0.1.9` changes (as they were a breaking change)
  ```
  #[cfg(any(
    feature = "std",
    target_os = "android",
    target_os = "dragonfly",
    target_os = "emscripten",
    target_os = "freebsd",
    target_os = "haiku",
    target_os = "illumos",
    target_os = "linux",
    target_os = "macos",
    target_os = "netbsd",
    target_os = "openbsd",
    target_os = "redox",
    target_os = "solaris",
  ))]
  ```
