### PR TITLE
Move common tests to tests/ directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,8 +233,3 @@ pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
     }
     imp::getrandom_inner(dest)
 }
-
-#[cfg(test)]
-mod test_common;
-#[cfg(test)]
-mod test_rdrand;

--- a/src/test_rdrand.rs
+++ b/src/test_rdrand.rs
@@ -1,8 +1,0 @@
-// We only test the RDRAND-based RNG source on supported architectures.
-#![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
-
-#[path = "rdrand.rs"]
-mod rdrand;
-use rdrand::getrandom_inner as getrandom;
-#[path = "test_common.rs"]
-mod test_common;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,4 @@
-// Allow getrandom to be renamed by the parent module.
-use super::getrandom;
+use super::getrandom_impl;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown", not(cargo_web)))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -10,16 +9,16 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 fn test_zero() {
     // Test that APIs are happy with zero-length requests
-    getrandom(&mut [0u8; 0]).unwrap();
+    getrandom_impl(&mut [0u8; 0]).unwrap();
 }
 
 #[test]
 fn test_diff() {
     let mut v1 = [0u8; 1000];
-    getrandom(&mut v1).unwrap();
+    getrandom_impl(&mut v1).unwrap();
 
     let mut v2 = [0u8; 1000];
-    getrandom(&mut v2).unwrap();
+    getrandom_impl(&mut v2).unwrap();
 
     let mut n_diff_bits = 0;
     for i in 0..v1.len() {
@@ -33,7 +32,7 @@ fn test_diff() {
 #[test]
 fn test_huge() {
     let mut huge = [0u8; 100_000];
-    getrandom(&mut huge).unwrap();
+    getrandom_impl(&mut huge).unwrap();
 }
 
 // On WASM, the thread API always fails/panics
@@ -54,7 +53,7 @@ fn test_multithreading() {
             let mut v = [0u8; 1000];
 
             for _ in 0..100 {
-                getrandom(&mut v).unwrap();
+                getrandom_impl(&mut v).unwrap();
                 thread::yield_now();
             }
         });

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -1,0 +1,3 @@
+// Use the normal getrandom implementation on this architecture.
+use getrandom::getrandom as getrandom_impl;
+mod common;

--- a/tests/rdrand.rs
+++ b/tests/rdrand.rs
@@ -1,0 +1,15 @@
+// We only test the RDRAND-based RNG source on supported architectures.
+#![cfg(any(target_arch = "x86_64", target_arch = "x86"))]
+
+// rdrand.rs expects to be part of the getrandom main crate, so we need these
+// additional imports to get rdrand.rs to compile.
+use getrandom::Error;
+#[macro_use]
+extern crate cfg_if;
+#[path = "../src/rdrand.rs"]
+mod rdrand;
+#[path = "../src/util.rs"]
+mod util;
+
+use rdrand::getrandom_inner as getrandom_impl;
+mod common;


### PR DESCRIPTION
This moves the common testing code to `tests/common/mod.rs` and we now have two separate test files:
  - `rdrand.rs`
  - `normal.rs`

The `Error` size checks stay where they are (as they make sense inline).