### PR TITLE
Remove extern crate std from source files

### DIFF
--- a/src/error_impls.rs
+++ b/src/error_impls.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
-extern crate std;
 
 use crate::Error;
 use core::convert::From;

--- a/src/js.rs
+++ b/src/js.rs
@@ -7,7 +7,6 @@
 // except according to those terms.
 use crate::Error;
 
-extern crate std;
 use std::thread_local;
 
 use js_sys::Uint8Array;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -39,7 +39,6 @@ fn test_huge() {
 #[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test_multithreading() {
-    extern crate std;
     use std::{sync::mpsc::channel, thread, vec};
 
     let mut txs = vec![];


### PR DESCRIPTION
This pull request removes 'extern crate std' from source files for cleaner name spaces.

It is no longer necessary to import crates: https://doc.rust-lang.org/edition-guide/rust-2018/module-system/path-clarity.html

This has been tested with 'cargo build' and 'cargo test'.