### PR TITLE
Improve detection for Node JS

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -162,7 +162,7 @@ fn internal_desc(error: Error) -> Option<&'static str> {
         Error::WINDOWS_RTL_GEN_RANDOM => Some("RtlGenRandom: Windows system function failure"),
         Error::FAILED_RDRAND => Some("RDRAND: failed multiple times: CPU issue likely"),
         Error::NO_RDRAND => Some("RDRAND: instruction not supported"),
-        Error::WEB_CRYPTO => Some("Web API self.crypto is unavailable"),
+        Error::WEB_CRYPTO => Some("Web Crypto API is unavailable"),
         Error::WEB_GET_RANDOM_VALUES => Some("Web API crypto.getRandomValues is unavailable"),
         Error::VXWORKS_RAND_SECURE => Some("randSecure: VxWorks RNG module is not initialized"),
         Error::NODE_CRYPTO => Some("Node.js crypto module is unavailable"),


### PR DESCRIPTION
Fixes #214 (CC: @devdoshi can you verify that this fixes your issue)

This uses `process.versions.node` to see if we are in Node.js rather
than using `global.self` to check if we are in a Browser.

This change also makes some minor `wasm_bindgen` improvements:
  - Use `js_sys::global()` to get the global object
  - Bind the Node's `require()` as `module.require`
  - Improving error messages
  - Being more strict about JsValue types (i.e. check that they are objects rather than just making sure they are not undefined)

Signed-off-by: Joe Richey <joerichey@google.com>