### PR TITLE
Fix Solaris CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,7 +166,7 @@ jobs:
     strategy:
       matrix:
         target: [
-          x86_64-sun-solaris,
+          sparcv9-sun-solaris,
           x86_64-unknown-netbsd,
         ]
     steps:


### PR DESCRIPTION
The new target is called `x86_64-pc-solaris`, but `cross` doesn't support that yet, so just use `sparcv9-sun-solaris`.

See the following issues for more info:
  - https://github.com/rust-lang/rust/issues/85098
  - https://github.com/rust-lang/rust/pull/82216

Signed-off-by: Joe Richey <joerichey@google.com>