### PR TITLE
redox: Switch to /dev/urandom

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@
 //! | Dragonfly BSD     | `*‑dragonfly`      | [`getrandom()`][22] if available, otherwise [`/dev/random`][8]
 //! | Solaris, illumos  | `*‑solaris`, `*‑illumos` | [`getrandom()`][9] if available, otherwise [`/dev/random`][10]
 //! | Fuchsia OS        | `*‑fuchsia`        | [`cprng_draw`][11]
-//! | Redox             | `*‑redox`          | [`rand:`][12]
+//! | Redox             | `*‑redox`          | [`/dev/urandom`][12]
 //! | Haiku             | `*‑haiku`          | `/dev/random` (identical to `/dev/urandom`)
 //! | SGX               | `x86_64‑*‑sgx`     | [RDRAND][18]
 //! | VxWorks           | `*‑wrs‑vxworks‑*`  | `randABytes` after checking entropy pool initialization with `randSecure`

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -17,8 +17,6 @@ use core::{
     sync::atomic::{AtomicUsize, Ordering::Relaxed},
 };
 
-#[cfg(target_os = "redox")]
-const FILE_PATH: &str = "rand:\0";
 #[cfg(any(
     target_os = "dragonfly",
     target_os = "emscripten",
@@ -28,7 +26,7 @@ const FILE_PATH: &str = "rand:\0";
     target_os = "illumos"
 ))]
 const FILE_PATH: &str = "/dev/random\0";
-#[cfg(any(target_os = "android", target_os = "linux"))]
+#[cfg(any(target_os = "android", target_os = "linux", target_os = "redox"))]
 const FILE_PATH: &str = "/dev/urandom\0";
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {


### PR DESCRIPTION
From https://github.com/briansmith/ring/pull/1341 apparently on Redox the `/dev/urandom` device now exists. Changing the implementation for consistency between RNG crates.

@jackpot51 does this look good to you? Also, where is this device documented?

Signed-off-by: Joe Richey <joerichey@google.com>