### PR TITLE
Use `NonZeroU32::new_unchecked` to convert wasi error

### DIFF
--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -12,10 +12,12 @@ use core::num::NonZeroU32;
 use wasi::random_get;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    unsafe { random_get(dest.as_mut_ptr(), dest.len()) }.map_err(|e: wasi::Error| {
-        // convert wasi's Error into getrandom's NonZeroU32 error
-        // SAFETY: `wasi::Error` is `NonZeroU16` internally, so `e.raw_error()`
-        // will never return 0
-        unsafe { NonZeroU32::new_unchecked(e.raw_error() as u32) }.into()
-    })
+    unsafe {
+        random_get(dest.as_mut_ptr(), dest.len()).map_err(|e: wasi::Error| {
+            // convert wasi's Error into getrandom's NonZeroU32 error
+            // SAFETY: `wasi::Error` is `NonZeroU16` internally, so `e.raw_error()`
+            // will never return 0
+            NonZeroU32::new_unchecked(e.raw_error() as u32).into()
+        })
+    }
 }


### PR DESCRIPTION
The check in `NonZeroU32::new` isn't needed, as `wasi::Error` is `NonZeroU16` internally, so `wasi::Error::raw_error` will never return zero