### PR TITLE
Fix Webpack warning caused by dynamic require

### DIFF
--- a/src/js.rs
+++ b/src/js.rs
@@ -59,7 +59,9 @@ pub(crate) fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 fn getrandom_init() -> Result<RngSource, Error> {
     let global: Global = global().unchecked_into();
     if is_node(&global) {
-        let crypto = require("crypto").map_err(|_| Error::NODE_CRYPTO)?;
+        let crypto = NODE_MODULE
+            .require("crypto")
+            .map_err(|_| Error::NODE_CRYPTO)?;
         return Ok(RngSource::Node(crypto));
     }
 
@@ -102,9 +104,12 @@ extern "C" {
     #[wasm_bindgen(method, js_name = getRandomValues, catch)]
     fn get_random_values(this: &BrowserCrypto, buf: &Uint8Array) -> Result<(), JsValue>;
 
+    type NodeModule;
+    #[wasm_bindgen(js_name = module)]
+    static NODE_MODULE: NodeModule;
     // Node JS crypto module (https://nodejs.org/api/crypto.html)
-    #[wasm_bindgen(catch, js_name = "module.require")]
-    fn require(s: &str) -> Result<NodeCrypto, JsValue>;
+    #[wasm_bindgen(method, catch)]
+    fn require(this: &NodeModule, s: &str) -> Result<NodeCrypto, JsValue>;
     type NodeCrypto;
     #[wasm_bindgen(method, js_name = randomFillSync, catch)]
     fn random_fill_sync(this: &NodeCrypto, buf: &mut [u8]) -> Result<(), JsValue>;

--- a/src/js.rs
+++ b/src/js.rs
@@ -104,6 +104,9 @@ extern "C" {
     #[wasm_bindgen(method, js_name = getRandomValues, catch)]
     fn get_random_values(this: &BrowserCrypto, buf: &Uint8Array) -> Result<(), JsValue>;
 
+    // We use a "module" object here instead of just annotating require() with
+    // js_name = "module.require", so that Webpack doesn't give a warning. See:
+    //   https://github.com/rust-random/getrandom/issues/224
     type NodeModule;
     #[wasm_bindgen(js_name = module)]
     static NODE_MODULE: NodeModule;


### PR DESCRIPTION
This PR reverts the changes in commit 120a1d7  **partially** . In particular, it changes the wasm-bindgen binding of `module.requirement` back to the older form. As a result the generated Javascript binding code looks now like:

```
 getObject(arg0).require(getStringFromWasm0(arg1, arg2))
```

As a consequence Webpack does not detect this as a package import and, thus, does not attempt to bundle it which solves problem. It is safe skip the bundling of the `crypto` package because (1) it is imported only on Node and (2) it comes with Node.

Relevant issues:

- https://github.com/rust-random/getrandom/issues/224
- https://github.com/rustwasm/wasm-pack/issues/822