### PR TITLE
Add SOLID target support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -314,6 +314,8 @@ jobs:
         run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-l4re-uclibc
       - name: VxWorks
         run: cargo build -Z build-std=core --target=x86_64-wrs-vxworks
+      - name: SOLID
+        run: cargo build -Z build-std=core --target=aarch64-kmc-solid_asp3
 
   clippy-fmt:
     name: Clippy + rustfmt

--- a/src/error.rs
+++ b/src/error.rs
@@ -73,7 +73,14 @@ impl Error {
     #[inline]
     pub fn raw_os_error(self) -> Option<i32> {
         if self.0.get() < Self::INTERNAL_START {
-            Some(self.0.get() as i32)
+            match () {
+                #[cfg(target_os = "solid_asp3")]
+                // On SOLID, negate the error code again to obtain the original
+                // error code.
+                () => Some(-(self.0.get() as i32)),
+                #[cfg(not(target_os = "solid_asp3"))]
+                () => Some(self.0.get() as i32),
+            }
         } else {
             None
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@
 //! | WASI              | `wasm32‑wasi`      | [`random_get`][17]
 //! | Web Browser       | `wasm32‑*‑unknown` | [`Crypto.getRandomValues()`][14], see [WebAssembly support][16]
 //! | Node.js           | `wasm32‑*‑unknown` | [`crypto.randomBytes`][15], see [WebAssembly support][16]
+//! | SOLID             | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
 //!
 //! There is no blanket implementation on `unix` targets that reads from
 //! `/dev/urandom`. This ensures all supported targets are using the recommended
@@ -203,6 +204,8 @@ cfg_if! {
     } else if #[cfg(target_os = "vxworks")] {
         mod util_libc;
         #[path = "vxworks.rs"] mod imp;
+    } else if #[cfg(target_os = "solid_asp3")] {
+        #[path = "solid.rs"] mod imp;
     } else if #[cfg(windows)] {
         #[path = "windows.rs"] mod imp;
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -1,0 +1,24 @@
+// Copyright 2021 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation for SOLID
+use crate::Error;
+use core::num::NonZeroU32;
+
+extern "C" {
+    pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
+}
+
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+    let er = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+    if let Some(er) = NonZeroU32::new(er as u32) {
+        Err(er.into())
+    } else {
+        Ok(())
+    }
+}

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -16,11 +16,11 @@ extern "C" {
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
-    // ITRON error numbers are always negative, so we negate it so that it
-    // doesn't fall in the range `INTERNAL_START..`.
-    if let Some(ret) = NonZeroU32::new((-ret) as u32) {
-        Err(ret.into())
-    } else {
+    if ret >= 0 {
         Ok(())
+    } else {
+        // ITRON error numbers are always negative, so we negate it so that it
+        // falls in the dedicated OS error range (1..INTERNAL_START).
+        Err(NonZeroU32::new((-ret) as u32).unwrap().into())
     }
 }

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -16,7 +16,9 @@ extern "C" {
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
-    if let Some(ret) = NonZeroU32::new(ret as u32) {
+    // ITRON error numbers are always negative, so we negate it so that it
+    // doesn't fall in the range `INTERNAL_START..`.
+    if let Some(ret) = NonZeroU32::new((-ret) as u32) {
         Err(ret.into())
     } else {
         Ok(())

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -15,9 +15,9 @@ extern "C" {
 }
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let er = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
-    if let Some(er) = NonZeroU32::new(er as u32) {
-        Err(er.into())
+    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+    if let Some(ret) = NonZeroU32::new(ret as u32) {
+        Err(ret.into())
     } else {
         Ok(())
     }


### PR DESCRIPTION
This PR adds support for [`*-kmc-solid_*`](https://doc.rust-lang.org/nightly/rustc/platform-support/kmc-solid.html), a new Tier 3 target.