### PR TITLE
Added x86_64-unknown-hermit support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -306,10 +306,10 @@ jobs:
           components: rust-src
           override: true
       - uses: Swatinem/rust-cache@v1
+      - name: Hermit (x86-64 only)
+        run: cargo build -Z build-std=core --target=x86_64-unknown-hermit
       - name: UEFI (RDRAND)
         run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-uefi
-      - name: Hermit (RDRAND)
-        run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-hermit
       - name: L4Re (RDRAND)
         run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-l4re-uclibc
       - name: VxWorks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+- Added x86_64-unknown-hermit support [#236]
+
+[#236]: https://github.com/rust-random/getrandom/pull/236
+
 ## [0.2.3] - 2021-04-10
 ### Changed
 - Replace build.rs with link attributes. [#205]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,7 @@
 //! | Fuchsia OS        | `*‑fuchsia`        | [`cprng_draw`][11]
 //! | Redox             | `*‑redox`          | [`/dev/urandom`][12]
 //! | Haiku             | `*‑haiku`          | `/dev/random` (identical to `/dev/urandom`)
+//! | Hermit            | `x86_64-*-hermit`  | [`RDRAND`][18]
 //! | SGX               | `x86_64‑*‑sgx`     | [RDRAND][18]
 //! | VxWorks           | `*‑wrs‑vxworks‑*`  | `randABytes` after checking entropy pool initialization with `randSecure`
 //! | Emscripten        | `*‑emscripten`     | `/dev/random` (identical to `/dev/urandom`)
@@ -200,6 +201,8 @@ cfg_if! {
         #[path = "openbsd.rs"] mod imp;
     } else if #[cfg(target_os = "wasi")] {
         #[path = "wasi.rs"] mod imp;
+    } else if #[cfg(all(target_arch = "x86_64", target_os = "hermit"))] {
+        #[path = "rdrand.rs"] mod imp;
     } else if #[cfg(target_os = "vxworks")] {
         mod util_libc;
         #[path = "vxworks.rs"] mod imp;


### PR DESCRIPTION
[Later](https://github.com/hermitcore/rusty-hermit/pull/64#issuecomment-980668685) once hermit supports `aarch64` rng I'll make a patch to support it. 

For more context see #199