### PR TITLE
Fix build break in wasm32-wasi target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.5] - 2022-01-18
+### Fixed
+- Fix Webpack dynamic require warning on `wasm32-unknown-unknown` [#234]
+- Fix build breakage on `wasm32-wasi` target [#242]
+
+[#234]: https://github.com/rust-random/getrandom/pull/234
+[#242]: https://github.com/rust-random/getrandom/pull/242
+
 ## [0.2.4] - 2021-12-13
 ### Changed
 - Use explicit imports in the `js` backend [#220]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.64", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
+# Version pinned to work around https://github.com/bytecodealliance/wasi/pull/62
 wasi = "=0.10.2"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.4" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.5" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
@@ -21,7 +21,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.64", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.10"
+wasi = "=0.10.2"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -146,7 +146,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.4"
+    html_root_url = "https://docs.rs/getrandom/0.2.5"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
Fixes https://github.com/rust-random/getrandom/issues/241

root cause is that wasi crate introduced breaking changes in version 0.10.3+wasi-snapshot-preview1