### PR TITLE
ios: Fix Error checking for SecRandomCopyBytes

### DIFF
--- a/src/ios.rs
+++ b/src/ios.rs
@@ -18,7 +18,8 @@ extern "C" {
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
     // Apple's documentation guarantees kSecRandomDefault is a synonym for NULL.
     let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr()) };
-    if ret == -1 {
+    // errSecSuccess (from SecBase.h) is always zero.
+    if ret != 0 {
         Err(Error::IOS_SEC_RANDOM)
     } else {
         Ok(())


### PR DESCRIPTION
Apple's documentation for SecRandomCopyBytes says that errSecSuccess is
returned on success, and all other values indicate failure.
  https://developer.apple.com/documentation/security/1399291-secrandomcopybytes

The SecBase.h header also clearly establishes that `errSecSuccess = 0`:
  https://opensource.apple.com/source/Security/Security-55471/sec/Security/SecBase.h.auto.html

Fixes #243

Signed-off-by: Joe Richey <joerichey@google.com>