### PR TITLE
Add support for the Nintendo 3DS (armv6k-nintendo-3ds)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,6 +316,8 @@ jobs:
         run: cargo build -Z build-std=core --target=x86_64-wrs-vxworks
       - name: SOLID
         run: cargo build -Z build-std=core --target=aarch64-kmc-solid_asp3
+      - name: Nintendo 3DS
+        run: cargo build -Z build-std=core --target=armv6k-nintendo-3ds
 
   clippy-fmt:
     name: Clippy + rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.64", default-features = false }
+libc = { version = "0.2.120", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = "0.10"

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -1,0 +1,17 @@
+// Copyright 2021 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation for Nintendo 3DS
+use crate::util_libc::sys_fill_exact;
+use crate::Error;
+
+pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+    sys_fill_exact(dest, |buf| unsafe {
+        libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0)
+    })
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! | Web Browser       | `wasm32‑*‑unknown` | [`Crypto.getRandomValues()`][14], see [WebAssembly support][16]
 //! | Node.js           | `wasm32‑*‑unknown` | [`crypto.randomBytes`][15], see [WebAssembly support][16]
 //! | SOLID             | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
+//! | Nintendo 3DS      | `armv6k-nintendo-3ds` | [`getrandom`][1]
 //!
 //! There is no blanket implementation on `unix` targets that reads from
 //! `/dev/urandom`. This ensures all supported targets are using the recommended
@@ -223,6 +224,11 @@ cfg_if! {
     } else if #[cfg(all(feature = "js",
                         target_arch = "wasm32", target_os = "unknown"))] {
         #[path = "js.rs"] mod imp;
+    } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
+        // We check for target_arch = "arm" because the Nintendo Switch also
+        // uses Horizon OS (it is aarch64).
+        mod util_libc;
+        #[path = "3ds.rs"] mod imp;
     } else if #[cfg(feature = "custom")] {
         use custom as imp;
     } else if #[cfg(all(target_arch = "wasm32", target_os = "unknown"))] {

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -20,6 +20,12 @@ cfg_if! {
         use libc::__error as errno_location;
     } else if #[cfg(target_os = "haiku")] {
         use libc::_errnop as errno_location;
+    } else if #[cfg(target_os = "horizon")] {
+        extern "C" {
+            // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
+            fn __errno() -> *mut libc::c_int;
+        }
+        use __errno as errno_location;
     }
 }
 

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -20,7 +20,7 @@ cfg_if! {
         use libc::__error as errno_location;
     } else if #[cfg(target_os = "haiku")] {
         use libc::_errnop as errno_location;
-    } else if #[cfg(target_os = "horizon")] {
+    } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
         extern "C" {
             // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
             fn __errno() -> *mut libc::c_int;


### PR DESCRIPTION
## Overview
The Nintendo 3DS is a mostly-UNIX looking system, with the caveat that it does not come with a full libc implementation out of the box. On the homebrew side (I'm not under NDA), the libc interface is (partially) implemented by a user library like [libctru](https://github.com/devkitPro/libctru). This is important because `getrandom` (conforming to Linux) is one of the functions that requires some work to make UNIX compatible.

Because of this, the implementation of `getrandom` needs to be supplied by a dependency. libctru doesn't supply a libc (linux) compatible `getrandom` but it does supply a similar function based on the underlying syscall. Our implementation of `getrandom` which uses this libctru function is here: https://github.com/Meziu/rust-linker-fix-3ds/blob/080f7af4f2193892cca69da271e7dfad2aaba4e4/src/lib.rs#L94.

This PR utilizes the libc implementation of [`getrandom`](https://man7.org/linux/man-pages/man2/getrandom.2.html) (conforming to Linux) by linking to it via the `libc` crate.

Note: the 3DS's [PS service](https://www.3dbrew.org/wiki/Process_Services) needs to be initialized before calling this function, otherwise it returns an error. It is expected that the user initializes this at the start of their process.

### Implementation choice
Technically we could fit the whole implementation in this `getrandom` crate since under the hood it's just a syscall. However, I didn't go down that path for a few reasons:
1. The underlying implementation (when linked against `rust-linker-fix-3ds`) uses libctru to perform the syscall. The call itself [is a little complex](https://github.com/devkitPro/libctru/blob/ebb53051886cfe966f1aa27ff3dd6689176de483/libctru/source/services/ps.c#L167) and requires a lot of knowledge about the platform (ex. needs to decode 3DS kernel error codes), so I didn't want to repeat that here.
2. Taking the above into account, we probably can't simply link in libctru because of some concerns best summarized here: https://github.com/rust-lang/rust/pull/88529#issuecomment-919938396. I think this concern also prevents us from writing the syscall wrapper manually, since it would be including details about the 3DS's kernel interface in a somewhat-official/blessed crate.

I may be wrong on point 2 (since this isn't an official `rust-lang` crate), in which case we may be "allowed" to reimplement the syscall wrapper in this crate directly. But reusing the libctru implementation is pretty easy, and allows for alternative (homebrew or potential NDA-ed libc library) implementations by way of linking to `libc::getrandom` instead of libctru directly.

### Building
The `armv6k-nintendo-3ds` tier 3 target is supported by rustc as of 1.57: https://github.com/rust-lang/rust/pull/88529. However, it is currently `core` and `alloc` only. `std` support requires a patched rustc: https://github.com/Meziu/rust-horizon (we plan on upstreaming this soon). The target also requires an external toolchain from devkitPro to compile: https://devkitpro.org/wiki/devkitPro_pacman. This dissuaded me from adding it to the build-std tests in `test.yaml`, but let me know if this test should be added.

## ~~Draft notice~~
**Update**: The libc changes merged so this PR is now published.

~~This PR currently relies on `libc::getrandom` which isn't currently exported for the target (needs a [patched libc](https://github.com/Meziu/libc)). The PR will be in draft until we upstream that change and it gets released.~~

~~Question: Once the new libc version is released, will this will require changing the minimum version of libc in `Cargo.toml`?~~