### PR TITLE
Update to wasi 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = "1"
 compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
-[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
+[target.'cfg(unix)'.dependencies]
 libc = { version = "0.2.120", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.120", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.10"
+wasi = "0.11"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ cfg-if = "1"
 compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(unix, target_os = "wasi"))'.dependencies]
 libc = { version = "0.2.120", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -110,8 +110,10 @@ cfg_if! {
             core::str::from_utf8(&buf[..idx]).ok()
         }
     } else if #[cfg(target_os = "wasi")] {
-        fn os_err(errno: i32, _buf: &mut [u8]) -> Option<wasi::Error> {
-            wasi::Error::from_raw_error(errno as _)
+        fn os_err(errno: i32, _buf: &mut [u8]) -> Option<wasi::Errno> {
+            // Can't create `Errno` at the moment, see
+            // <https://github.com/bytecodealliance/wasi/issues/64>.
+            None
         }
     } else {
         fn os_err(_errno: i32, _buf: &mut [u8]) -> Option<&str> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ impl Error {
 }
 
 cfg_if! {
-    if #[cfg(any(unix, target_os = "wasi"))] {
+    if #[cfg(unix)] {
         fn os_err(errno: i32, buf: &mut [u8]) -> Option<&str> {
             let buf_ptr = buf.as_mut_ptr() as *mut libc::c_char;
             if unsafe { libc::strerror_r(errno, buf_ptr, buf.len()) } != 0 {

--- a/src/error.rs
+++ b/src/error.rs
@@ -97,7 +97,7 @@ impl Error {
 }
 
 cfg_if! {
-    if #[cfg(unix)] {
+    if #[cfg(any(unix, target_os = "wasi"))] {
         fn os_err(errno: i32, buf: &mut [u8]) -> Option<&str> {
             let buf_ptr = buf.as_mut_ptr() as *mut libc::c_char;
             if unsafe { libc::strerror_r(errno, buf_ptr, buf.len()) } != 0 {
@@ -108,12 +108,6 @@ cfg_if! {
             let n = buf.len();
             let idx = buf.iter().position(|&b| b == 0).unwrap_or(n);
             core::str::from_utf8(&buf[..idx]).ok()
-        }
-    } else if #[cfg(target_os = "wasi")] {
-        fn os_err(errno: i32, _buf: &mut [u8]) -> Option<wasi::Errno> {
-            // Can't create `Errno` at the moment, see
-            // <https://github.com/bytecodealliance/wasi/issues/64>.
-            None
         }
     } else {
         fn os_err(_errno: i32, _buf: &mut [u8]) -> Option<&str> {

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -9,13 +9,11 @@
 //! Implementation for WASI
 use crate::Error;
 use core::num::NonZeroU32;
-use wasi::random_get;
+use wasi::wasi_snapshot_preview1::random_get;
 
 pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    random_get(dest.as_mut_ptr(), dest.len()).map_err(|e: wasi::Errno| {
-        // NOTE: `random_get` deals with return value of zero for us, so the
-        // unwrap below won't panic. However in case the code ever changes we
-        // don't want to use `new_unchecked` and cause UB.
-        NonZeroU32::new(e.raw() as u32).unwrap().into()
-    })
+    match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
+        0 => Ok(()),
+        err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),
+    }
 }


### PR DESCRIPTION
The main breaking change between v0.10 and v0.11 is that Error is
removed in favour of Errno. Unfortunately we can't create an Errno from
outside the wasi create so we're loosing some debug information for
errors.

I've opened an issue to add back such a constructor, see
<https://github.com/bytecodealliance/wasi/issues/64>.