### PR TITLE
Auto-emit feature js on wasm32-unknown-unknown target

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -205,7 +205,9 @@ jobs:
           tar -C /tmp -xzf /tmp/binaries.tar.gz --strip-components=1
           mv /tmp/wasm-bindgen-test-runner ~/.cargo/bin
       - name: Test (Node)
-        run: cargo test --target=wasm32-unknown-unknown --features=js
+        run: |
+          cargo test --target=wasm32-unknown-unknown
+          cargo test --target=wasm32-unknown-unknown --features=js
       - name: Test (Firefox)
         env:
           GECKODRIVER: /usr/bin/geckodriver

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ libc = { version = "0.2.120", default-features = false }
 wasi = "0.11"
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }
-js-sys = { version = "0.3", optional = true }
+wasm-bindgen = { version = "0.2.62", default-features = false }
+js-sys = "0.3"
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.18"
 
@@ -35,7 +35,9 @@ std = []
 # Feature to enable fallback RDRAND-based implementation on x86/x86_64
 rdrand = []
 # Feature to enable JavaScript bindings on wasm32-unknown-unknown
-js = ["wasm-bindgen", "js-sys"]
+# This is deprecated and has been moved into build.rs as a virtual feature
+# keep it here only for compatibility
+js = []
 # Feature to enable custom RNG implementations
 custom = []
 # Unstable feature to support being a libstd dependency

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,11 @@
+use std::env;
+
+fn main() {
+    let arch = env::var("CARGO_CFG_TARGET_ARCH");
+    let os = env::var("CARGO_CFG_TARGET_OS");
+    if arch == Ok("wasm32".into()) && os == Ok("unknown".into()) {
+        // Emits virtual feature js which is used to enable
+        // JavaScript bindings on wasm32-unknown-unknown
+        println!("cargo:rustc-cfg=feature=\"js\"");
+    }
+}


### PR DESCRIPTION
Currently, feature `js` has to be enabled explicitly to build on `wasm32-unknown-unknown` target.  This PR tries to automatically emit feature `js` on `wasm32-unknown-unknown` target with cargo build script, to make `cargo build --target wasm32-unknown-unknown` work.  Feature `js` is still kept in `Cargo.toml` for compatibility, it can be removed in future release.

All CI tests pass on my fork: https://github.com/hanabi1224/getrandom/actions/runs/2203432125