### PR TITLE
Add support for forced custom implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ rdrand = []
 js = ["wasm-bindgen", "js-sys"]
 # Feature to enable custom RNG implementations
 custom = []
+# Feature to force usage of custom RNG implementation
+force-custom = []
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = [
   "compiler_builtins",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ mod error;
 mod util;
 // To prevent a breaking change when targets are added, we always export the
 // register_custom_getrandom macro, so old Custom RNG crates continue to build.
-#[cfg(feature = "custom")]
+#[cfg(any(feature = "custom", feature = "force-custom"))]
 mod custom;
 #[cfg(feature = "std")]
 mod error_impls;
@@ -173,7 +173,9 @@ pub use crate::error::Error;
 //
 // These should all provide getrandom_inner with the same signature as getrandom.
 cfg_if! {
-    if #[cfg(any(target_os = "emscripten", target_os = "haiku",
+    if #[cfg(feature = "force-custom")] {
+        use custom as imp;
+    } else if #[cfg(any(target_os = "emscripten", target_os = "haiku",
                  target_os = "redox"))] {
         mod util_libc;
         #[path = "use_file.rs"] mod imp;


### PR DESCRIPTION
This adds a feature `force-custom` that will supersede `target_os` based rng selection.

This fixes #230, and supports my particular use case, which is building for `wasm32-unknown-unknown` in theory, but using `wasm32-unknown-emscripten` in practice, with a custom rand impl.