### PR TITLE
use $crate in macro

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -79,7 +79,7 @@ macro_rules! register_custom_getrandom {
         // We use an extern "C" function to get the guarantees of a stable ABI.
         #[no_mangle]
         extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
-            let f: fn(&mut [u8]) -> Result<(), ::getrandom::Error> = $path;
+            let f: fn(&mut [u8]) -> Result<(), $crate::Error> = $path;
             let slice = unsafe { ::core::slice::from_raw_parts_mut(dest, len) };
             match f(slice) {
                 Ok(()) => 0,


### PR DESCRIPTION
This is the recommended way of referring to the current crate in a macro.