### PR TITLE
Added possibility to pass uninit arrays to random generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,9 @@ rustc-dep-of-std = [
 # Unstable/test-only feature to run wasm-bindgen tests in a browser
 test-in-browser = []
 
+# Nightly-only implementation with `std::io::ReadBuf` struct.
+rdbuf-impl = []
+
 [package.metadata.docs.rs]
 features = ["std", "custom"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -7,10 +7,12 @@
 // except according to those terms.
 
 //! Implementation for Nintendo 3DS
+use core::mem::MaybeUninit;
+
 use crate::util_libc::sys_fill_exact;
 use crate::Error;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0)
     })

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -7,13 +7,13 @@
 // except according to those terms.
 
 //! Implementation for DragonFly BSD
-use crate::{
-    use_file,
-    util_libc::{sys_fill_exact, Weak},
-    Error,
-};
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+use crate::use_file;
+use crate::util_libc::{sys_fill_exact, Weak};
+use crate::Error;
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -7,14 +7,16 @@
 // except according to those terms.
 
 //! Implementation for ESP-IDF
-use crate::Error;
 use core::ffi::c_void;
+use core::mem::MaybeUninit;
+
+use crate::Error;
 
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
     // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
     // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -14,7 +14,7 @@ extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    unsafe { zx_cprng_draw(dest.as_mut_ptr(), dest.len()) }
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { zx_cprng_draw(dest.as_mut_ptr() as *mut _, dest.len()) }
     Ok(())
 }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -15,9 +15,9 @@ extern "C" {
     fn SecRandomCopyBytes(rnd: *const c_void, count: usize, bytes: *mut u8) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Apple's documentation guarantees kSecRandomDefault is a synonym for NULL.
-    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr()) };
+    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr() as *mut u8) };
     // errSecSuccess (from SecBase.h) is always zero.
     if ret != 0 {
         Err(Error::IOS_SEC_RANDOM)

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -7,13 +7,15 @@
 // except according to those terms.
 
 //! Implementation for Linux / Android
+use core::mem::MaybeUninit;
+
 use crate::{
     util::LazyBool,
     util_libc::{last_os_error, sys_fill_exact},
     {use_file, Error},
 };
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Linux 3.17
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -7,22 +7,23 @@
 // except according to those terms.
 
 //! Implementation for macOS
+use core::mem::{transmute, MaybeUninit};
+
 use crate::{
     use_file,
     util_libc::{last_os_error, Weak},
     Error,
 };
-use core::mem;
 
 type GetEntropyFn = unsafe extern "C" fn(*mut u8, libc::size_t) -> libc::c_int;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in 10.12, Rust supports 10.7+
     static GETENTROPY: Weak = unsafe { Weak::new("getentropy\0") };
     if let Some(fptr) = GETENTROPY.ptr() {
-        let func: GetEntropyFn = unsafe { mem::transmute(fptr) };
+        let func: GetEntropyFn = unsafe { transmute(fptr) };
         for chunk in dest.chunks_mut(256) {
-            let ret = unsafe { func(chunk.as_mut_ptr(), chunk.len()) };
+            let ret = unsafe { func(chunk.as_mut_ptr() as *mut u8, chunk.len()) };
             if ret != 0 {
                 return Err(last_os_error());
             }

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -9,7 +9,7 @@
 //! Implementation for OpenBSD
 use crate::{util_libc::last_os_error, Error};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in OpenBSD 5.6, so we can use it unconditionally.
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -17,19 +17,20 @@
 //! To make sure we can compile on both Solaris and its derivatives, as well as
 //! function, we check for the existence of getrandom(2) in libc by calling
 //! libc::dlsym.
+use core::mem;
+
 use crate::{
     use_file,
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
-use core::mem;
 
 #[cfg(target_os = "illumos")]
 type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 #[cfg(target_os = "solaris")]
 type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::c_int;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [mem::MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Solaris 11.3 for Illumos in 2015.
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     if let Some(fptr) = GETRANDOM.ptr() {
@@ -38,7 +39,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
         // derived platforms for atomically obtaining random data.
         for chunk in dest.chunks_mut(256) {
             sys_fill_exact(chunk, |buf| unsafe {
-                func(buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
+                func(buf.as_mut_ptr() as *mut u8, buf.len(), 0) as libc::ssize_t
             })?
         }
         Ok(())

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -7,15 +7,17 @@
 // except according to those terms.
 
 //! Implementation for SOLID
-use crate::Error;
+use core::mem::MaybeUninit;
 use core::num::NonZeroU32;
+
+use crate::Error;
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr() as *mut u8, dest.len()) };
     if ret >= 0 {
         Ok(())
     } else {

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -6,13 +6,14 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![allow(dead_code)]
-use crate::Error;
-use core::{
-    num::NonZeroU32,
-    ptr::NonNull,
-    sync::atomic::{fence, AtomicPtr, Ordering},
-};
+use core::mem::MaybeUninit;
+use core::num::NonZeroU32;
+use core::ptr::NonNull;
+use core::sync::atomic::{fence, AtomicPtr, Ordering};
+
 use libc::c_void;
+
+use crate::Error;
 
 cfg_if! {
     if #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android"))] {
@@ -59,8 +60,8 @@ pub fn last_os_error() -> Error {
 //   - should return -1 and set errno on failure
 //   - should return the number of bytes written on success
 pub fn sys_fill_exact(
-    mut buf: &mut [u8],
-    sys_fill: impl Fn(&mut [u8]) -> libc::ssize_t,
+    mut buf: &mut [MaybeUninit<u8>],
+    sys_fill: impl Fn(&mut [MaybeUninit<u8>]) -> libc::ssize_t,
 ) -> Result<(), Error> {
     while !buf.is_empty() {
         let res = sys_fill(buf);

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -11,9 +11,11 @@ use crate::Error;
 use core::num::NonZeroU32;
 use wasi::wasi_snapshot_preview1::random_get;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
-        0 => Ok(()),
-        err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    let res = unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) };
+    if res == 0 {
+        Ok(())
+    } else {
+        Err(unsafe { NonZeroU32::new_unchecked(res as u32) }.into())
     }
 }

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -6,8 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+use core::ffi::c_void;
+use core::mem::MaybeUninit;
+use core::num::NonZeroU32;
+use core::ptr;
+
 use crate::Error;
-use core::{ffi::c_void, num::NonZeroU32, ptr};
 
 const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
 
@@ -15,14 +19,16 @@ const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
 extern "system" {
     fn BCryptGenRandom(
         hAlgorithm: *mut c_void,
-        pBuffer: *mut u8,
+        pBuffer: *mut MaybeUninit<u8>,
         cbBuffer: u32,
         dwFlags: u32,
     ) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
+    // Note: chunk cannot overflow isize::max_value() on 32bit systems
+    // because original slice cannot be longer than that.
     for chunk in dest.chunks_mut(u32::max_value() as usize) {
         // BCryptGenRandom was introduced in Windows Vista
         let ret = unsafe {
@@ -38,6 +44,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
             // We zeroize the highest bit, so the error code will reside
             // inside the range designated for OS codes.
             let code = ret ^ (1 << 31);
+            debug_assert_ne!(code, 0);
             // SAFETY: the second highest bit is always equal to one,
             // so it's impossible to get zero. Unfortunately the type
             // system does not have a way to express this yet.

--- a/tests/rdrand.rs
+++ b/tests/rdrand.rs
@@ -11,5 +11,11 @@ mod rdrand;
 #[path = "../src/util.rs"]
 mod util;
 
-use rdrand::getrandom_inner as getrandom_impl;
+use rdrand::getrandom_inner;
+
+fn getrandom_impl(dest: &mut [u8]) -> Result<(), Error> {
+    getrandom_inner(unsafe {
+        core::slice::from_raw_parts_mut(dest.as_mut_ptr() as *mut _, dest.len())
+    })
+}
 mod common;


### PR DESCRIPTION
This can be useful to skip extra work on caller side and it is more logical because we don't really need to have initialized values to fill them with new values.