### PR TITLE
Implement raw API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        toolchain: [nightly, beta, stable, 1.34]
+        toolchain: [nightly, beta, stable, 1.36]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
           - os: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `getrandom_raw` and `getrandom_uninit` functions [#279]
+
+### Changed
+- Bump MSRV to 1.36 [#279]
+
+[#279]: https://github.com/rust-random/getrandom/pull/279
+
 ## [0.2.7] - 2022-06-14
 ### Changed
 - Update `wasi` dependency to `0.11` [#253]

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ crate features, WASM support and Custom RNGs see the
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.34.0 or later.
+This crate requires Rust 1.36.0 or later.
 
 # License
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,59 +1,21 @@
 #![feature(test)]
 extern crate test;
 
-use std::{
-    alloc::{alloc_zeroed, dealloc, Layout},
-    ptr::NonNull,
-};
-
-// AlignedBuffer is like a Box<[u8; N]> except that it is always N-byte aligned
-struct AlignedBuffer<const N: usize>(NonNull<[u8; N]>);
-
-impl<const N: usize> AlignedBuffer<N> {
-    fn layout() -> Layout {
-        Layout::from_size_align(N, N).unwrap()
-    }
-
-    fn new() -> Self {
-        let p = unsafe { alloc_zeroed(Self::layout()) } as *mut [u8; N];
-        Self(NonNull::new(p).unwrap())
-    }
-
-    fn buf(&mut self) -> &mut [u8; N] {
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl<const N: usize> Drop for AlignedBuffer<N> {
-    fn drop(&mut self) {
-        unsafe { dealloc(self.0.as_ptr() as *mut u8, Self::layout()) }
-    }
-}
-
-// Used to benchmark the throughput of getrandom in an optimal scenario.
-// The buffer is hot, and does not require initialization.
 #[inline(always)]
 fn bench<const N: usize>(b: &mut test::Bencher) {
-    let mut ab = AlignedBuffer::<N>::new();
-    let buf = ab.buf();
     b.iter(|| {
+        let mut buf = [0u8; N];
         getrandom::getrandom(&mut buf[..]).unwrap();
         test::black_box(&buf);
     });
     b.bytes = N as u64;
 }
 
-// Used to benchmark the throughput of getrandom is a slightly less optimal
-// scenario. The buffer is still hot, but requires initialization.
 #[inline(always)]
-fn bench_with_init<const N: usize>(b: &mut test::Bencher) {
-    let mut ab = AlignedBuffer::<N>::new();
-    let buf = ab.buf();
+fn bench_raw<const N: usize>(b: &mut test::Bencher) {
     b.iter(|| {
-        for byte in buf.iter_mut() {
-            *byte = 0;
-        }
-        getrandom::getrandom(&mut buf[..]).unwrap();
+        let mut buf = core::mem::MaybeUninit::<[u8; N]>::uninit();
+        unsafe { getrandom::getrandom_raw(buf.as_mut_ptr().cast(), N).unwrap() };
         test::black_box(&buf);
     });
     b.bytes = N as u64;
@@ -71,8 +33,8 @@ fn bench_seed(b: &mut test::Bencher) {
     bench::<SEED>(b);
 }
 #[bench]
-fn bench_seed_init(b: &mut test::Bencher) {
-    bench_with_init::<SEED>(b);
+fn bench_seed_raw(b: &mut test::Bencher) {
+    bench_raw::<SEED>(b);
 }
 
 #[bench]
@@ -80,8 +42,8 @@ fn bench_page(b: &mut test::Bencher) {
     bench::<PAGE>(b);
 }
 #[bench]
-fn bench_page_init(b: &mut test::Bencher) {
-    bench_with_init::<PAGE>(b);
+fn bench_page_raw(b: &mut test::Bencher) {
+    bench_raw::<PAGE>(b);
 }
 
 #[bench]
@@ -89,6 +51,6 @@ fn bench_large(b: &mut test::Bencher) {
     bench::<LARGE>(b);
 }
 #[bench]
-fn bench_large_init(b: &mut test::Bencher) {
-    bench_with_init::<LARGE>(b);
+fn bench_large_raw(b: &mut test::Bencher) {
+    bench_raw::<LARGE>(b);
 }

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -10,8 +10,9 @@
 use crate::util_libc::sys_fill_exact;
 use crate::Error;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    sys_fill_exact(dest, |buf| unsafe {
-        libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0)
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
+    // TODO: use `cast` on MSRV bump to 1.38
+    sys_fill_exact(dst, len, |cdst, clen| {
+        libc::getrandom(cdst as *mut libc::c_void, clen, 0)
     })
 }

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -7,22 +7,20 @@
 // except according to those terms.
 
 //! Implementation for FreeBSD and NetBSD
-use crate::{util_libc::sys_fill_exact, Error};
+use crate::{util::raw_chunks, util_libc::sys_fill_exact, Error};
 use core::ptr;
 
-fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
+unsafe fn kern_arnd(dst: *mut u8, mut len: usize) -> libc::ssize_t {
     static MIB: [libc::c_int; 2] = [libc::CTL_KERN, libc::KERN_ARND];
-    let mut len = buf.len();
-    let ret = unsafe {
-        libc::sysctl(
-            MIB.as_ptr(),
-            MIB.len() as libc::c_uint,
-            buf.as_mut_ptr() as *mut _,
-            &mut len,
-            ptr::null(),
-            0,
-        )
-    };
+    // TODO: use `cast` on MSRV bump to 1.38
+    let ret = libc::sysctl(
+        MIB.as_ptr(),
+        MIB.len() as libc::c_uint,
+        dst as *mut libc::c_void,
+        &mut len,
+        ptr::null(),
+        0,
+    );
     if ret == -1 {
         -1
     } else {
@@ -30,7 +28,7 @@ fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
     }
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     // getrandom(2) was introduced in FreeBSD 12.0 and NetBSD 10.0
     #[cfg(target_os = "freebsd")]
     {
@@ -40,14 +38,13 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
             unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
         if let Some(fptr) = GETRANDOM.ptr() {
-            let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-            return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
+            let func: GetRandomFn = core::mem::transmute(fptr);
+            return sys_fill_exact(dst, len, |cdst, clen| func(cdst, clen, 0));
         }
     }
     // Both FreeBSD and NetBSD will only return up to 256 bytes at a time, and
     // older NetBSD kernels will fail on longer buffers.
-    for chunk in dest.chunks_mut(256) {
-        sys_fill_exact(chunk, kern_arnd)?
-    }
-    Ok(())
+    raw_chunks(dst, len, 256, |cdst, clen| {
+        sys_fill_exact(cdst, clen, |cdst2, clen2| kern_arnd(cdst2, clen2))
+    })
 }

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -90,11 +90,11 @@ macro_rules! register_custom_getrandom {
 }
 
 #[allow(dead_code)]
-pub fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     extern "C" {
         fn __getrandom_custom(dst: *mut u8, len: usize) -> u32;
     }
-    let ret = unsafe { __getrandom_custom(dst, len) };
+    let ret = __getrandom_custom(dst, len);
     match NonZeroU32::new(ret) {
         None => Ok(()),
         Some(code) => Err(Error::from(code)),

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -14,13 +14,13 @@ extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
     // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
     // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
     //
     // However tracking if some of these entropy sources is enabled is way too difficult to implement here
-    unsafe { esp_fill_random(dest.as_mut_ptr().cast(), dest.len()) };
-
+    // TODO: use `cast` on MSRV bump to 1.38
+    esp_fill_random(dst as *mut c_void, len);
     Ok(())
 }

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -14,7 +14,7 @@ extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    unsafe { zx_cprng_draw(dest.as_mut_ptr(), dest.len()) }
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
+    zx_cprng_draw(dst, len);
     Ok(())
 }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -15,13 +15,12 @@ extern "C" {
     fn SecRandomCopyBytes(rnd: *const c_void, count: usize, bytes: *mut u8) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     // Apple's documentation guarantees kSecRandomDefault is a synonym for NULL.
-    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr()) };
+    let ret = SecRandomCopyBytes(null(), len, dst);
     // errSecSuccess (from SecBase.h) is always zero.
-    if ret != 0 {
-        Err(Error::IOS_SEC_RANDOM)
-    } else {
-        Ok(())
+    match ret {
+        0 => Ok(()),
+        _ => Err(Error::IOS_SEC_RANDOM),
     }
 }

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -7,15 +7,16 @@
 // except according to those terms.
 
 //! Implementation for OpenBSD
-use crate::{util_libc::last_os_error, Error};
+use crate::{util::raw_chunks, util_libc::last_os_error, Error};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     // getentropy(2) was added in OpenBSD 5.6, so we can use it unconditionally.
-    for chunk in dest.chunks_mut(256) {
-        let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
-        if ret == -1 {
-            return Err(last_os_error());
+    raw_chunks(dst, len, 256, |cdst, clen| {
+        // TODO: use `cast` on MSRV bump to 1.38
+        let ret = libc::getentropy(cdst as *mut libc::c_void, clen);
+        match ret {
+            -1 => Err(last_os_error()),
+            _ => Ok(()),
         }
-    }
-    Ok(())
+    })
 }

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -14,8 +14,8 @@ extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
+    let ret = SOLID_RNG_SampleRandomBytes(dst, len);
     if ret >= 0 {
         Ok(())
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -62,3 +62,20 @@ impl LazyBool {
         self.0.unsync_init(|| init() as usize) != 0
     }
 }
+
+pub unsafe fn raw_chunks(
+    mut dst: *mut u8,
+    mut len: usize,
+    chunk_len: usize,
+    f: impl Fn(*mut u8, usize) -> Result<(), crate::Error>,
+) -> Result<(), crate::Error> {
+    while len >= chunk_len {
+        f(dst, chunk_len)?;
+        dst = dst.add(chunk_len);
+        len -= chunk_len;
+    }
+    if len != 0 {
+        f(dst, len)?;
+    }
+    Ok(())
+}

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -7,28 +7,28 @@
 // except according to those terms.
 
 //! Implementation for VxWorks
-use crate::{util_libc::last_os_error, Error};
+use crate::{util::raw_chunks, util_libc::last_os_error, Error};
 use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
-        let ret = unsafe { libc::randSecure() };
+        let ret = libc::randSecure();
         if ret < 0 {
             return Err(Error::VXWORKS_RAND_SECURE);
         } else if ret > 0 {
             RNG_INIT.store(true, Relaxed);
             break;
         }
-        unsafe { libc::usleep(10) };
+        libc::usleep(10);
     }
 
     // Prevent overflow of i32
-    for chunk in dest.chunks_mut(i32::max_value() as usize) {
-        let ret = unsafe { libc::randABytes(chunk.as_mut_ptr(), chunk.len() as i32) };
-        if ret != 0 {
-            return Err(last_os_error());
+    raw_chunks(dst, len, i32::max_value() as usize, |cdst, clen| {
+        let ret = libc::randABytes(cdst, clen as i32);
+        match ret {
+            0 => Ok(()),
+            _ => Err(last_os_error()),
         }
-    }
-    Ok(())
+    })
 }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -11,9 +11,11 @@ use crate::Error;
 use core::num::NonZeroU32;
 use wasi::wasi_snapshot_preview1::random_get;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
+pub unsafe fn getrandom_inner(dst: *mut u8, len: usize) -> Result<(), Error> {
+    // NOTE: WASI is a 32-bit target, it can not have objects bigger
+    // than `i32::MAX - 1`, so we do not need chunking here
+    match random_get(dst as i32, len as i32) {
         0 => Ok(()),
-        err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),
+        err => Err(NonZeroU32::new_unchecked(err as u32).into()),
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,4 +1,4 @@
-use super::getrandom_impl;
+use super::getrandom;
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -9,16 +9,16 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 fn test_zero() {
     // Test that APIs are happy with zero-length requests
-    getrandom_impl(&mut [0u8; 0]).unwrap();
+    getrandom(&mut [0u8; 0]).unwrap();
 }
 
 #[test]
 fn test_diff() {
     let mut v1 = [0u8; 1000];
-    getrandom_impl(&mut v1).unwrap();
+    getrandom(&mut v1).unwrap();
 
     let mut v2 = [0u8; 1000];
-    getrandom_impl(&mut v2).unwrap();
+    getrandom(&mut v2).unwrap();
 
     let mut n_diff_bits = 0;
     for i in 0..v1.len() {
@@ -32,7 +32,7 @@ fn test_diff() {
 #[test]
 fn test_huge() {
     let mut huge = [0u8; 100_000];
-    getrandom_impl(&mut huge).unwrap();
+    getrandom(&mut huge).unwrap();
 }
 
 // On WASM, the thread API always fails/panics
@@ -53,7 +53,7 @@ fn test_multithreading() {
             let mut v = [0u8; 1000];
 
             for _ in 0..100 {
-                getrandom_impl(&mut v).unwrap();
+                getrandom(&mut v).unwrap();
                 thread::yield_now();
             }
         });

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -7,5 +7,5 @@
 )))]
 
 // Use the normal getrandom implementation on this architecture.
-use getrandom::getrandom as getrandom_impl;
+use getrandom::getrandom;
 mod common;

--- a/tests/rdrand.rs
+++ b/tests/rdrand.rs
@@ -11,5 +11,11 @@ mod rdrand;
 #[path = "../src/util.rs"]
 mod util;
 
-use rdrand::getrandom_inner as getrandom_impl;
+pub fn getrandom(dst: &mut [u8]) -> Result<(), Error> {
+    if dst.is_empty() {
+        return Ok(());
+    }
+    unsafe { rdrand::getrandom_inner(dst.as_mut_ptr(), dst.len()) }
+}
+
 mod common;


### PR DESCRIPTION
A simpler alternative to #271.

It introduces `getrandom_raw` function with the following signature:
```rust
pub unsafe fn getrandom_raw(dst: *mut u8, len: usize) -> Result<(), Error> { ... }
```

Note that `getrandom` is built on top of this function and all `getrandom_impl`s also now implement the pointer-based API. It fits quite well for all backends except the `js` one.

It allows to fill uninitialized arrays with random data.

Additionally, as a safe wrapper around `getrandom_raw` this PR adds `getrandom_uninit`:
```rust
pub fn getrandom_uninit(dst: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error> { ... }
```

Because of `MaybeUninit` MSRV gets bumped to 1.36 (the same MSRV as `rand`).

I have reworked the benchmark and I get the following results:
```
running 6 tests
test bench_large     ... bench:  26,509,202 ns/iter (+/- 131,913) = 79 MB/s
test bench_large_raw ... bench:  26,478,315 ns/iter (+/- 96,640) = 79 MB/s
test bench_page      ... bench:      52,642 ns/iter (+/- 376) = 77 MB/s
test bench_page_raw  ... bench:      52,592 ns/iter (+/- 328) = 77 MB/s
test bench_seed      ... bench:         888 ns/iter (+/- 4) = 36 MB/s
test bench_seed_raw  ... bench:         887 ns/iter (+/- 5) = 36 MB/s
```
On my (Linux-based) PC the difference between `getrandom` and `getrandom_raw` is less than 1% and barely noticeable. The former zeroizes stack-based buffer before calling `getrandom`, while the latter uses `MaybeUninit` to skip the unnecessary initialization step.