### PR TITLE
Add `getrandom_uninit_slice(dest: &mut [MaybeUninit<u8>]) -> ...`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        toolchain: [nightly, beta, stable, 1.34]
+        toolchain: [nightly, beta, stable, 1.36]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
           - os: macos-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- `getrandom_uninit` [#291]
+
+### Breaking Changes
+- Update MSRV to 1.36 [#291]
+
+[#291]: https://github.com/rust-random/getrandom/pull/291
+
 ## [0.2.8] - 2022-10-20
 ### Changed
 - The [Web Cryptography API] will now be preferred on `wasm32-unknown-unknown`

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ crate features, WASM support and Custom RNGs see the
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.34.0 or later.
+This crate requires Rust 1.36.0 or later.
 
 # License
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,4 +1,6 @@
 #![feature(test)]
+#![feature(maybe_uninit_as_bytes)]
+
 extern crate test;
 
 use std::mem::MaybeUninit;
@@ -21,16 +23,9 @@ fn bench_getrandom<const N: usize>(b: &mut test::Bencher) {
 fn bench_getrandom_uninit<const N: usize>(b: &mut test::Bencher) {
     b.bytes = N as u64;
     b.iter(|| {
-        // TODO: When the feature `maybe_uninit_as_bytes` is available, use:
-        // ```
-        // let mut buf: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
-        // getrandom::getrandom_uninit(buf.as_bytes_mut()).unwrap();
-        // test::black_box(unsafe { buf.assume_init() })
-        // ```
-        // since that is the shape we expect most callers to have.
-        let mut buf = [MaybeUninit::new(0u8); N];
-        let buf = getrandom::getrandom_uninit(&mut buf[..]).unwrap();
-        test::black_box(&buf);
+        let mut buf: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
+        let buf = getrandom::getrandom_uninit(buf.as_bytes_mut()).unwrap();
+        test::black_box(buf);
     });
 }
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -13,7 +13,7 @@ fn bench_getrandom<const N: usize>(b: &mut test::Bencher) {
     b.iter(|| {
         let mut buf = [0u8; N];
         getrandom::getrandom(&mut buf[..]).unwrap();
-        test::black_box(&buf);
+        test::black_box(buf);
     });
 }
 
@@ -24,8 +24,9 @@ fn bench_getrandom_uninit<const N: usize>(b: &mut test::Bencher) {
     b.bytes = N as u64;
     b.iter(|| {
         let mut buf: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
-        let buf = getrandom::getrandom_uninit(buf.as_bytes_mut()).unwrap();
-        test::black_box(buf);
+        let _ = getrandom::getrandom_uninit(buf.as_bytes_mut()).unwrap();
+        let buf: [u8; N] = unsafe { buf.assume_init() };
+        test::black_box(buf)
     });
 }
 

--- a/benches/mod.rs
+++ b/benches/mod.rs
@@ -1,94 +1,58 @@
 #![feature(test)]
 extern crate test;
 
-use std::{
-    alloc::{alloc_zeroed, dealloc, Layout},
-    ptr::NonNull,
-};
-
-// AlignedBuffer is like a Box<[u8; N]> except that it is always N-byte aligned
-struct AlignedBuffer<const N: usize>(NonNull<[u8; N]>);
-
-impl<const N: usize> AlignedBuffer<N> {
-    fn layout() -> Layout {
-        Layout::from_size_align(N, N).unwrap()
-    }
-
-    fn new() -> Self {
-        let p = unsafe { alloc_zeroed(Self::layout()) } as *mut [u8; N];
-        Self(NonNull::new(p).unwrap())
-    }
-
-    fn buf(&mut self) -> &mut [u8; N] {
-        unsafe { self.0.as_mut() }
-    }
-}
-
-impl<const N: usize> Drop for AlignedBuffer<N> {
-    fn drop(&mut self) {
-        unsafe { dealloc(self.0.as_ptr() as *mut u8, Self::layout()) }
-    }
-}
+use std::mem::MaybeUninit;
 
 // Used to benchmark the throughput of getrandom in an optimal scenario.
 // The buffer is hot, and does not require initialization.
 #[inline(always)]
-fn bench<const N: usize>(b: &mut test::Bencher) {
-    let mut ab = AlignedBuffer::<N>::new();
-    let buf = ab.buf();
+fn bench_getrandom<const N: usize>(b: &mut test::Bencher) {
     b.iter(|| {
+        let mut buf = [0u8; N];
         getrandom::getrandom(&mut buf[..]).unwrap();
         test::black_box(&buf);
     });
-    b.bytes = N as u64;
 }
 
 // Used to benchmark the throughput of getrandom is a slightly less optimal
 // scenario. The buffer is still hot, but requires initialization.
 #[inline(always)]
-fn bench_with_init<const N: usize>(b: &mut test::Bencher) {
-    let mut ab = AlignedBuffer::<N>::new();
-    let buf = ab.buf();
+fn bench_getrandom_uninit<const N: usize>(b: &mut test::Bencher) {
     b.iter(|| {
-        for byte in buf.iter_mut() {
-            *byte = 0;
-        }
-        getrandom::getrandom(&mut buf[..]).unwrap();
+        // TODO: When the feature `maybe_uninit_as_bytes` is available, use:
+        // ```
+        // let mut buf: MaybeUninit<[u8; N]> = MaybeUninit::uninit();
+        // getrandom::getrandom_uninit(buf.as_bytes_mut()).unwrap();
+        // test::black_box(unsafe { buf.assume_init() })
+        // ```
+        // since that is the shape we expect most callers to have.
+        let mut buf = [MaybeUninit::new(0u8); N];
+        let buf = getrandom::getrandom_uninit(&mut buf[..]).unwrap();
         test::black_box(&buf);
     });
-    b.bytes = N as u64;
 }
 
-// 32 bytes (256-bit) is the seed sized used for rand::thread_rng
-const SEED: usize = 32;
-// Common size of a page, 4 KiB
-const PAGE: usize = 4096;
-// Large buffer to get asymptotic performance, 2 MiB
-const LARGE: usize = 1 << 21;
+macro_rules! bench {
+    ( $name:ident, $size:expr ) => {
+        pub mod $name {
+            #[bench]
+            pub fn bench_getrandom(b: &mut test::Bencher) {
+                super::bench_getrandom::<{ $size }>(b);
+            }
 
-#[bench]
-fn bench_seed(b: &mut test::Bencher) {
-    bench::<SEED>(b);
-}
-#[bench]
-fn bench_seed_init(b: &mut test::Bencher) {
-    bench_with_init::<SEED>(b);
-}
-
-#[bench]
-fn bench_page(b: &mut test::Bencher) {
-    bench::<PAGE>(b);
-}
-#[bench]
-fn bench_page_init(b: &mut test::Bencher) {
-    bench_with_init::<PAGE>(b);
+            #[bench]
+            pub fn bench_getrandom_uninit(b: &mut test::Bencher) {
+                super::bench_getrandom_uninit::<{ $size }>(b);
+            }
+        }
+    };
 }
 
-#[bench]
-fn bench_large(b: &mut test::Bencher) {
-    bench::<LARGE>(b);
-}
-#[bench]
-fn bench_large_init(b: &mut test::Bencher) {
-    bench_with_init::<LARGE>(b);
-}
+// 32 bytes (256 bits) is the seed sized used for rand::thread_rng
+// and the `random` value in a ClientHello/ServerHello for TLS.
+// This is also the size of a 256-bit AES/HMAC/P-256/Curve25519 key
+// and/or nonce.
+bench!(p256, 256 / 8);
+
+// A P-384/HMAC-384 key and/or nonce.
+bench!(p384, 384 / 8);

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -9,8 +9,9 @@
 //! Implementation for Nintendo 3DS
 use crate::util_libc::sys_fill_exact;
 use crate::Error;
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr() as *mut libc::c_void, buf.len(), 0)
     })

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -8,9 +8,9 @@
 
 //! Implementation for FreeBSD and NetBSD
 use crate::{util_libc::sys_fill_exact, Error};
-use core::ptr;
+use core::{mem::MaybeUninit, ptr};
 
-fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
+fn kern_arnd(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
     static MIB: [libc::c_int; 2] = [libc::CTL_KERN, libc::KERN_ARND];
     let mut len = buf.len();
     let ret = unsafe {
@@ -30,7 +30,7 @@ fn kern_arnd(buf: &mut [u8]) -> libc::ssize_t {
     }
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in FreeBSD 12.0 and NetBSD 10.0
     #[cfg(target_os = "freebsd")]
     {
@@ -41,7 +41,9 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 
         if let Some(fptr) = GETRANDOM.ptr() {
             let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-            return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
+            return sys_fill_exact(dest, |buf| unsafe {
+                func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
+            });
         }
     }
     // Both FreeBSD and NetBSD will only return up to 256 bytes at a time, and

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -12,8 +12,9 @@ use crate::{
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
+use std::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
 

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -8,13 +8,13 @@
 
 //! Implementation for ESP-IDF
 use crate::Error;
-use core::ffi::c_void;
+use core::{ffi::c_void, mem::MaybeUninit};
 
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
     // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
     // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -8,13 +8,14 @@
 
 //! Implementation for Fuchsia Zircon
 use crate::Error;
+use core::mem::MaybeUninit;
 
 #[link(name = "zircon")]
 extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    unsafe { zx_cprng_draw(dest.as_mut_ptr(), dest.len()) }
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { zx_cprng_draw(dest.as_mut_ptr() as *mut u8, dest.len()) }
     Ok(())
 }

--- a/src/ios.rs
+++ b/src/ios.rs
@@ -8,16 +8,16 @@
 
 //! Implementation for iOS
 use crate::Error;
-use core::{ffi::c_void, ptr::null};
+use core::{ffi::c_void, mem::MaybeUninit, ptr::null};
 
 #[link(name = "Security", kind = "framework")]
 extern "C" {
     fn SecRandomCopyBytes(rnd: *const c_void, count: usize, bytes: *mut u8) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Apple's documentation guarantees kSecRandomDefault is a synonym for NULL.
-    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr()) };
+    let ret = unsafe { SecRandomCopyBytes(null(), dest.len(), dest.as_mut_ptr() as *mut u8) };
     // errSecSuccess (from SecBase.h) is always zero.
     if ret != 0 {
         Err(Error::IOS_SEC_RANDOM)

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -12,8 +12,9 @@ use crate::{
     util_libc::{last_os_error, sys_fill_exact},
     {use_file, Error},
 };
+use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Linux 3.17
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -12,17 +12,17 @@ use crate::{
     util_libc::{last_os_error, Weak},
     Error,
 };
-use core::mem;
+use core::mem::{self, MaybeUninit};
 
 type GetEntropyFn = unsafe extern "C" fn(*mut u8, libc::size_t) -> libc::c_int;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in 10.12, Rust supports 10.7+
     static GETENTROPY: Weak = unsafe { Weak::new("getentropy\0") };
     if let Some(fptr) = GETENTROPY.ptr() {
         let func: GetEntropyFn = unsafe { mem::transmute(fptr) };
         for chunk in dest.chunks_mut(256) {
-            let ret = unsafe { func(chunk.as_mut_ptr(), chunk.len()) };
+            let ret = unsafe { func(chunk.as_mut_ptr() as *mut u8, chunk.len()) };
             if ret != 0 {
                 return Err(last_os_error());
             }

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -9,7 +9,7 @@
 //! Implementation for OpenBSD
 use crate::{util_libc::last_os_error, Error};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in OpenBSD 5.6, so we can use it unconditionally.
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -29,7 +29,7 @@ type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> 
 #[cfg(target_os = "solaris")]
 type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::c_int;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Solaris 11.3 for Illumos in 2015.
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
     if let Some(fptr) = GETRANDOM.ptr() {

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -8,14 +8,14 @@
 
 //! Implementation for SOLID
 use crate::Error;
-use core::num::NonZeroU32;
+use core::{mem::MaybeUninit, num::NonZeroU32};
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
-    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr(), dest.len()) };
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr() as *mut u8, dest.len()) };
     if ret >= 0 {
         Ok(())
     } else {

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,11 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![allow(dead_code)]
-use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+use core::{
+    mem::{self, MaybeUninit},
+    ptr,
+    sync::atomic::{AtomicUsize, Ordering::Relaxed},
+};
 
 // This structure represents a lazily initialized static usize value. Useful
 // when it is preferable to just rerun initialization instead of locking.
@@ -61,4 +65,37 @@ impl LazyBool {
     pub fn unsync_init(&self, init: impl FnOnce() -> bool) -> bool {
         self.0.unsync_init(|| init() as usize) != 0
     }
+}
+
+/// Polyfill for `maybe_uninit_slice` feature's
+/// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
+/// been initialized.
+#[inline(always)]
+pub unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    mem::transmute(slice)
+}
+
+#[inline]
+pub fn uninit_slice_fill_zero(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
+    unsafe { ptr::write_bytes(slice.as_mut_ptr(), 0, slice.len()) };
+    unsafe { slice_assume_init_mut(slice) }
+}
+
+#[inline(always)]
+pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    // There is no risk of writing a `MaybeUninit<T>` into the result since
+    // the result isn't mutable.
+    unsafe { mem::transmute(slice) }
+}
+
+/// View an mutable initialized array as potentially-uninitialized.
+///
+/// This is unsafe because it allows assigning uninitialized values into
+/// `slice`, which would be undefined behavior.
+#[inline(always)]
+pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
+    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
+    mem::transmute(slice)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 #![allow(dead_code)]
 use core::{
-    mem::{self, MaybeUninit},
+    mem::MaybeUninit,
     ptr,
     sync::atomic::{AtomicUsize, Ordering::Relaxed},
 };
@@ -73,7 +73,7 @@ impl LazyBool {
 #[inline(always)]
 pub unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    mem::transmute(slice)
+    &mut *(slice as *mut [MaybeUninit<T>] as *mut [T])
 }
 
 #[inline]
@@ -87,7 +87,7 @@ pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
     // There is no risk of writing a `MaybeUninit<T>` into the result since
     // the result isn't mutable.
-    unsafe { mem::transmute(slice) }
+    unsafe { &*(slice as *const [T] as *const [MaybeUninit<T>]) }
 }
 
 /// View an mutable initialized array as potentially-uninitialized.
@@ -97,5 +97,5 @@ pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
 #[inline(always)]
 pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    mem::transmute(slice)
+    &mut *(slice as *mut [T] as *mut [MaybeUninit<T>])
 }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code)]
 use crate::Error;
 use core::{
+    mem::MaybeUninit,
     num::NonZeroU32,
     ptr::NonNull,
     sync::atomic::{fence, AtomicPtr, Ordering},
@@ -59,8 +60,8 @@ pub fn last_os_error() -> Error {
 //   - should return -1 and set errno on failure
 //   - should return the number of bytes written on success
 pub fn sys_fill_exact(
-    mut buf: &mut [u8],
-    sys_fill: impl Fn(&mut [u8]) -> libc::ssize_t,
+    mut buf: &mut [MaybeUninit<u8>],
+    sys_fill: impl Fn(&mut [MaybeUninit<u8>]) -> libc::ssize_t,
 ) -> Result<(), Error> {
     while !buf.is_empty() {
         let res = sys_fill(buf);

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -8,9 +8,12 @@
 
 //! Implementation for VxWorks
 use crate::{util_libc::last_os_error, Error};
-use core::sync::atomic::{AtomicBool, Ordering::Relaxed};
+use core::{
+    mem::MaybeUninit,
+    sync::atomic::{AtomicBool, Ordering::Relaxed},
+};
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };
@@ -25,7 +28,7 @@ pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
 
     // Prevent overflow of i32
     for chunk in dest.chunks_mut(i32::max_value() as usize) {
-        let ret = unsafe { libc::randABytes(chunk.as_mut_ptr(), chunk.len() as i32) };
+        let ret = unsafe { libc::randABytes(chunk.as_mut_ptr() as *mut u8, chunk.len() as i32) };
         if ret != 0 {
             return Err(last_os_error());
         }

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -8,10 +8,10 @@
 
 //! Implementation for WASI
 use crate::Error;
-use core::num::NonZeroU32;
+use core::{mem::MaybeUninit, num::NonZeroU32};
 use wasi::wasi_snapshot_preview1::random_get;
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
         0 => Ok(()),
         err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -7,7 +7,7 @@
 // except according to those terms.
 
 use crate::Error;
-use core::{ffi::c_void, num::NonZeroU32, ptr};
+use core::{ffi::c_void, mem::MaybeUninit, num::NonZeroU32, ptr};
 
 const BCRYPT_USE_SYSTEM_PREFERRED_RNG: u32 = 0x00000002;
 
@@ -21,14 +21,14 @@ extern "system" {
     ) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [u8]) -> Result<(), Error> {
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
     for chunk in dest.chunks_mut(u32::max_value() as usize) {
         // BCryptGenRandom was introduced in Windows Vista
         let ret = unsafe {
             BCryptGenRandom(
                 ptr::null_mut(),
-                chunk.as_mut_ptr(),
+                chunk.as_mut_ptr() as *mut u8,
                 chunk.len() as u32,
                 BCRYPT_USE_SYSTEM_PREFERRED_RNG,
             )

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,4 @@
 use super::getrandom_impl;
-use core::mem::{self, MaybeUninit};
 
 #[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -10,16 +9,16 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 fn test_zero() {
     // Test that APIs are happy with zero-length requests
-    getrandom_impl(unsafe { slice_as_uninit_mut(&mut [0u8; 0]) }).unwrap();
+    getrandom_impl(&mut [0u8; 0]).unwrap();
 }
 
 #[test]
 fn test_diff() {
     let mut v1 = [0u8; 1000];
-    getrandom_impl(unsafe { slice_as_uninit_mut(&mut v1) }).unwrap();
+    getrandom_impl(&mut v1).unwrap();
 
     let mut v2 = [0u8; 1000];
-    getrandom_impl(unsafe { slice_as_uninit_mut(&mut v2) }).unwrap();
+    getrandom_impl(&mut v2).unwrap();
 
     let mut n_diff_bits = 0;
     for i in 0..v1.len() {
@@ -33,7 +32,7 @@ fn test_diff() {
 #[test]
 fn test_huge() {
     let mut huge = [0u8; 100_000];
-    getrandom_impl(unsafe { slice_as_uninit_mut(&mut huge) }).unwrap();
+    getrandom_impl(&mut huge).unwrap();
 }
 
 // On WASM, the thread API always fails/panics
@@ -52,9 +51,9 @@ fn test_multithreading() {
             // wait until all the tasks are ready to go.
             rx.recv().unwrap();
             let mut v = [0u8; 1000];
-            let y = unsafe { slice_as_uninit_mut(&mut v) };
+
             for _ in 0..100 {
-                getrandom_impl(y).unwrap();
+                getrandom_impl(&mut v).unwrap();
                 thread::yield_now();
             }
         });
@@ -64,10 +63,4 @@ fn test_multithreading() {
     for tx in txs.iter() {
         tx.send(()).unwrap();
     }
-}
-
-#[inline(always)]
-unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
-    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    mem::transmute(slice)
 }

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -7,5 +7,5 @@
 )))]
 
 // Use the normal getrandom implementation on this architecture.
-use getrandom::getrandom_uninit as getrandom_impl;
+use getrandom::getrandom as getrandom_impl;
 mod common;

--- a/tests/normal.rs
+++ b/tests/normal.rs
@@ -7,5 +7,5 @@
 )))]
 
 // Use the normal getrandom implementation on this architecture.
-use getrandom::getrandom as getrandom_impl;
+use getrandom::getrandom_uninit as getrandom_impl;
 mod common;

--- a/tests/rdrand.rs
+++ b/tests/rdrand.rs
@@ -11,5 +11,10 @@ mod rdrand;
 #[path = "../src/util.rs"]
 mod util;
 
-use rdrand::getrandom_inner as getrandom_impl;
+// The rdrand implementation has the signature of getrandom_uninit(), but our
+// tests expect getrandom_impl() to have the signature of getrandom().
+fn getrandom_impl(dest: &mut [u8]) -> Result<(), Error> {
+    rdrand::getrandom_inner(unsafe { util::slice_as_uninit_mut(dest) })?;
+    Ok(())
+}
 mod common;


### PR DESCRIPTION
Add a public API for filling an `&mut [MaybeUninit<u8>]`. This will primarily serve as the building block for more typeful APIs for constructing random arrays.

Fixes #226.