### PR TITLE
Add back empty slice check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -322,7 +322,9 @@ pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
 /// ```
 #[inline]
 pub fn getrandom_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error> {
-    imp::getrandom_inner(dest)?;
+    if !dest.is_empty() {
+        imp::getrandom_inner(dest)?;
+    }
     // SAFETY: `dest` has been fully initialized by `imp::getrandom_inner`
     // since it returned `Ok`.
     Ok(unsafe { slice_assume_init_mut(dest) })


### PR DESCRIPTION
https://github.com/rust-random/getrandom/pull/291 inadvertantly removed this check

See https://github.com/rust-random/getrandom/pull/104 for why this was added in the first place. Also, per our docs:

> If `dest` is empty, `getrandom` immediately returns success, making
> no calls to the underlying operating system.

Signed-off-by: Joe Richey <joerichey@google.com>