### PR TITLE
Tests: Use custom tests to verify operations on empty slices are no-ops.

### DIFF
--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -6,45 +6,7 @@
     not(feature = "js")
 ))]
 
-use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(feature = "test-in-browser")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+use getrandom::getrandom as getrandom_impl;
 
-use core::{
-    num::NonZeroU32,
-    sync::atomic::{AtomicU8, Ordering},
-};
-use getrandom::{getrandom, register_custom_getrandom, Error};
-
-fn len7_err() -> Error {
-    NonZeroU32::new(Error::INTERNAL_START + 7).unwrap().into()
-}
-
-fn super_insecure_rng(buf: &mut [u8]) -> Result<(), Error> {
-    // Length 7 buffers return a custom error
-    if buf.len() == 7 {
-        return Err(len7_err());
-    }
-    // Otherwise, increment an atomic counter
-    static COUNTER: AtomicU8 = AtomicU8::new(0);
-    for b in buf {
-        *b = COUNTER.fetch_add(1, Ordering::Relaxed);
-    }
-    Ok(())
-}
-
-register_custom_getrandom!(super_insecure_rng);
-
-#[test]
-fn custom_rng_output() {
-    let mut buf = [0u8; 4];
-    assert_eq!(getrandom(&mut buf), Ok(()));
-    assert_eq!(buf, [0, 1, 2, 3]);
-    assert_eq!(getrandom(&mut buf), Ok(()));
-    assert_eq!(buf, [4, 5, 6, 7]);
-}
-
-#[test]
-fn rng_err_output() {
-    assert_eq!(getrandom(&mut [0; 7]), Err(len7_err()));
-}
+mod common;
+mod custom_common;

--- a/tests/custom_common/mod.rs
+++ b/tests/custom_common/mod.rs
@@ -1,0 +1,25 @@
+// Common infrastructure for the custom* test suites (only).
+use core::{
+    num::NonZeroU32,
+    sync::atomic::{AtomicU8, Ordering},
+};
+use getrandom::{register_custom_getrandom, Error};
+
+pub fn len7_err() -> Error {
+    NonZeroU32::new(Error::INTERNAL_START + 7).unwrap().into()
+}
+
+fn super_insecure_rng(buf: &mut [u8]) -> Result<(), Error> {
+    // Length 7 buffers return a custom error
+    if buf.len() == 7 {
+        return Err(len7_err());
+    }
+    // Otherwise, increment an atomic counter
+    static COUNTER: AtomicU8 = AtomicU8::new(0);
+    for b in buf {
+        *b = COUNTER.fetch_add(1, Ordering::Relaxed);
+    }
+    Ok(())
+}
+
+register_custom_getrandom!(super_insecure_rng);

--- a/tests/custom_common/mod.rs
+++ b/tests/custom_common/mod.rs
@@ -10,6 +10,9 @@ pub fn len7_err() -> Error {
 }
 
 fn super_insecure_rng(buf: &mut [u8]) -> Result<(), Error> {
+    // `getrandom` guarantees it will not call any implementation if the output
+    // buffer is empty.
+    assert!(!buf.is_empty());
     // Length 7 buffers return a custom error
     if buf.len() == 7 {
         return Err(len7_err());

--- a/tests/custom_kat.rs
+++ b/tests/custom_kat.rs
@@ -1,0 +1,33 @@
+// Test that a custom handler works on wasm32-unknown-unknown.
+#![cfg(all(
+    target_arch = "wasm32",
+    target_os = "unknown",
+    feature = "custom",
+    not(feature = "js")
+))]
+
+use wasm_bindgen_test::wasm_bindgen_test as test;
+#[cfg(feature = "test-in-browser")]
+wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+mod custom_common;
+
+use custom_common::len7_err;
+use getrandom::getrandom;
+
+// This known-answer test cannot be in the same test suite as any other
+// tests that use the `custom_common` implementation since the known answers
+// depend on the exact state of `custom_common`.
+#[test]
+fn custom_rng_output() {
+    let mut buf = [0u8; 4];
+    assert_eq!(getrandom(&mut buf), Ok(()));
+    assert_eq!(buf, [0, 1, 2, 3]);
+    assert_eq!(getrandom(&mut buf), Ok(()));
+    assert_eq!(buf, [4, 5, 6, 7]);
+}
+
+#[test]
+fn rng_err_output() {
+    assert_eq!(getrandom(&mut [0; 7]), Err(len7_err()));
+}


### PR DESCRIPTION
Modify the custom tests so that they would have detected and prevented the issue fixed in https://github.com/rust-random/getrandom/pull/298.