### PR TITLE
Tests: Use custom tests to verify operations on empty slices are no-ops.

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,6 +13,7 @@ fn test_zero() {
 }
 
 #[test]
+#[cfg(not(feature = "custom"))]
 fn test_diff() {
     let mut v1 = [0u8; 1000];
     getrandom_impl(&mut v1).unwrap();

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -7,8 +7,6 @@
 ))]
 
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(feature = "test-in-browser")]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 use core::num::NonZeroU32;
 use getrandom::{getrandom, register_custom_getrandom, Error};
@@ -32,6 +30,9 @@ fn super_insecure_rng(buf: &mut [u8]) -> Result<(), Error> {
 }
 
 register_custom_getrandom!(super_insecure_rng);
+
+use getrandom::getrandom as getrandom_impl;
+mod common;
 
 #[test]
 fn custom_rng_output() {

--- a/tests/custom.rs
+++ b/tests/custom.rs
@@ -16,6 +16,9 @@ fn len7_err() -> Error {
 }
 
 fn super_insecure_rng(buf: &mut [u8]) -> Result<(), Error> {
+    // `getrandom` guarantees it will not call any implementation if the output
+    // buffer is empty.
+    assert!(!buf.is_empty());
     // Length 7 buffers return a custom error
     if buf.len() == 7 {
         return Err(len7_err());


### PR DESCRIPTION
Reworking of #299 to keep our custom tests in a single file (and keep things better organized in general).

The individual commits are meaningful here, so we should "merge" rather than "squash" this PR.