### PR TITLE
Fix Solaris/OpenBSD/Dragonfly build and re-enable CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -287,7 +287,7 @@ jobs:
         with:
           profile: minimal
           target: ${{ matrix.target }}
-          toolchain: nightly # Required to build libc for Redox
+          toolchain: stable
           override: true
       - uses: Swatinem/rust-cache@v1
       - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,6 +319,8 @@ jobs:
         run: cargo build -Z build-std=core --target=aarch64-kmc-solid_asp3
       - name: Nintendo 3DS
         run: cargo build -Z build-std=core --target=armv6k-nintendo-3ds
+      - name: RISC-V ESP-IDF
+        run: cargo build -Z build-std=core --target=riscv32imc-esp-espidf
       - name: OpenBSD
         run: cargo build -Z build-std=std --target=x86_64-unknown-openbsd --features=std
       - name: Dragonfly BSD

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,7 @@ jobs:
       matrix:
         target: [
           sparcv9-sun-solaris,
+          x86_64-unknown-freebsd,
           x86_64-unknown-netbsd,
         ]
     steps:
@@ -276,7 +277,6 @@ jobs:
     strategy:
       matrix:
         target: [
-          x86_64-unknown-freebsd,
           x86_64-fuchsia,
           x86_64-unknown-redox,
           x86_64-fortanix-unknown-sgx,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -166,8 +166,7 @@ jobs:
     strategy:
       matrix:
         target: [
-          # See: https://github.com/rust-random/getrandom/issues/254
-          # sparcv9-sun-solaris,
+          sparcv9-sun-solaris,
           x86_64-unknown-netbsd,
         ]
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -167,6 +167,7 @@ jobs:
       matrix:
         target: [
           sparcv9-sun-solaris,
+          x86_64-unknown-illumos,
           x86_64-unknown-freebsd,
           x86_64-unknown-netbsd,
         ]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -319,6 +319,12 @@ jobs:
         run: cargo build -Z build-std=core --target=aarch64-kmc-solid_asp3
       - name: Nintendo 3DS
         run: cargo build -Z build-std=core --target=armv6k-nintendo-3ds
+      - name: OpenBSD
+        run: cargo build -Z build-std=std --target=x86_64-unknown-openbsd --features=std
+      - name: Dragonfly BSD
+        run: cargo build -Z build-std=std --target=x86_64-unknown-dragonfly --features=std
+      - name: Haiku OS
+        run: cargo build -Z build-std=std --target=x86_64-unknown-haiku --features=std
 
   clippy-fmt:
     name: Clippy + rustfmt

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -12,7 +12,7 @@ use crate::{
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
-use std::mem::MaybeUninit;
+use core::mem::MaybeUninit;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
@@ -21,7 +21,9 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in DragonflyBSD 5.7
     if let Some(fptr) = GETRANDOM.ptr() {
         let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-        return sys_fill_exact(dest, |buf| unsafe { func(buf.as_mut_ptr(), buf.len(), 0) });
+        return sys_fill_exact(dest, |buf| unsafe {
+            func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
+        });
     } else {
         use_file::getrandom_inner(dest)
     }

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -8,6 +8,7 @@
 
 //! Implementation for OpenBSD
 use crate::{util_libc::last_os_error, Error};
+use core::mem::MaybeUninit;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getentropy(2) was added in OpenBSD 5.6, so we can use it unconditionally.

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -22,7 +22,7 @@ use crate::{
     util_libc::{sys_fill_exact, Weak},
     Error,
 };
-use core::mem;
+use core::mem::{self, MaybeUninit};
 
 #[cfg(target_os = "illumos")]
 type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
@@ -38,7 +38,7 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         // derived platforms for atomically obtaining random data.
         for chunk in dest.chunks_mut(256) {
             sys_fill_exact(chunk, |buf| unsafe {
-                func(buf.as_mut_ptr(), buf.len(), 0) as libc::ssize_t
+                func(buf.as_mut_ptr() as *mut u8, buf.len(), 0) as libc::ssize_t
             })?
         }
         Ok(())


### PR DESCRIPTION
Fixes #216 

This also adds two minor CI improvements:
  - Do a full link on `freebsd`
  - Build, Link, but don't run on `illumos`
  - Use the stable toolchain for our Tier 2 Build-only targets
  - Build (via `build-std`) for Tier 3 targets: `openbsd`, `dragonfly`, `haiku`

Signed-off-by: Joe Richey <joerichey@google.com>