### PR TITLE
Add additional, sharper tests for checking RNG quality

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,11 +16,10 @@ fn test_zero() {
 #[cfg(not(feature = "custom"))]
 fn num_diff_bits(s1: &[u8], s2: &[u8]) -> usize {
     assert_eq!(s1.len(), s2.len());
-    let mut n = 0;
-    for i in 0..s1.len() {
-        n += (s1[i] ^ s2[i]).count_ones() as usize;
-    }
-    n
+    s1.iter()
+        .zip(s2.iter())
+        .map(|(a, b)| (a ^ b).count_ones() as usize)
+        .sum()
 }
 
 // Tests the quality of calling getrandom on two large buffers


### PR DESCRIPTION
This PR adds some tests which make sure calls to getrandom (for both small and large buffers) "look" random.

While we could certainly add more complicated randomness tests, these simple tests are:
  - Very easy to understand
  - Don't require any external crates
  - Makes sure we aren't doing something obviously stupid like
    - forgetting [these lines](https://github.com/rust-random/getrandom/blob/bd0654fe70980583e51573e755bafa3b2f8342d9/src/rdrand.rs#L91-L95)
    - failing to initialize every other byte
    - initializing some significant fraction of bytes with a constant

As this tests all buffer sizes from 1 to 64, it also fixes #290.