### PR TITLE
Cleanup wasm32-wasi target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 libc = { version = "0.2.120", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
-wasi = "0.11"
+wasi = { version = "0.11", default-features = false }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -238,7 +238,7 @@ cfg_if! {
     } else if #[cfg(target_os = "openbsd")] {
         mod util_libc;
         #[path = "openbsd.rs"] mod imp;
-    } else if #[cfg(target_os = "wasi")] {
+    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi"))] {
         #[path = "wasi.rs"] mod imp;
     } else if #[cfg(all(target_arch = "x86_64", target_os = "hermit"))] {
         #[path = "rdrand.rs"] mod imp;

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -8,12 +8,18 @@
 
 //! Implementation for WASI
 use crate::Error;
-use core::{mem::MaybeUninit, num::NonZeroU32};
-use wasi::wasi_snapshot_preview1::random_get;
+use core::{
+    mem::MaybeUninit,
+    num::{NonZeroU16, NonZeroU32},
+};
+use wasi::random_get;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    match unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) } {
-        0 => Ok(()),
-        err => Err(unsafe { NonZeroU32::new_unchecked(err as u32) }.into()),
-    }
+    unsafe { random_get(dest.as_mut_ptr() as *mut u8, dest.len()) }.map_err(|e| {
+        // The WASI errno will always be non-zero, but we check just in case.
+        match NonZeroU16::new(e.raw()) {
+            Some(r) => Error::from(NonZeroU32::from(r)),
+            None => Error::ERRNO_NOT_POSITIVE,
+        }
+    })
 }


### PR DESCRIPTION
This change ensures that we only compile our WASI implementation for 32-bit targets. The interaction between the WASI proposal and the memory64 proposal is not yet clear, [wasmtime does not yet support]( https://github.com/bytecodealliance/wasmtime/issues/3594#issuecomment-992590383) using WASI with memory64, and many of the interfaces use 32-bit values for pointers.

This change also reduces the use of `unsafe` from the wasi implementation. As noted in #253, changes to `Errno` mean that we can't get the error message from the raw error code, but we can avoid using unsafe when converting this code to a NonZeroU32. This handling also makes WASI behave more like our other targets, which also manually check that errno is non-zero.

Signed-off-by: Joe Richey <joerichey@google.com>