### PR TITLE
Use getentropy on Emscripten

### DIFF
--- a/src/emscripten.rs
+++ b/src/emscripten.rs
@@ -1,0 +1,18 @@
+//! Implementation for Emscripten
+use crate::{util_libc::last_os_error, Error};
+use core::mem::MaybeUninit;
+
+// Not yet defined in libc crate.
+extern "C" {
+    fn getentropy(buffer: *mut libc::c_void, length: usize) -> libc::c_int;
+}
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    // Emscripten 2.0.5 added getentropy, so we can use it unconditionally.
+    // Unlike other getentropy implementations, there is no max buffer length.
+    let ret = unsafe { getentropy(dest.as_mut_ptr() as *mut libc::c_void, dest.len()) };
+    if ret < 0 {
+        return Err(last_os_error());
+    }
+    Ok(())
+}


### PR DESCRIPTION
Fixes #275, note that `libc::getentropy` isn't in the `libc` crate yet, so we have to manually declare the bindings.

The last version of the EMSDK that didn't have support for this was 2.0.4 released over two years ago, so I don't think we have to worry about users using a super old SDK version, especially considering this is an less-used target.

Signed-off-by: Joe Richey <joerichey@google.com>