### PR TITLE
CI: On Nightly toolchains, test the benchmarks instead of just building them.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,7 +61,7 @@ jobs:
       - run: cargo test --features=std
       - run: cargo test --features=custom # custom should do nothing here
       - if: ${{ matrix.toolchain == 'nightly' }}
-        run: cargo build --benches
+        run: cargo test --benches
 
   linux-tests:
     name: Additional Linux targets


### PR DESCRIPTION
`cargo test --benches` will run one iteration of each benchmark to provide evidence that they don't fail in an obvious way (e.g. unintended panics).