### PR TITLE
CI: Run iOS targets and other improvements

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,11 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly # Needed for -Z minimal-versions and doc_cfg
-          override: true
+      - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cargo-deadlinks
         run: |
@@ -51,11 +47,9 @@ jobs:
             toolchain: stable
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo test
       - run: cargo test --features=std
@@ -75,11 +69,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v1
       - name: Install multilib
         # update is needed to fix the 404 error on install, see:
@@ -103,11 +95,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
+          targets: x86_64-apple-ios
       - uses: Swatinem/rust-cache@v1
       - name: Build Tests
         run: cargo test --no-run --target=${{ matrix.target }} --features=std
@@ -124,12 +114,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@master
         with:
-          profile: minimal
           toolchain: ${{ matrix.toolchain }}
-          override: true
       - uses: Swatinem/rust-cache@v1
       - run: cargo test --features=std
 
@@ -146,11 +133,6 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
@@ -174,11 +156,6 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
@@ -194,11 +171,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          target: wasm32-unknown-unknown
-          toolchain: stable
+          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled wasm-bindgen-test-runner
         run: |
@@ -224,12 +199,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
         with:
-          profile: minimal
-          toolchain: nightly
           components: rust-src
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Build and Link tests (build-std)
         # This target is Tier 3, so we have to build libstd ourselves.
@@ -242,11 +214,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          target: wasm32-wasi
-          toolchain: stable
+          targets: wasm32-wasi
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled wasmtime
         run: |
@@ -268,12 +238,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: stable
-          override: true
+          targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v1
       - name: Build
         run: cargo build --target=${{ matrix.target }} --features=std
@@ -283,13 +250,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
-          profile: minimal
-          toolchain: nightly # Required to build libcore
           components: rust-src
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: Hermit (x86-64 only)
         run: cargo build -Z build-std=core --target=x86_64-unknown-hermit
@@ -317,14 +280,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          # https://github.com/rust-lang/rust-clippy/pull/6379 added MSRV
-          # support, so we need to use nightly until this is on stable.
-          toolchain: nightly
           components: rustfmt, clippy
-          override: true
       - uses: Swatinem/rust-cache@v1
       - name: clippy
         run: cargo clippy --all --features=custom,std

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
-      - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cargo-deadlinks
         run: |
           export URL=$(curl -s https://api.github.com/repos/deadlinks/cargo-deadlinks/releases/latest | jq -r '.assets[] | select(.name | contains("cargo-deadlinks-linux")) | .browser_download_url')
           wget -O /tmp/cargo-deadlinks $URL
           chmod +x /tmp/cargo-deadlinks
           mv /tmp/cargo-deadlinks ~/.cargo/bin
+      - uses: Swatinem/rust-cache@v2
       - name: Generate Docs
         env:
           RUSTDOCFLAGS: --cfg docsrs
@@ -51,7 +51,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test
       - run: cargo test --features=std
       - run: cargo test --features=custom # custom should do nothing here
@@ -73,13 +73,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v1
       - name: Install multilib
         # update is needed to fix the 404 error on install, see:
         # https://github.com/actions/virtual-environments/issues/675
         run: |
           sudo apt-get update
           sudo apt-get install gcc-multilib
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --target=${{ matrix.target }} --features=std
 
   ios-tests:
@@ -90,7 +90,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-ios
-      - uses: Swatinem/rust-cache@v1
       - name: Download cargo-dinghy
         run: |
           VERSION=0.6.2
@@ -103,6 +102,7 @@ jobs:
           SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 $RUNTIME_ID)
           xcrun simctl boot $SIM_ID
           echo "device=$SIM_ID" >> $GITHUB_ENV
+      - uses: Swatinem/rust-cache@v2
       - name: Run tests
         run: cargo dinghy -d ${{ env.device }} test
 
@@ -121,7 +121,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --features=std
 
   cross-tests:
@@ -137,13 +137,13 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
           export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
           wget -O /tmp/binaries.tar.gz $URL
           tar -C /tmp -xzf /tmp/binaries.tar.gz
           mv /tmp/cross ~/.cargo/bin
+      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std
 
@@ -155,7 +155,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin, aarch64-apple-ios
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --no-run --target=aarch64-apple-darwin --features=std
       - run: cargo test --no-run --target=aarch64-apple-ios --features=std
 
@@ -172,13 +172,13 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
-      - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
           export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
           wget -O /tmp/binaries.tar.gz $URL
           tar -C /tmp -xzf /tmp/binaries.tar.gz
           mv /tmp/cross ~/.cargo/bin
+      - uses: Swatinem/rust-cache@v2
       - name: Build Tests
         run: cross test --no-run --target=${{ matrix.target }} --features=std
 
@@ -190,13 +190,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - uses: Swatinem/rust-cache@v1
       - name: Install precompiled wasm-bindgen-test-runner
         run: |
           export VERSION=$(cargo metadata --format-version=1 | jq -r '.packages[] | select ( .name == "wasm-bindgen" ) | .version')
           wget -O /tmp/binaries.tar.gz https://github.com/rustwasm/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz
           tar -C /tmp -xzf /tmp/binaries.tar.gz --strip-components=1
           mv /tmp/wasm-bindgen-test-runner ~/.cargo/bin
+      - uses: Swatinem/rust-cache@v2
       - name: Test (Node)
         run: cargo test --target=wasm32-unknown-unknown --features=js
       - name: Test (Firefox)
@@ -218,7 +218,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
         with:
           components: rust-src
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Build and Link tests (build-std)
         # This target is Tier 3, so we have to build libstd ourselves.
         # We currently cannot run these tests because wasm-bindgen-test-runner
@@ -233,13 +233,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
-      - uses: Swatinem/rust-cache@v1
       - name: Install precompiled wasmtime
         run: |
           export URL=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-linux.tar.xz")) | .browser_download_url')
           wget -O /tmp/binaries.tar.xz $URL
           tar -C /tmp -xf /tmp/binaries.tar.xz --strip-components=1
           mv /tmp/wasmtime ~/.cargo/bin
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --target wasm32-wasi
 
   build-tier2:
@@ -257,7 +257,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --target=${{ matrix.target }} --features=std
 
@@ -269,7 +269,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
           components: rust-src
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: Hermit (x86-64 only)
         run: cargo build -Z build-std=core --target=x86_64-unknown-hermit
       - name: UEFI (RDRAND)
@@ -299,7 +299,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: clippy
         run: cargo clippy --all --features=custom,std
       - name: fmt

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     name: Docs, deadlinks, minimal dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cargo-deadlinks
@@ -47,7 +47,7 @@ jobs:
           - os: macos-latest
             toolchain: stable
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -69,7 +69,7 @@ jobs:
           i686-unknown-linux-musl,
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -86,7 +86,7 @@ jobs:
     name: iOS Simulator Test
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-ios
@@ -117,7 +117,7 @@ jobs:
           stable-i686-msvc,
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -136,7 +136,7 @@ jobs:
           wasm32-unknown-emscripten,
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
@@ -151,7 +151,7 @@ jobs:
     name: macOS ARM64 Build/Link
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin, aarch64-apple-ios
@@ -171,7 +171,7 @@ jobs:
           x86_64-unknown-netbsd,
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: Swatinem/rust-cache@v1
       - name: Install precompiled cross
         run: |
@@ -186,7 +186,7 @@ jobs:
     name: Web Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
@@ -214,7 +214,7 @@ jobs:
     name: wasm64 Build/Link
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
         with:
           components: rust-src
@@ -229,7 +229,7 @@ jobs:
     name: WASI Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
@@ -253,7 +253,7 @@ jobs:
           x86_64-fortanix-unknown-sgx,
         ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -265,7 +265,7 @@ jobs:
     name: Tier 3 Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
           components: rust-src

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           cargo generate-lockfile -Z minimal-versions
           cargo test --features=custom,std
 
+  # TODO: add aarch64-based macOS runner when it's supported by Github Actions
   main-tests:
     name: Tier 1 Test
     runs-on: ${{ matrix.os }}
@@ -81,26 +82,29 @@ jobs:
           sudo apt-get install gcc-multilib
       - run: cargo test --target=${{ matrix.target }} --features=std
 
-  # We can only Build/Link on these targets for now.
-  # TODO: Run the iOS binaries in the simulator
-  # TODO: build/run aarch64-apple-darwin binaries on a x86_64 Mac
-  apple-tests:
-    name: Additional Apple targets
+  ios-tests:
+    name: iOS Simulator Test
     runs-on: macos-latest
-    strategy:
-      matrix:
-        target: [
-          aarch64-apple-ios,
-          x86_64-apple-ios,
-        ]
     steps:
       - uses: actions/checkout@v2
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-ios
       - uses: Swatinem/rust-cache@v1
-      - name: Build Tests
-        run: cargo test --no-run --target=${{ matrix.target }} --features=std
+      - name: Download cargo-dinghy
+        run: |
+          VERSION=0.6.2
+          URL="https://github.com/sonos/dinghy/releases/download/${VERSION}/cargo-dinghy-macos-${VERSION}.tgz"
+          curl -L $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
+          cargo dinghy --version
+      - name: Setup Simulator
+        run: |
+          RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1)
+          SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 $RUNTIME_ID)
+          xcrun simctl boot $SIM_ID
+          echo "device=$SIM_ID" >> $GITHUB_ENV
+      - name: Run tests
+        run: cargo dinghy -d ${{ env.device }} test
 
   windows-tests:
     name: Windows Test
@@ -142,6 +146,18 @@ jobs:
           mv /tmp/cross ~/.cargo/bin
       - name: Test
         run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std
+
+  macos-link:
+    name: macOS ARM64 Build/Link
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin, aarch64-apple-ios
+      - uses: Swatinem/rust-cache@v1
+      - run: cargo test --no-run --target=aarch64-apple-darwin --features=std
+      - run: cargo test --no-run --target=aarch64-apple-ios --features=std
 
   cross-link:
     name: Cross Build/Link

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,7 +35,7 @@ jobs:
           cargo test --features=custom,std
 
   main-tests:
-    name: Main tests
+    name: Tier 1 Test
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -58,7 +58,7 @@ jobs:
         run: cargo test --benches
 
   linux-tests:
-    name: Additional Linux targets
+    name: Linux Test
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -103,7 +103,7 @@ jobs:
         run: cargo test --no-run --target=${{ matrix.target }} --features=std
 
   windows-tests:
-    name: Additional Windows targets
+    name: Windows Test
     runs-on: windows-latest
     strategy:
       matrix:
@@ -167,7 +167,7 @@ jobs:
         run: cross test --no-run --target=${{ matrix.target }} --features=std
 
   web-tests:
-    name: Web tests
+    name: Web Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -195,7 +195,7 @@ jobs:
         run: cargo test --target=wasm32-unknown-unknown --features=custom
 
   wasm64-tests:
-    name: WASM memory64
+    name: wasm64 Build/Link
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -210,7 +210,7 @@ jobs:
         run: cargo test --no-run -Z build-std=std,panic_abort --target=wasm64-unknown-unknown --features=js
 
   wasi-tests:
-    name: WASI test
+    name: WASI Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -226,8 +226,8 @@ jobs:
           mv /tmp/wasmtime ~/.cargo/bin
       - run: cargo test --target wasm32-wasi
 
-  build:
-    name: Build only
+  build-tier2:
+    name: Tier 2 Build
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -245,8 +245,8 @@ jobs:
       - name: Build
         run: cargo build --target=${{ matrix.target }} --features=std
 
-  build-std:
-    name: Build-only (build-std)
+  build-tier3:
+    name: Tier 3 Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -264,32 +264,36 @@ jobs:
   build-tier3:
     name: Tier 3 Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Supported tier 3 targets without libstd support
+        target: [
+          x86_64-unknown-hermit,
+          x86_64-wrs-vxworks,
+          aarch64-kmc-solid_asp3,
+          armv6k-nintendo-3ds,
+          riscv32imc-esp-espidf,
+        ]
+        include:
+          # Supported tier 3 targets without libstd support
+          - target: x86_64-unknown-openbsd
+            features: ["std"]
+          - target: x86_64-unknown-dragonfly
+            features: ["std"]
+          - target: x86_64-unknown-haiku
+            features: ["std"]
+          # Unsupported tier 3 targets to test the rdrand feature
+          - target: x86_64-unknown-uefi
+            features: ["rdrand"]
+          - target: x86_64-unknown-l4re-uclibc
+            features: ["rdrand"]
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - name: Hermit (x86-64 only)
-        run: cargo build -Z build-std=core --target=x86_64-unknown-hermit
-      - name: UEFI (RDRAND)
-        run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-uefi
-      - name: L4Re (RDRAND)
-        run: cargo build -Z build-std=core --features=rdrand --target=x86_64-unknown-l4re-uclibc
-      - name: VxWorks
-        run: cargo build -Z build-std=core --target=x86_64-wrs-vxworks
-      - name: SOLID
-        run: cargo build -Z build-std=core --target=aarch64-kmc-solid_asp3
-      - name: Nintendo 3DS
-        run: cargo build -Z build-std=core --target=armv6k-nintendo-3ds
-      - name: RISC-V ESP-IDF
-        run: cargo build -Z build-std=core --target=riscv32imc-esp-espidf
-      - name: OpenBSD
-        run: cargo build -Z build-std=std --target=x86_64-unknown-openbsd --features=std
-      - name: Dragonfly BSD
-        run: cargo build -Z build-std=std --target=x86_64-unknown-dragonfly --features=std
-      - name: Haiku OS
-        run: cargo build -Z build-std=std --target=x86_64-unknown-haiku --features=std
+      - run: cargo build -Z build-std=${{ contains(matrix.features, 'std') && 'std' || 'core'}} --target=${{ matrix.target }} --features="${{ join(matrix.features, ',') }}"
 
   clippy-fmt:
     name: Clippy + rustfmt


### PR DESCRIPTION
Fixes most of #194 (except being about to run on Apple Silicon).

This changes multiple things in the CI, so it might be easier to review commit by commit:
  - Move from actions-rs/toolchain to dtolnay/rust-toolchain
    - The current action we are using is unmantained: https://github.com/actions-rs/toolchain/issues/216
    - This replacement is faster, smaller, and more cachable.
    - We can also completely remove the toolchain step when testing with
    cross, as cross handles configuration of its own toolchain.
  - Make job names consistent. This makes it easier to tell on which targets we:
      - Build
      - Link
      - Run
  - Run iOS Simulator Tests
    - This builds, links, and runs the tests on `x86_64-apple-ios` using
    [`dinghy`](https://github.com/sonos/dinghy).
    - It moves the aarch64 targets which only Build/Link to their own job.
  - Update to actions/checkout@v3
  - Update to Swatinem/rust-cache@v2
  - Break up Tier 3 builds into a job for each build.
    - Makes things more parallel
