### PR TITLE
CI: Add Web Tests for Edge on Windows 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -186,31 +186,46 @@ jobs:
 
   web-tests:
     name: Web Test
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          # Reenable when Safari tests start working
+          # - os: macos-12
+          #   target: x86_64-apple-darwin
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-      - name: Install precompiled wasm-bindgen-test-runner
+      - run: choco install wget
+        if: matrix.os == 'windows-latest'
+      - name: Install precompiled wasm-pack
+        shell: bash
         run: |
-          export VERSION=$(cargo metadata --format-version=1 | jq -r '.packages[] | select ( .name == "wasm-bindgen" ) | .version')
-          wget -O /tmp/binaries.tar.gz https://github.com/rustwasm/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz
-          tar -C /tmp -xzf /tmp/binaries.tar.gz --strip-components=1
-          mv /tmp/wasm-bindgen-test-runner ~/.cargo/bin
+          VERSION=$(wget -nv -O - https://api.github.com/repos/rustwasm/wasm-pack/releases/latest | jq -r '.tag_name')
+          URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.target }}.tar.gz
+          wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
+          wasm-pack --version
       - uses: Swatinem/rust-cache@v2
       - name: Test (Node)
-        run: cargo test --target=wasm32-unknown-unknown --features=js
+        run: wasm-pack test --node --features=js
       - name: Test (Firefox)
-        env:
-          GECKODRIVER: /usr/bin/geckodriver
-        run: cargo test --target=wasm32-unknown-unknown --features=js,test-in-browser
+        run: wasm-pack test --headless --firefox --features=js,test-in-browser
       - name: Test (Chrome)
-        env:
-          CHROMEDRIVER: /usr/bin/chromedriver
-        run: cargo test --target=wasm32-unknown-unknown --features=js,test-in-browser
+        run: wasm-pack test --headless --chrome --features=js,test-in-browser
+      - name: Test (Edge)
+        if: matrix.os == 'windows-latest'
+        run: wasm-pack test --headless --chrome --chromedriver $Env:EDGEWEBDRIVER\msedgedriver.exe --features=js,test-in-browser
+      # Safari tests are broken: https://github.com/rustwasm/wasm-bindgen/issues/3004
+      # - name: Test (Safari)
+      #   if: matrix.os == 'macos-12'
+      #   run: wasm-pack test --headless --safari --features=js,test-in-browser
       - name: Test (custom getrandom)
-        run: cargo test --target=wasm32-unknown-unknown --features=custom
+        run: wasm-pack test --node --features=custom
 
   wasm64-tests:
     name: wasm64 Build/Link

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,15 +19,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/deadlinks/cargo-deadlinks/releases/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cargo-deadlinks
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=0.8.1
           URL="https://github.com/deadlinks/cargo-deadlinks/releases/download/${VERSION}/cargo-deadlinks-linux"
           wget -O ~/.cargo/bin/cargo-deadlinks $URL
           chmod +x ~/.cargo/bin/cargo-deadlinks
@@ -97,15 +91,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-ios
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/sonos/dinghy/releases/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cargo-dinghy
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=0.6.2
           URL="https://github.com/sonos/dinghy/releases/download/${VERSION}/cargo-dinghy-macos-${VERSION}.tgz"
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           cargo dinghy --version
@@ -150,15 +138,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/cross-rs/cross/releases/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cross
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=v0.2.4
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
@@ -193,15 +175,9 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/cross-rs/cross/releases/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cross
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=v0.2.4
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
@@ -228,16 +204,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: choco install wget
         if: matrix.os == 'windows-latest'
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/rustwasm/wasm-pack/releases/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=v0.10.3
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.target }}.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version
@@ -281,15 +251,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
-      - uses: octokit/request-action@v2.x
-        id: latest
-        with:
-          route: GET /repos/cross-rs/bytecodealliance/wasmtime/latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled wasmtime
         run: |
-          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          VERSION=v2.0.0
           URL=https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz
           wget -O - $URL | tar -xJ --strip-components=1 -C ~/.cargo/bin
           wasmtime --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,19 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/deadlinks/cargo-deadlinks/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cargo-deadlinks
         run: |
-          export URL=$(curl -s https://api.github.com/repos/deadlinks/cargo-deadlinks/releases/latest | jq -r '.assets[] | select(.name | contains("cargo-deadlinks-linux")) | .browser_download_url')
-          wget -O /tmp/cargo-deadlinks $URL
-          chmod +x /tmp/cargo-deadlinks
-          mv /tmp/cargo-deadlinks ~/.cargo/bin
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          URL="https://github.com/deadlinks/cargo-deadlinks/releases/download/${VERSION}/cargo-deadlinks-linux"
+          wget -O ~/.cargo/bin/cargo-deadlinks $URL
+          chmod +x ~/.cargo/bin/cargo-deadlinks
+          cargo deadlinks --version
       - uses: Swatinem/rust-cache@v2
       - name: Generate Docs
         env:
@@ -90,11 +97,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-apple-ios
-      - name: Download cargo-dinghy
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/sonos/dinghy/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install precompiled cargo-dinghy
         run: |
-          VERSION=0.6.2
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
           URL="https://github.com/sonos/dinghy/releases/download/${VERSION}/cargo-dinghy-macos-${VERSION}.tgz"
-          curl -L $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
+          wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           cargo dinghy --version
       - name: Setup Simulator
         run: |
@@ -137,12 +150,18 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/cross-rs/cross/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cross
         run: |
-          export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.gz $URL
-          tar -C /tmp -xzf /tmp/binaries.tar.gz
-          mv /tmp/cross ~/.cargo/bin
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
+          wget -O - $URL | tar -xz -C ~/.cargo/bin
+          cross --version
       - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std
@@ -174,12 +193,18 @@ jobs:
         ]
     steps:
       - uses: actions/checkout@v3
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/cross-rs/cross/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled cross
         run: |
-          export URL=$(curl -s https://api.github.com/repos/cross-rs/cross/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-unknown-linux-gnu.tar.gz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.gz $URL
-          tar -C /tmp -xzf /tmp/binaries.tar.gz
-          mv /tmp/cross ~/.cargo/bin
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
+          wget -O - $URL | tar -xz -C ~/.cargo/bin
+          cross --version
       - uses: Swatinem/rust-cache@v2
       - name: Build Tests
         run: cross test --no-run --target=${{ matrix.target }} --features=std
@@ -203,10 +228,16 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - run: choco install wget
         if: matrix.os == 'windows-latest'
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/rustwasm/wasm-pack/releases/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=$(wget -nv -O - https://api.github.com/repos/rustwasm/wasm-pack/releases/latest | jq -r '.tag_name')
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.target }}.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version
@@ -250,12 +281,18 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
+      - uses: octokit/request-action@v2.x
+        id: latest
+        with:
+          route: GET /repos/cross-rs/bytecodealliance/wasmtime/latest
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Install precompiled wasmtime
         run: |
-          export URL=$(curl -s https://api.github.com/repos/bytecodealliance/wasmtime/releases/latest | jq -r '.assets[] | select(.name | contains("x86_64-linux.tar.xz")) | .browser_download_url')
-          wget -O /tmp/binaries.tar.xz $URL
-          tar -C /tmp -xf /tmp/binaries.tar.xz --strip-components=1
-          mv /tmp/wasmtime ~/.cargo/bin
+          VERSION=${{ fromJson(steps.latest.outputs.data).tag_name }}
+          URL=https://github.com/bytecodealliance/wasmtime/releases/download/${VERSION}/wasmtime-${VERSION}-x86_64-linux.tar.xz
+          wget -O - $URL | tar -xJ --strip-components=1 -C ~/.cargo/bin
+          wasmtime --version
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --target wasm32-wasi
 


### PR DESCRIPTION
Fixes most of #320 (except that Safari tests are currently broken)

This changes the CI to use `wasm-pack` for tests (instead of manually downloading/invoking `wasm-bindgen-test-runner`)

Because the most of the job time is spent on setup and installation, I decided to also run Node/Chrome/Firefox tests on Windows (they are already installed).

I also cleaned up our out binary download steps to:
  - be more consistent
  - Always use `wget` instead of `curl` (makes debugging easier)
  - Just pin the versions of `cargo-deadlinks`, `cargo-dinghy`, `cross`, `wasm-pack`, and `wasmtime` that we download
    - This avoids API rate limiting (causing macOS test flakes)
    - Avoids complexity in using https://github.com/octokit/request-action to get the latest version
    - Avoids our CI breaking if a project changes the format of their artifacts.