### PR TITLE
Fix iOS simulator CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
 
   ios-tests:
     name: iOS Simulator Test
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
The upgrade to macOS 12 broke this iOS simulator CI (as support for the iPhone 7 was dropped I think).

We should have a follow up PR to see if we can just test against a more recent iPhone.

Signed-off-by: Joe Richey <joerichey@google.com>