### PR TITLE
Improve CI and update runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -192,12 +192,12 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
+            host: x86_64-unknown-linux-musl
           - os: windows-latest
-            target: x86_64-pc-windows-msvc
+            host: x86_64-pc-windows-msvc
           # Reenable when Safari tests start working
           # - os: macos-12
-          #   target: x86_64-apple-darwin
+          #   host: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -208,7 +208,7 @@ jobs:
         shell: bash
         run: |
           VERSION=v0.10.3
-          URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.target }}.tar.gz
+          URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.host }}.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,9 +94,15 @@ jobs:
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           cargo dinghy --version
       - name: Setup Simulator
+        # Use the first installed iOS runtime and the first (i.e. oldest) supported iPhone device.
         run: |
-          RUNTIME_ID=$(xcrun simctl list runtimes | grep iOS | cut -d ' ' -f 7 | tail -1)
-          SIM_ID=$(xcrun simctl create My-iphone7 com.apple.CoreSimulator.SimDeviceType.iPhone-7 $RUNTIME_ID)
+          RUNTIME=$(xcrun simctl list runtimes --json | jq '.runtimes | map(select(.name | contains("iOS"))) | .[0]')
+          RUNTIME_ID=$(echo $RUNTIME | jq -r '.identifier')
+          echo "Using runtime:" $RUNTIME_ID
+          DEVICE_ID=$(echo $RUNTIME | jq -r '.supportedDeviceTypes | map(select(.productFamily == "iPhone")) | .[0].identifier')
+          echo "Using device:" $DEVICE_ID
+          SIM_ID=$(xcrun simctl create Test-iPhone $DEVICE_ID $RUNTIME_ID)
+          echo "Created simulator:" $SIM_ID
           xcrun simctl boot $SIM_ID
           echo "device=$SIM_ID" >> $GITHUB_ENV
       - uses: Swatinem/rust-cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
       - run: choco install wget
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
@@ -219,11 +219,11 @@ jobs:
       - name: Test (Chrome)
         run: wasm-pack test --headless --chrome --features=js,test-in-browser
       - name: Test (Edge)
-        if: matrix.os == 'windows-latest'
+        if: runner.os == 'Windows'
         run: wasm-pack test --headless --chrome --chromedriver $Env:EDGEWEBDRIVER\msedgedriver.exe --features=js,test-in-browser
       # Safari tests are broken: https://github.com/rustwasm/wasm-bindgen/issues/3004
       # - name: Test (Safari)
-      #   if: matrix.os == 'macos-12'
+      #   if: runner.os == 'macOS'
       #   run: wasm-pack test --headless --safari --features=js,test-in-browser
       - name: Test (custom getrandom)
         run: wasm-pack test --node --features=custom

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ env:
 jobs:
   check-doc:
     name: Docs, deadlinks, minimal dependencies
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-22.04, windows-latest]
         toolchain: [nightly, beta, stable, 1.36]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
@@ -61,7 +61,7 @@ jobs:
 
   linux-tests:
     name: Linux Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [
@@ -127,7 +127,7 @@ jobs:
 
   cross-tests:
     name: Cross Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [
@@ -164,7 +164,7 @@ jobs:
 
   cross-link:
     name: Cross Build/Link
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [
@@ -191,7 +191,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: ubuntu-22.04
             host: x86_64-unknown-linux-musl
           - os: windows-latest
             host: x86_64-pc-windows-msvc
@@ -230,7 +230,7 @@ jobs:
 
   wasm64-tests:
     name: wasm64 Build/Link
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
@@ -245,7 +245,7 @@ jobs:
 
   wasi-tests:
     name: WASI Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -262,7 +262,7 @@ jobs:
 
   build-tier2:
     name: Tier 2 Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         target: [
@@ -281,7 +281,7 @@ jobs:
 
   build-tier3:
     name: Tier 3 Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # Supported tier 3 targets without libstd support
@@ -318,7 +318,7 @@ jobs:
 
   clippy-fmt:
     name: Clippy + rustfmt
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-latest]
+        os: [ubuntu-22.04, windows-2022]
         toolchain: [nightly, beta, stable, 1.36]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
@@ -105,7 +105,7 @@ jobs:
 
   windows-tests:
     name: Windows Test
-    runs-on: windows-latest
+    runs-on: windows-2022
     strategy:
       matrix:
         toolchain: [
@@ -189,7 +189,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             host: x86_64-unknown-linux-musl
-          - os: windows-latest
+          - os: windows-2022
             host: x86_64-pc-windows-msvc
           # Reenable when Safari tests start working
           # - os: macos-12

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,11 +75,7 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - name: Install multilib
-        # update is needed to fix the 404 error on install, see:
-        # https://github.com/actions/virtual-environments/issues/675
-        run: |
-          sudo apt-get update
-          sudo apt-get install gcc-multilib
+        run: sudo apt-get install gcc-multilib
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --target=${{ matrix.target }} --features=std
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
         toolchain: [nightly, beta, stable, 1.36]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
-          - os: macos-latest
+          - os: macos-12
             toolchain: stable
     steps:
       - uses: actions/checkout@v3
@@ -81,7 +81,7 @@ jobs:
 
   ios-tests:
     name: iOS Simulator Test
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
@@ -152,7 +152,7 @@ jobs:
 
   macos-link:
     name: macOS ARM64 Build/Link
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -187,7 +187,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          # Firefox isn't available on 22.04 yet, so we must use 20.04
+          - os: ubuntu-20.04
             host: x86_64-unknown-linux-musl
           - os: windows-2022
             host: x86_64-pc-windows-msvc


### PR DESCRIPTION
As noted in #323 we were broken by the macOS image update. To avoid such things in the future, we:

- Now use `macos-12`, `ubuntu-22.04`, and `windows-2022` instead of relying on a generic "latest"
- For iOS tests, we programatically get the Runtime and Device IDs from XCode, rather than hardcoding these IDs.
  - The runtime is just the first iOS runtime installed
  - The device is just the first (i.e. oldest) iPhone device supported by the runtime
  - So on macOS 12, this is:
    - Runtime: iOS 16
    - Device:iPhone 8
- We still have to run the Web Tests on Ubuntu 20.04, as the 22.04 image dropped Firefox support (due to the [complexity of Firefox packaging on 22.04](https://evertpot.com/firefox-ubuntu-snap/)).
- This also adds a few minor cleanups around naming and removing workarounds.

The individual changes can be seen in each commit.