### PR TITLE
Add QNX/nto support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,6 +294,7 @@ jobs:
           aarch64-kmc-solid_asp3,
           armv6k-nintendo-3ds,
           riscv32imc-esp-espidf,
+          aarch64-unknown-nto-qnx710,
           # `std` support still in progress. Can be moved up with the other
           # apple targets after https://github.com/rust-lang/rust/pull/103503
           aarch64-apple-tvos,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.136", default-features = false }
+libc = { version = "0.2.139", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = { version = "0.11", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! | Web Browser and Node.js | `wasm*‑*‑unknown` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js, see [WebAssembly support]
 //! | SOLID             | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
 //! | Nintendo 3DS      | `armv6k-nintendo-3ds` | [`getrandom`][1]
+//! | QNX Neutrino      | `*‑nto-qnx*`          | [`/dev/urandom`][14] (identical to `/dev/random`)
 //!
 //! There is no blanket implementation on `unix` targets that reads from
 //! `/dev/urandom`. This ensures all supported targets are using the recommended
@@ -160,6 +161,7 @@
 //! [11]: https://docs.oracle.com/cd/E88353_01/html/E37841/getrandom-2.html
 //! [12]: https://docs.oracle.com/cd/E86824_01/html/E54777/random-7d.html
 //! [13]: https://github.com/emscripten-core/emscripten/pull/12240
+//! [14]: https://www.qnx.com/developers/docs/7.1/index.html#com.qnx.doc.neutrino.utilities/topic/r/random.html
 //!
 //! [`BCryptGenRandom`]: https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptgenrandom
 //! [`Crypto.getRandomValues`]: https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues
@@ -209,7 +211,7 @@ pub use crate::error::Error;
 // The function MUST NOT ever write uninitialized bytes into `dest`,
 // regardless of what value it returns.
 cfg_if! {
-    if #[cfg(any(target_os = "haiku", target_os = "redox"))] {
+    if #[cfg(any(target_os = "haiku", target_os = "redox", target_os = "nto"))] {
         mod util_libc;
         #[path = "use_file.rs"] mod imp;
     } else if #[cfg(any(target_os = "android", target_os = "linux"))] {

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -21,7 +21,7 @@ use core::{
 // We prefer using /dev/urandom and only use /dev/random if the OS
 // documentation indicates that /dev/urandom is insecure.
 // On Solaris/Illumos, see src/solaris_illumos.rs
-// On Dragonfly, Haiku, and macOS, the devices are identical.
+// On Dragonfly, Haiku, macOS, and QNX Neutrino the devices are identical.
 #[cfg(any(target_os = "solaris", target_os = "illumos"))]
 const FILE_PATH: &str = "/dev/random\0";
 #[cfg(any(
@@ -30,7 +30,8 @@ const FILE_PATH: &str = "/dev/random\0";
     target_os = "redox",
     target_os = "dragonfly",
     target_os = "haiku",
-    target_os = "macos"
+    target_os = "macos",
+    target_os = "nto",
 ))]
 const FILE_PATH: &str = "/dev/urandom\0";
 

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -26,6 +26,8 @@ cfg_if! {
         use libc::__error as errno_location;
     } else if #[cfg(target_os = "haiku")] {
         use libc::_errnop as errno_location;
+    } else if #[cfg(target_os = "nto")] {
+        use libc::__get_errno_ptr as errno_location;
     } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
         extern "C" {
             // Not provided by libc: https://github.com/rust-lang/libc/issues/1995


### PR DESCRIPTION
This patch adds support to the QNX/nto operating system. This target is supported by Rust: https://github.com/rust-lang/rust/pull/102701.

cc @gh-tr