### PR TITLE
Do not use open64

### DIFF
--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -140,19 +140,11 @@ impl Weak {
     }
 }
 
-cfg_if! {
-    if #[cfg(any(target_os = "linux", target_os = "emscripten"))] {
-        use libc::open64 as open;
-    } else {
-        use libc::open;
-    }
-}
-
 // SAFETY: path must be null terminated, FD must be manually closed.
 pub unsafe fn open_readonly(path: &str) -> Result<libc::c_int, Error> {
     debug_assert_eq!(path.as_bytes().last(), Some(&0));
     loop {
-        let fd = open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
+        let fd = libc::open(path.as_ptr() as *const _, libc::O_RDONLY | libc::O_CLOEXEC);
         if fd >= 0 {
             return Ok(fd);
         }


### PR DESCRIPTION
glibc is providing open64 and other lfs64 functions but musl aliases them to normal equivalents since off_t is always 64-bit on musl, therefore check for target env along when target OS is linux before using open64, this is more available. Latest Musl has made these namespace changes [1]

[1] https://git.musl-libc.org/cgit/musl/commit/?id=246f1c811448f37a44b41cd8df8d0ef9736d95f4

Signed-off-by: Khem Raj <raj.khem@gmail.com>