### PR TITLE
Remove #cfg from bsd_arandom.rs

### DIFF
--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -7,7 +7,10 @@
 // except according to those terms.
 
 //! Implementation for FreeBSD and NetBSD
-use crate::{util_libc::sys_fill_exact, Error};
+use crate::{
+    util_libc::{sys_fill_exact, Weak},
+    Error,
+};
 use core::{mem::MaybeUninit, ptr};
 
 fn kern_arnd(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
@@ -30,22 +33,18 @@ fn kern_arnd(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
     }
 }
 
+type GetRandomFn = unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
+
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in FreeBSD 12.0 and NetBSD 10.0
-    #[cfg(any(target_os = "freebsd", target_os = "netbsd"))]
-    {
-        use crate::util_libc::Weak;
-        static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
-        type GetRandomFn =
-            unsafe extern "C" fn(*mut u8, libc::size_t, libc::c_uint) -> libc::ssize_t;
-
-        if let Some(fptr) = GETRANDOM.ptr() {
-            let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
-            return sys_fill_exact(dest, |buf| unsafe {
-                func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
-            });
-        }
+    static GETRANDOM: Weak = unsafe { Weak::new("getrandom\0") };
+    if let Some(fptr) = GETRANDOM.ptr() {
+        let func: GetRandomFn = unsafe { core::mem::transmute(fptr) };
+        return sys_fill_exact(dest, |buf| unsafe {
+            func(buf.as_mut_ptr() as *mut u8, buf.len(), 0)
+        });
     }
+
     // Both FreeBSD and NetBSD will only return up to 256 bytes at a time, and
     // older NetBSD kernels will fail on longer buffers.
     for chunk in dest.chunks_mut(256) {


### PR DESCRIPTION
Followup to #331, we don't need the condidtional compilation anymore, because this file is only used if
`any(target_os = "freebsd", target_os = "netbsd")` anyway.

Also cleans up `use` statements and type declarations to look like those in macos.rs

Signed-off-by: Joe Richey <joerichey@google.com>