### PR TITLE
Eliminate potential panic in sys_fill_exact

### DIFF
--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -8,6 +8,7 @@
 #![allow(dead_code)]
 use crate::Error;
 use core::{
+    cmp::min,
     mem::MaybeUninit,
     num::NonZeroU32,
     ptr::NonNull,
@@ -78,7 +79,8 @@ pub fn sys_fill_exact(
         } else {
             // We don't check for EOF (ret = 0) as the data we are reading
             // should be an infinite stream of random bytes.
-            buf = &mut buf[(res as usize)..];
+            let len = min(res as usize, buf.len());
+            buf = &mut buf[len..];
         }
     }
     Ok(())


### PR DESCRIPTION
In practice we should never get number of read bytes bigger than buffer length, but compiler can not prove it, so it generates a panic branch for it. This change does not help with performance (compiler still generates branch on most targets), but makes resulting binary a bit smaller.