### PR TITLE
rdrand: Remove checking for 0 and !0 and instead check CPU family and do a self-test

### DIFF
--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -45,10 +45,10 @@ unsafe fn rdrand() -> Result<[u8; WORD_SIZE], Error> {
     Err(Error::FAILED_RDRAND)
 }
 
-// "rdrand" target feature requires "+rdrnd" flag, see https://github.com/rust-lang/rust/issues/49653.
+// "rdrand" target feature requires "+rdrand" flag, see https://github.com/rust-lang/rust/issues/49653.
 #[cfg(all(target_env = "sgx", not(target_feature = "rdrand")))]
 compile_error!(
-    "SGX targets require 'rdrand' target feature. Enable by using -C target-feature=+rdrnd."
+    "SGX targets require 'rdrand' target feature. Enable by using -C target-feature=+rdrand."
 );
 
 #[cfg(target_feature = "rdrand")]

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -50,8 +50,8 @@ compile_error!(
 // Fails with probability < 2^(-90) on 32-bit systems
 #[target_feature(enable = "rdrand")]
 unsafe fn self_test() -> bool {
-    // On AMD, RDRAND returns usize::MAX on failure, count it as a collision.
-    let mut prev = usize::MAX;
+    // On AMD, RDRAND returns 0xFF...FF on failure, count it as a collision.
+    let mut prev = !0; // TODO(MSRV 1.43): Move to usize::MAX
     let mut fails = 0;
     for _ in 0..8 {
         match rdrand() {

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -5,8 +5,6 @@
 // <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
-
-//! Implementation for SGX using RDRAND instruction
 use crate::{
     util::{slice_as_uninit, LazyBool},
     Error,


### PR DESCRIPTION
Fixes #228 

This is essentially the plan discussed in https://github.com/rust-random/getrandom/issues/228#issuecomment-1407391965

I changed the `rdrand` function to return `Option<u64>` as that makes reusing it in the self-test much nicer.

The main complexity here comes from:
  - Checking if the CPU is AMD with family < 0x17
  - Performing the self test. See the [Linux implementation](https://github.com/torvalds/linux/blob/9f266ccaa2f5228bfe67ad58a94ca4e0109b954a/arch/x86/kernel/cpu/rdrand.c)

There are also some minor commits which:
  - Refer to the the correct flag name now that [`+rdrand` is supported by rustc](https://github.com/rust-lang/rust/pull/84991)
  - Update old comments