### PR TITLE
Reenable cross build/link tests and update cross

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,7 +142,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install precompiled cross
         run: |
-          VERSION=v0.2.4
+          VERSION=v0.2.5
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
@@ -171,17 +171,15 @@ jobs:
       matrix:
         target: [
           sparcv9-sun-solaris,
-          # These jobs currently result in a linking error:
-          # https://github.com/rust-random/getrandom/actions/runs/3835874649/jobs/6529484986
-          # x86_64-unknown-illumos,
-          # x86_64-unknown-freebsd,
-          # x86_64-unknown-netbsd,
+          x86_64-unknown-illumos,
+          x86_64-unknown-freebsd,
+          x86_64-unknown-netbsd,
         ]
     steps:
       - uses: actions/checkout@v3
       - name: Install precompiled cross
         run: |
-          VERSION=v0.2.4
+          VERSION=v0.2.5
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,8 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Firefox isn't available on 22.04 yet, so we must use 20.04
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             host: x86_64-unknown-linux-musl
           - os: windows-2022
             host: x86_64-pc-windows-msvc
@@ -300,7 +299,7 @@ jobs:
           aarch64-apple-tvos,
         ]
         include:
-          # Supported tier 3 targets without libstd support
+          # Supported tier 3 targets with libstd support
           - target: x86_64-unknown-openbsd
             features: ["std"]
           - target: x86_64-unknown-dragonfly


### PR DESCRIPTION
The build/link tests were failing due to certain libraries not being present. This was fixed in Cross version 0.2.5: https://github.com/cross-rs/cross/pull/1166

Earlier, I had thought these tests were failing because of improperly cached builds. However, I was wrong, the failures were due to a missing library..

Fixes #329 


This also moves our Web Tests to Ubuntu 22.04, as that image now has Firefox: https://github.com/actions/runner-images/pull/6528

Signed-off-by: Joe Richey <joerichey@google.com>