### PR TITLE
ci: Don't use rust-cache for Cross Build/Link

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,7 +146,6 @@ jobs:
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
-      - uses: Swatinem/rust-cache@v2
       - name: Test
         run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std
 
@@ -183,7 +182,6 @@ jobs:
           URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
-      - uses: Swatinem/rust-cache@v2
       - name: Build Tests
         run: cross test --no-run --target=${{ matrix.target }} --features=std
 


### PR DESCRIPTION
I think the caching isn't interacting well with the libc build script.

Lets see if this fixes things.