### PR TITLE
Mark __getrandom_custom unsafe

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -78,9 +78,9 @@ macro_rules! register_custom_getrandom {
     ($path:path) => {
         // We use an extern "C" function to get the guarantees of a stable ABI.
         #[no_mangle]
-        extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
+        unsafe extern "C" fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
             let f: fn(&mut [u8]) -> Result<(), $crate::Error> = $path;
-            let slice = unsafe { ::core::slice::from_raw_parts_mut(dest, len) };
+            let slice = ::core::slice::from_raw_parts_mut(dest, len);
             match f(slice) {
                 Ok(()) => 0,
                 Err(e) => e.code().get(),


### PR DESCRIPTION
Right now, the lack of documentation is the only thing stopping callers from directly calling `__getrandom_custom()` from safe code:

```rust
#![forbid(unsafe_code)]

use getrandom::register_custom_getrandom;
use std::ptr;

fn example(buf: &mut [u8]) -> Result<(), getrandom::Error> {
    buf[0] = 0;
    Ok(())
}

register_custom_getrandom!(example);

fn main() {
    __getrandom_custom(ptr::null_mut(), 1); // segfault
}
```

Marking the function `unsafe` should discourage this.

(Also, note that it is currently formally considered UB if an `extern "C"` function unwinds after a panic, and there is nothing in `__getrandom_custom()` to prevent the callback from unwinding through it. However, the Rust project has plans to automatically add an unwind-to-abort shim to `extern "C"` functions (rust-lang/rust#74990), so waiting for that may be simpler than adding `catch_unwind()` or a drop guard.)