### PR TITLE
ci: Fix the fuchsia tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,7 +268,7 @@ jobs:
     strategy:
       matrix:
         target: [
-          x86_64-fuchsia,
+          x86_64-unknown-fuchsia,
           x86_64-unknown-redox,
           x86_64-fortanix-unknown-sgx,
         ]


### PR DESCRIPTION
The target triple name was changed in https://github.com/rust-lang/rust/pull/106429

While `rustc` knows the old spelling of the triple, `rustup` does not, so the toolchain download was not working.