### PR TITLE
Move __getrandom_custom definition into a const block 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -268,7 +268,7 @@ jobs:
     strategy:
       matrix:
         target: [
-          x86_64-fuchsia,
+          x86_64-unknown-fuchsia,
           x86_64-unknown-redox,
           x86_64-fortanix-unknown-sgx,
         ]


### PR DESCRIPTION
This supersedes #341 (and depends on #343)

  - All the code for implementing `__getrandom_custom` is now in an
    **named** `const` block (unnamed consts require Rust 1.37)
    - I found this approch [here](https://internals.rust-lang.org/t/anonymous-modules/15441)
    - Nothing inside the block can be referenced outside of it
  - `__getrandom_custom` is marked `unsafe`
    - It can't be accessed externally, but is "logically" unsafe as it
      dereferences raw pointers
  - The type of the function is moved to a typedef, so we can check that
    the defined type matches that of `getrandom:getrandom`.
  - Use `::core::result::Result` instead of `Result`
    - Similar to use use of `from_raw_parts_mut` this prevents
      compilation errors if `Result` is redefined.

I checked that our `custom` test still worked, and that the `__getrandom_custom` function was no longer directly accessible from Rust code.

Signed-off-by: Joe Richey <joerichey@google.com>