### PR TITLE
Disable cross build/tests on Android

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -208,7 +208,7 @@ jobs:
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=v0.10.3
+          VERSION=v0.11.0
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.host }}.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -134,7 +134,9 @@ jobs:
       matrix:
         target: [
           aarch64-unknown-linux-gnu,
-          aarch64-linux-android,
+          # TODO: add Android tests back when the cross cuts a new release.
+          # See: https://github.com/cross-rs/cross/issues/1222
+          # aarch64-linux-android,
           mips-unknown-linux-gnu,
           wasm32-unknown-emscripten,
         ]


### PR DESCRIPTION
Cross is currently broken on Android, see https://github.com/cross-rs/cross/issues/1222

The bug is fixed on master, but a new release of cross hasn't come out yet.