### PR TITLE
ci: use minimal permissions for Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 12 * * 1"
 
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"


### PR DESCRIPTION
Fixes #348

we only need to read the contents of the repo to run our tests, no other permissions are needed, as we currently do not publish via our CI jobs.

Thanks to @joycebrum for bringing this to our attention.