### PR TITLE
Draft: Options API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: "0 12 * * 1"
 
+permissions:
+  contents: read
+
 env:
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: "-Dwarnings"

--- a/benches/buffer.rs
+++ b/benches/buffer.rs
@@ -3,11 +3,13 @@ extern crate test;
 
 use std::mem::MaybeUninit;
 
+use getrandom::Options;
+
 // Call getrandom on a zero-initialized stack buffer
 #[inline(always)]
 fn bench_getrandom<const N: usize>() {
     let mut buf = [0u8; N];
-    getrandom::getrandom(&mut buf).unwrap();
+    Options::DEFAULT.fill(&mut buf).unwrap();
     test::black_box(&buf as &[u8]);
 }
 
@@ -15,7 +17,7 @@ fn bench_getrandom<const N: usize>() {
 #[inline(always)]
 fn bench_getrandom_uninit<const N: usize>() {
     let mut uninit = [MaybeUninit::uninit(); N];
-    let buf: &[u8] = getrandom::getrandom_uninit(&mut uninit).unwrap();
+    let buf: &[u8] = Options::DEFAULT.fill_uninit(&mut uninit).unwrap();
     test::black_box(buf);
 }
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,25 @@
+use std::env;
+use std::process::Command;
+use std::str;
+
+fn main() {
+    let minor_ver = rustc_minor().expect("failed to get rustc version");
+
+    if minor_ver >= 40 {
+        println!("cargo:rustc-cfg=getrandom_non_exhaustive");
+    }
+}
+
+// Based on libc's implementation:
+// https://github.com/rust-lang/libc/blob/74e81a50c2528b01507e9d03f594949c0f91c817/build.rs#L168-L205
+fn rustc_minor() -> Option<u32> {
+    let rustc = env::var_os("RUSTC")?;
+    let output = Command::new(rustc).arg("--version").output().ok()?.stdout;
+    let version = str::from_utf8(&output).ok()?;
+    let mut pieces = version.split('.');
+    if pieces.next()? != "rustc 1" {
+        return None;
+    }
+    let minor = pieces.next()?;
+    minor.parse().ok()
+}


### PR DESCRIPTION
Looking through the wonderful review by @m-ou-se in https://github.com/m-ou-se/getrandom/pull/1, I realized that at some point we might need a separate API for generating hashmap seeds. This is because when generating a hashmap seed on Linux, we would not want to block waiting on the RNG to initialize.

However, **if** we decided to add a different source or configuration for the RNG one day, it wouldn't make sense to just have it be a free function in this crate. This is because with the addition of #291 (and potentially #293), we also use free functions to get the random bytes in different ways (fill a `&mut [u8]`, fill a `&mut [MaybeUninit<u8>]`, return an array).

This PR contains the proposed `Options` API:
  - The different variants of `Options` would determine the RNG source/configuration.
  - The methods on `Options` would be used to get random bytes in different ways:
    - `fill`
    - `fill_uninit`
    - `array` (not in this PR, see https://github.com/rust-random/getrandom/pull/352 for how we might add it)

Right now we only have a single option: `Options::DEFAULT`. However, in the future, we could add `Options` to:
  - use a insecure but non-blocking system source (for seeding hashmaps).
  - guarantee the function doesn't block (would return an error on most targets)
  - not use a fallback mechanism (@briansmith had something like this for ring at one point).
  - never use the custom RNG source
  - always prefere the custom RNG source if it exists

Not all of these are things we should _necessarily_ do, but this gives
us the flexibility to add such options in the future.

Bikeshed: This enum could be called `Options`/`Source`/`Config`, it could also be an opaque struct at this point rather than an enum (as we only have one variant).

Signed-off-by: Joe Richey <joerichey@google.com>