### PR TITLE
Release v0.2.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,55 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.9] - 2023-04-03
 ### Added
-- `getrandom_uninit` [#291]
+- AIX support [#282]
+- `getrandom_uninit` function [#291]
+- `wasm64-unknown-unknown` support [#303]
+- tvOS and watchOS support [#317]
+- QNX/nto support [#325]
+- Support for `getrandom` syscall on NetBSD ≥ 10.0 [#331]
+- `RtlGenRandom` fallback for non-UWP Windows [#337]
 
 ### Breaking Changes
 - Update MSRV to 1.36 [#291]
 
+### Fixed
+- Solaris/OpenBSD/Dragonfly build [#301]
+
+### Changed
+- Update MSRV to 1.36 [#291]
+- Use getentropy on Emscripten [#307]
+- Solaris: consistantly use `/dev/random` source [#310]
+- Move 3ds selection above rdrand/js/custom fallback [#312]
+- Remove buffer zeroing from Node.js implementation [#315]
+- Use `open` instead of `open64` [#326]
+- Remove #cfg from bsd_arandom.rs [#332]
+- Hermit: use `sys_read_entropy` syscall [#333]
+- Eliminate potential panic in sys_fill_exact [#334]
+- rdrand: Remove checking for 0 and !0 and instead check CPU family and do a self-test [#335]
+- Move `__getrandom_custom` definition into a const block [#344]
+- Switch the custom backend to Rust ABI [#347]
+
+[#282]: https://github.com/rust-random/getrandom/pull/282
 [#291]: https://github.com/rust-random/getrandom/pull/291
+[#301]: https://github.com/rust-random/getrandom/pull/301
+[#303]: https://github.com/rust-random/getrandom/pull/303
+[#307]: https://github.com/rust-random/getrandom/pull/307
+[#310]: https://github.com/rust-random/getrandom/pull/310
+[#312]: https://github.com/rust-random/getrandom/pull/312
+[#315]: https://github.com/rust-random/getrandom/pull/315
+[#317]: https://github.com/rust-random/getrandom/pull/317
+[#325]: https://github.com/rust-random/getrandom/pull/325
+[#326]: https://github.com/rust-random/getrandom/pull/326
+[#331]: https://github.com/rust-random/getrandom/pull/331
+[#332]: https://github.com/rust-random/getrandom/pull/332
+[#333]: https://github.com/rust-random/getrandom/pull/333
+[#334]: https://github.com/rust-random/getrandom/pull/334
+[#335]: https://github.com/rust-random/getrandom/pull/335
+[#337]: https://github.com/rust-random/getrandom/pull/337
+[#344]: https://github.com/rust-random/getrandom/pull/344
+[#347]: https://github.com/rust-random/getrandom/pull/347
 
 ## [0.2.8] - 2022-10-20
 ### Changed
@@ -340,6 +381,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.9]: https://github.com/rust-random/getrandom/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/rust-random/getrandom/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/rust-random/getrandom/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/rust-random/getrandom/compare/v0.2.5...v0.2.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.8" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.9" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -184,7 +184,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.8"
+    html_root_url = "https://docs.rs/getrandom/0.2.9"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
Closes #349 

### Added
- AIX support [#282]
- `getrandom_uninit` function [#291]
- `wasm64-unknown-unknown` support [#303]
- tvOS and watchOS support [#317]
- QNX/nto support [#325]
- Support for `getrandom` syscall on NetBSD ≥ 10.0 [#331]
- `RtlGenRandom` fallback for non-UWP Windows [#337]

### Breaking Changes
- Update MSRV to 1.36 [#291]

### Fixed
- Solaris/OpenBSD/Dragonfly build [#301]

### Changed
- Update MSRV to 1.36 [#291]
- Use getentropy on Emscripten [#307]
- Solaris: consistantly use `/dev/random` source [#310]
- Move 3ds selection above rdrand/js/custom fallback [#312]
- Remove buffer zeroing from Node.js implementation [#315]
- Use `open` instead of `open64` [#326]
- Remove #cfg from bsd_arandom.rs [#332]
- Hermit: use `sys_read_entropy` syscall [#333]
- Eliminate potential panic in sys_fill_exact [#334]
- rdrand: Remove checking for 0 and !0 and instead check CPU family and do a self-test [#335]
- Move `__getrandom_custom` definition into a const block [#344]
- Switch the custom backend to Rust ABI [#347]

[#282]: https://github.com/rust-random/getrandom/pull/282
[#291]: https://github.com/rust-random/getrandom/pull/291
[#301]: https://github.com/rust-random/getrandom/pull/301
[#303]: https://github.com/rust-random/getrandom/pull/303
[#307]: https://github.com/rust-random/getrandom/pull/307
[#310]: https://github.com/rust-random/getrandom/pull/310
[#312]: https://github.com/rust-random/getrandom/pull/312
[#315]: https://github.com/rust-random/getrandom/pull/315
[#317]: https://github.com/rust-random/getrandom/pull/317
[#325]: https://github.com/rust-random/getrandom/pull/325
[#326]: https://github.com/rust-random/getrandom/pull/326
[#331]: https://github.com/rust-random/getrandom/pull/331
[#332]: https://github.com/rust-random/getrandom/pull/332
[#333]: https://github.com/rust-random/getrandom/pull/333
[#334]: https://github.com/rust-random/getrandom/pull/334
[#335]: https://github.com/rust-random/getrandom/pull/335
[#337]: https://github.com/rust-random/getrandom/pull/337
[#344]: https://github.com/rust-random/getrandom/pull/344
[#347]: https://github.com/rust-random/getrandom/pull/347