### PR TITLE
Add support for PS Vita (armv7-sony-vita-newlibeabihf)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -297,6 +297,7 @@ jobs:
           x86_64-wrs-vxworks,
           aarch64-kmc-solid_asp3,
           armv6k-nintendo-3ds,
+          armv7-sony-vita-newlibeabihf,
           riscv32imc-esp-espidf,
           aarch64-unknown-nto-qnx710,
           # `std` support still in progress. Can be moved up with the other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.139", default-features = false }
+libc = { version = "0.2.143", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = { version = "0.11", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! | Web Browser and Node.js | `wasm*‑*‑unknown` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js, see [WebAssembly support]
 //! | SOLID             | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
 //! | Nintendo 3DS      | `armv6k-nintendo-3ds` | [`getrandom`][1]
+//! | PS Vita           | `armv7-sony-vita-newlibeabihf` | [`getentropy`][13]
 //! | QNX Neutrino      | `*‑nto-qnx*`          | [`/dev/urandom`][14] (identical to `/dev/random`)
 //! | AIX               | `*-ibm-aix`        | [`/dev/urandom`][15]
 //!
@@ -262,6 +263,9 @@ cfg_if! {
         // uses Horizon OS (it is aarch64).
         mod util_libc;
         #[path = "3ds.rs"] mod imp;
+    } else if #[cfg(target_os = "vita")] {
+        mod util_libc;
+        #[path = "vita.rs"] mod imp;
     } else if #[cfg(target_os = "emscripten")] {
         mod util_libc;
         #[path = "emscripten.rs"] mod imp;

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -29,7 +29,7 @@ cfg_if! {
         use libc::_errnop as errno_location;
     } else if #[cfg(target_os = "nto")] {
         use libc::__get_errno_ptr as errno_location;
-    } else if #[cfg(all(target_os = "horizon", target_arch = "arm"))] {
+    } else if #[cfg(any(all(target_os = "horizon", target_arch = "arm"), target_os = "vita"))] {
         extern "C" {
             // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
             fn __errno() -> *mut libc::c_int;

--- a/src/vita.rs
+++ b/src/vita.rs
@@ -1,0 +1,21 @@
+// Copyright 2021 Developers of the Rand project.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Implementation for PS Vita
+use crate::{util_libc::last_os_error, Error};
+use core::mem::MaybeUninit;
+
+pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    for chunk in dest.chunks_mut(256) {
+        let ret = unsafe { libc::getentropy(chunk.as_mut_ptr() as *mut libc::c_void, chunk.len()) };
+        if ret == -1 {
+            return Err(last_os_error());
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Overview 
Hi, the idea here is similar to #248, but for a different target.
The same logic applies here - native platform API is not used here due to its complexity and Sony's NDA.

This PR supports PS Vita via `getentropy`, which is implemented in [homebrew newlib](https://github.com/vitasdk/newlib). As of today, rust-lang/libc#3230, which adds `getentropy` to libc crate is merged but not released yet.

### Building

Currently, rust supports `armv7-sony-vita-newlibeabihf` with `core` and `alloc`, and `std` support is in progress (rust-lang/rust#110638).

### ~Draft notice~

~Waiting until `libc` is released~