### PR TITLE
custom: rename __getrandom_internal to follow Rust conventions

### DIFF
--- a/src/custom.rs
+++ b/src/custom.rs
@@ -77,7 +77,7 @@ use core::{mem::MaybeUninit, num::NonZeroU32};
 macro_rules! register_custom_getrandom {
     ($path:path) => {
         // TODO(MSRV 1.37): change to unnamed block
-        const __getrandom_internal: () = {
+        const __GETRANDOM_INTERNAL: () = {
             // We use Rust ABI to be safe against potential panics in the passed function.
             #[no_mangle]
             unsafe fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {


### PR DESCRIPTION
Fixes #368 CC: @ethever

This symbol isn't actually used anywhere, so it's fine to be renamed.

Once we are at MSRV 1.37, we can change the code to use an [unnamed `const`](https://blog.rust-lang.org/2019/08/15/Rust-1.37.0.html#using-unnamed-const-items-for-macros), for example:
```rust
const _: () = {
    // We use Rust ABI to be safe against potential panics in the passed function.
    #[no_mangle]
    unsafe fn __getrandom_custom(dest: *mut u8, len: usize) -> u32 {
```