### PR TITLE
CI: replace MIPS cross tests with PPC32

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -140,7 +140,7 @@ jobs:
           # TODO: add Android tests back when the cross cuts a new release.
           # See: https://github.com/cross-rs/cross/issues/1222
           # aarch64-linux-android,
-          mips-unknown-linux-gnu,
+          powerpc-unknown-linux-gnu,
           wasm32-unknown-emscripten,
         ]
     steps:


### PR DESCRIPTION
`mips-unknown-linux-gnu` is now a Tier 3 target: rust-lang/rust#115218.

This means we can't use it for cross tests anymore since `std` is no longer built for it.

This commit replaces it with `powerpc-unknown-linux-gnu`, a big endian Tier 2 target.