### PR TITLE
Release v0.2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.11] - 2023-11-08
+### Added
+- GNU/Hurd support [#370]
+
+### Changed
+- Renamed `__getrandom_internal` to `__GETRANDOM_INTERNAL`  [#369]
+- Updated link to Hermit docs [#374]
+
+[#369]: https://github.com/rust-random/getrandom/pull/369
+[#370]: https://github.com/rust-random/getrandom/pull/370
+[#374]: https://github.com/rust-random/getrandom/pull/374
+
 ## [0.2.10] - 2023-06-06
 ### Added
 - Support for PS Vita (`armv7-sony-vita-newlibeabihf`) [#359]
@@ -391,6 +403,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.11]: https://github.com/rust-random/getrandom/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/rust-random/getrandom/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/rust-random/getrandom/compare/v0.2.8...v0.2.9
 [0.2.8]: https://github.com/rust-random/getrandom/compare/v0.2.7...v0.2.8

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.10" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.11" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -187,7 +187,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.10"
+    html_root_url = "https://docs.rs/getrandom/0.2.11"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
### Added
- GNU/Hurd support [#370]

### Changed
- Renamed `__getrandom_internal` to `__GETRANDOM_INTERNAL`  [#369]
- Updated link to Hermit docs [#374]

[#369]: https://github.com/rust-random/getrandom/pull/369
[#370]: https://github.com/rust-random/getrandom/pull/370
[#374]: https://github.com/rust-random/getrandom/pull/374