### PR TITLE
Add support for targets without atomics

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -6,66 +6,10 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 #![allow(dead_code)]
-use core::{
-    mem::MaybeUninit,
-    ptr,
-    sync::atomic::{AtomicUsize, Ordering::Relaxed},
-};
+use core::{mem::MaybeUninit, ptr};
 
-// This structure represents a lazily initialized static usize value. Useful
-// when it is preferable to just rerun initialization instead of locking.
-// Both unsync_init and sync_init will invoke an init() function until it
-// succeeds, then return the cached value for future calls.
-//
-// Both methods support init() "failing". If the init() method returns UNINIT,
-// that value will be returned as normal, but will not be cached.
-//
-// Users should only depend on the _value_ returned by init() functions.
-// Specifically, for the following init() function:
-//      fn init() -> usize {
-//          a();
-//          let v = b();
-//          c();
-//          v
-//      }
-// the effects of c() or writes to shared memory will not necessarily be
-// observed and additional synchronization methods with be needed.
-pub struct LazyUsize(AtomicUsize);
-
-impl LazyUsize {
-    pub const fn new() -> Self {
-        Self(AtomicUsize::new(Self::UNINIT))
-    }
-
-    // The initialization is not completed.
-    pub const UNINIT: usize = usize::max_value();
-
-    // Runs the init() function at least once, returning the value of some run
-    // of init(). Multiple callers can run their init() functions in parallel.
-    // init() should always return the same value, if it succeeds.
-    pub fn unsync_init(&self, init: impl FnOnce() -> usize) -> usize {
-        // Relaxed ordering is fine, as we only have a single atomic variable.
-        let mut val = self.0.load(Relaxed);
-        if val == Self::UNINIT {
-            val = init();
-            self.0.store(val, Relaxed);
-        }
-        val
-    }
-}
-
-// Identical to LazyUsize except with bool instead of usize.
-pub struct LazyBool(LazyUsize);
-
-impl LazyBool {
-    pub const fn new() -> Self {
-        Self(LazyUsize::new())
-    }
-
-    pub fn unsync_init(&self, init: impl FnOnce() -> bool) -> bool {
-        self.0.unsync_init(|| init() as usize) != 0
-    }
-}
+#[cfg(target_has_atomic = "ptr")]
+pub use atomic::*;
 
 /// Polyfill for `maybe_uninit_slice` feature's
 /// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
@@ -98,4 +42,63 @@ pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
 pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
     &mut *(slice as *mut [T] as *mut [MaybeUninit<T>])
+}
+
+#[cfg(target_has_atomic = "ptr")]
+mod atomic {
+    use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
+    // This structure represents a lazily initialized static usize value. Useful
+    // when it is preferable to just rerun initialization instead of locking.
+    // Both unsync_init and sync_init will invoke an init() function until it
+    // succeeds, then return the cached value for future calls.
+    //
+    // Both methods support init() "failing". If the init() method returns UNINIT,
+    // that value will be returned as normal, but will not be cached.
+    //
+    // Users should only depend on the _value_ returned by init() functions.
+    // Specifically, for the following init() function:
+    //      fn init() -> usize {
+    //          a();
+    //          let v = b();
+    //          c();
+    //          v
+    //      }
+    // the effects of c() or writes to shared memory will not necessarily be
+    // observed and additional synchronization methods with be needed.
+    pub struct LazyUsize(AtomicUsize);
+
+    impl LazyUsize {
+        pub const fn new() -> Self {
+            Self(AtomicUsize::new(Self::UNINIT))
+        }
+
+        // The initialization is not completed.
+        pub const UNINIT: usize = usize::max_value();
+
+        // Runs the init() function at least once, returning the value of some run
+        // of init(). Multiple callers can run their init() functions in parallel.
+        // init() should always return the same value, if it succeeds.
+        pub fn unsync_init(&self, init: impl FnOnce() -> usize) -> usize {
+            // Relaxed ordering is fine, as we only have a single atomic variable.
+            let mut val = self.0.load(Relaxed);
+            if val == Self::UNINIT {
+                val = init();
+                self.0.store(val, Relaxed);
+            }
+            val
+        }
+    }
+
+    // Identical to LazyUsize except with bool instead of usize.
+    pub struct LazyBool(LazyUsize);
+
+    impl LazyBool {
+        pub const fn new() -> Self {
+            Self(LazyUsize::new())
+        }
+
+        pub fn unsync_init(&self, init: impl FnOnce() -> bool) -> bool {
+            self.0.unsync_init(|| init() as usize) != 0
+        }
+    }
 }


### PR DESCRIPTION
Conditionally compile LazyUsize/Bool based on whether atomics are available on the target.

Workaround for https://github.com/rust-random/getrandom/issues/383