### PR TITLE
Document platform support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ This crate requires Rust 1.36.0 or later.
 ## Platform Support
 
 This crate generally supports the same operating system and platform versions that the Rust standard library does. 
-Additional targets may be supported using plugable custom implementations.
+Additional targets may be supported using pluggable custom implementations.
 
 This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
 in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ crate features, WASM support and Custom RNGs see the
 
 This crate requires Rust 1.36.0 or later.
 
+## Platform Support
+
+This crate generally supports the same operating system and platform versions that the Rust standard library does. 
+Additional targets may be supported using plugable custom implementations.
+
+This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
+in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.
+
 # License
 
 The `getrandom` library is distributed under either of

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,6 +106,13 @@
 //! ```
 //! This crate will then use the provided `webcrypto` implementation.
 //!
+//! ### Platform Support
+//! This crate generally supports the same operating system and platform versions that the Rust standard library does.
+//! Additional targets may be supported using plugable custom implementations.
+//!
+//! This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
+//! in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.
+//!
 //! ### Custom implementations
 //!
 //! The [`register_custom_getrandom!`] macro allows a user to mark their own

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@
 //!
 //! ### Platform Support
 //! This crate generally supports the same operating system and platform versions that the Rust standard library does.
-//! Additional targets may be supported using plugable custom implementations.
+//! Additional targets may be supported using pluggable custom implementations.
 //!
 //! This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
 //! in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.


### PR DESCRIPTION
This writes down `getrandom`'s unofficial platform support policy to make it official, like I discussed a few months ago. Per that, the policy will be to track the latest `std`'s platform support and allow removing support for the OS versions that upstream Rust has decided aren't worth keeping around.

cc @newpavlov @josephlr 

Closes https://github.com/rust-random/getrandom/issues/371