### PR TITLE
Release v0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.12] - 2024-01-07
+## [0.2.12] - 2024-01-09
 ### Fixed
 - Custom backend for targets without atomics [#385]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.12] - 2024-01-07
+### Fixed
+- Custom backend for targets without atomics [#385]
 
 ### Changed
-- Raise minimum supported Apple OS versions to macOS 10.12 and iOS 10.
+- Improve robustness of the Hermit backend and `sys_fill_exact` [#386]
+- Raise minimum supported Apple OS versions to macOS 10.12 and iOS 10 [#388]
+
+### Added
+- Document platform support policy [#387]
+
+[#385]: https://github.com/rust-random/getrandom/pull/385
+[#386]: https://github.com/rust-random/getrandom/pull/386
+[#387]: https://github.com/rust-random/getrandom/pull/387
+[#388]: https://github.com/rust-random/getrandom/pull/388
 
 ## [0.2.11] - 2023-11-08
 ### Added
@@ -408,6 +419,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.12]: https://github.com/rust-random/getrandom/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/rust-random/getrandom/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/rust-random/getrandom/compare/v0.2.9...v0.2.10
 [0.2.9]: https://github.com/rust-random/getrandom/compare/v0.2.8...v0.2.9

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.11" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.12" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2018 Developers of the Rand project
+Copyright 2018-2024 Developers of the Rand project
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright 2018-2024 Developers of the Rand project
+Copyright (c) 2018-2024 The rust-random Project Developers
 Copyright (c) 2014 The Rust Project Developers
 
 Permission is hereby granted, free of charge, to any

--- a/README.md
+++ b/README.md
@@ -62,11 +62,20 @@ Additional targets may be supported using pluggable custom implementations.
 This means that as Rust drops support for old versions of operating systems (such as old Linux kernel versions, Android API levels, etc)
 in stable releases, `getrandom` may create new patch releases (`0.N.x`) that remove support for outdated platform versions.
 
-# License
+## License
 
 The `getrandom` library is distributed under either of
 
- * [Apache License, Version 2.0](LICENSE-APACHE)
- * [MIT license](LICENSE-MIT)
+ * [Apache License, Version 2.0][LICENSE-APACHE]
+ * [MIT license][LICENSE-MIT]
 
 at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+dual licensed as above, without any additional terms or conditions.
+
+[LICENSE-APACHE]: https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE
+[LICENSE-MIT]: https://github.com/rust-random/getrandom/blob/master/LICENSE-MIT

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for Nintendo 3DS
 use crate::util_libc::sys_fill_exact;
 use crate::Error;

--- a/src/3ds.rs
+++ b/src/3ds.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/apple-other.rs
+++ b/src/apple-other.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Developers of the Rand project.
+// Copyright 2023-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/apple-other.rs
+++ b/src/apple-other.rs
@@ -1,11 +1,3 @@
-// Copyright 2023-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for iOS, tvOS, and watchOS where `getentropy` is unavailable.
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for FreeBSD and NetBSD
 use crate::{
     util_libc::{sys_fill_exact, Weak},

--- a/src/bsd_arandom.rs
+++ b/src/bsd_arandom.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! An implementation which calls out to an externally defined function.
 use crate::{util::uninit_slice_fill_zero, Error};
 use core::{mem::MaybeUninit, num::NonZeroU32};

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for DragonFly BSD
 use crate::{
     use_file,

--- a/src/dragonfly.rs
+++ b/src/dragonfly.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 use core::{fmt, num::NonZeroU32};
 
 /// A small and `no_std` compatible error type

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/error_impls.rs
+++ b/src/error_impls.rs
@@ -1,10 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![cfg_attr(docsrs, doc(cfg(feature = "std")))]
 extern crate std;
 

--- a/src/error_impls.rs
+++ b/src/error_impls.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/espidf.rs
+++ b/src/espidf.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for ESP-IDF
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for Fuchsia Zircon
 use crate::Error;
 use core::mem::MaybeUninit;

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -1,3 +1,4 @@
+//! Implementation for Hermit
 use crate::Error;
 use core::{mem::MaybeUninit, num::NonZeroU32};
 

--- a/src/hurd.rs
+++ b/src/hurd.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/hurd.rs
+++ b/src/hurd.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for GNU/Hurd
 use crate::util_libc::sys_fill_exact;
 use crate::Error;

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,10 +1,4 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+//! Implementation for WASM based on Web and Node.js
 use crate::Error;
 
 extern crate std;

--- a/src/js.rs
+++ b/src/js.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Developers of the Rand project.
+// Copyright 2019-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
@@ -194,7 +194,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.11"
+    html_root_url = "https://docs.rs/getrandom/0.2.12"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,21 +150,6 @@
 //! on every call to `getrandom`, hence after the first successful call one
 //! can be reasonably confident that no errors will occur.
 //!
-//! # License
-//!
-//! The `getrandom` library is distributed under either of
-//!
-//! * [Apache License, Version 2.0][LICENSE-APACHE]
-//! * [MIT license][LICENSE-MIT]
-//!
-//! at your option.
-//!
-//! ## Contribution
-//!
-//! Unless you explicitly state otherwise, any contribution intentionally submitted
-//! for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
-//! dual licensed as above, without any additional terms or conditions.
-//!
 //! [1]: http://man7.org/linux/man-pages/man2/getrandom.2.html
 //! [2]: http://man7.org/linux/man-pages/man4/urandom.4.html
 //! [3]: https://www.unix.com/man-page/mojave/2/getentropy/
@@ -197,9 +182,6 @@
 //! [CommonJS modules]: https://nodejs.org/api/modules.html
 //! [ES modules]: https://nodejs.org/api/esm.html
 //! [`sys_read_entropy`]: https://github.com/hermit-os/kernel/blob/315f58ff5efc81d9bf0618af85a59963ff55f8b1/src/syscalls/entropy.rs#L47-L55
-//!
-//! [LICENSE-APACHE]: https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE
-//! [LICENSE-MIT]: https://github.com/rust-random/getrandom/blob/master/LICENSE-MIT
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,3 @@
-// Copyright 2019-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Interface to the operating system's random number generator.
 //!
 //! # Supported targets

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,21 @@
 //! on every call to `getrandom`, hence after the first successful call one
 //! can be reasonably confident that no errors will occur.
 //!
+//! # License
+//!
+//! The `getrandom` library is distributed under either of
+//!
+//! * [Apache License, Version 2.0][LICENSE-APACHE]
+//! * [MIT license][LICENSE-MIT]
+//!
+//! at your option.
+//!
+//! ## Contribution
+//!
+//! Unless you explicitly state otherwise, any contribution intentionally submitted
+//! for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
+//! dual licensed as above, without any additional terms or conditions.
+//!
 //! [1]: http://man7.org/linux/man-pages/man2/getrandom.2.html
 //! [2]: http://man7.org/linux/man-pages/man4/urandom.4.html
 //! [3]: https://www.unix.com/man-page/mojave/2/getentropy/
@@ -182,6 +197,9 @@
 //! [CommonJS modules]: https://nodejs.org/api/modules.html
 //! [ES modules]: https://nodejs.org/api/esm.html
 //! [`sys_read_entropy`]: https://github.com/hermit-os/kernel/blob/315f58ff5efc81d9bf0618af85a59963ff55f8b1/src/syscalls/entropy.rs#L47-L55
+//!
+//! [LICENSE-APACHE]: https://github.com/rust-random/getrandom/blob/master/LICENSE-APACHE
+//! [LICENSE-MIT]: https://github.com/rust-random/getrandom/blob/master/LICENSE-MIT
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for Linux / Android
 use crate::{
     lazy::LazyBool,

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,11 +1,3 @@
-// Copyright 2023-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for macOS
 use crate::{util_libc::last_os_error, Error};
 use core::mem::MaybeUninit;

--- a/src/macos.rs
+++ b/src/macos.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Developers of the Rand project.
+// Copyright 2023-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/openbsd.rs
+++ b/src/openbsd.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for OpenBSD
 use crate::{util_libc::last_os_error, Error};
 use core::mem::MaybeUninit;

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -1,10 +1,4 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
+//! RDRAND backend for x86(-64) targets
 use crate::{lazy::LazyBool, util::slice_as_uninit, Error};
 use core::mem::{size_of, MaybeUninit};
 

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for the Solaris family
 //!
 //! `/dev/random` uses the Hash_DRBG with SHA512 algorithm from NIST SP 800-90A.

--- a/src/solaris_illumos.rs
+++ b/src/solaris_illumos.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for SOLID
 use crate::Error;
 use core::{mem::MaybeUninit, num::NonZeroU32};

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Developers of the Rand project.
+// Copyright 2023-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -1,11 +1,3 @@
-// Copyright 2023-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementations that just need to read from a file
 use crate::{
     util_libc::{open_readonly, sys_fill_exact},

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Developers of the Rand project.
+// Copyright 2019-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,3 @@
-// Copyright 2019-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![allow(dead_code)]
 use core::{mem::MaybeUninit, ptr};
 

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -1,4 +1,4 @@
-// Copyright 2019 Developers of the Rand project.
+// Copyright 2019-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -1,10 +1,3 @@
-// Copyright 2019-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
 #![allow(dead_code)]
 use crate::Error;
 use core::{

--- a/src/vita.rs
+++ b/src/vita.rs
@@ -1,11 +1,3 @@
-// Copyright 2021-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for PS Vita
 use crate::{util_libc::last_os_error, Error};
 use core::mem::MaybeUninit;

--- a/src/vita.rs
+++ b/src/vita.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Developers of the Rand project.
+// Copyright 2021-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for VxWorks
 use crate::{util_libc::last_os_error, Error};
 use core::{

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -1,11 +1,3 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
 //! Implementation for WASI
 use crate::Error;
 use core::{

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,11 +1,4 @@
-// Copyright 2018-2024 Developers of the Rand project.
-//
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-
+//! Implementation for Windows
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit, num::NonZeroU32, ptr};
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -1,4 +1,4 @@
-// Copyright 2018 Developers of the Rand project.
+// Copyright 2018-2024 Developers of the Rand project.
 //
 // Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 // https://www.apache.org/licenses/LICENSE-2.0> or the MIT license


### PR DESCRIPTION
### Fixed
- Custom backend for targets without atomics [#385]

### Changed
- Improve robustness of the Hermit backend and `sys_fill_exact` [#386]
- Raise minimum supported Apple OS versions to macOS 10.12 and iOS 10 [#388]

### Added
- Document platform support policy [#387]

[#385]: https://github.com/rust-random/getrandom/pull/385
[#386]: https://github.com/rust-random/getrandom/pull/386
[#387]: https://github.com/rust-random/getrandom/pull/387
[#388]: https://github.com/rust-random/getrandom/pull/388