### PR TITLE
Remove NetBSD workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,14 +51,3 @@ test-in-browser = []
 [package.metadata.docs.rs]
 features = ["std", "custom"]
 rustdoc-args = ["--cfg", "docsrs"]
-
-# workaround for https://github.com/cross-rs/cross/issues/1345
-[package.metadata.cross.target.x86_64-unknown-netbsd]
-pre-build = [
-    "mkdir -p /tmp/netbsd",
-    "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
-    "tar -C /tmp/netbsd -xJf base.tar.xz",
-    "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
-    "rm base.tar.xz",
-    "rm -rf /tmp/netbsd",
-]


### PR DESCRIPTION
The issue was fixed in October, so we probably no longer need the workaround.