### PR TITLE
Correct comments regarding LazyUsize

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -2,10 +2,10 @@ use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 
 // This structure represents a lazily initialized static usize value. Useful
 // when it is preferable to just rerun initialization instead of locking.
-// Both unsync_init and sync_init will invoke an init() function until it
-// succeeds, then return the cached value for future calls.
+// unsync_init will invoke an init() function until it succeeds, then return the
+// cached value for future calls.
 //
-// Both methods support init() "failing". If the init() method returns UNINIT,
+// unsync_init supports init() "failing". If the init() method returns UNINIT,
 // that value will be returned as normal, but will not be cached.
 //
 // Users should only depend on the _value_ returned by init() functions.
@@ -17,7 +17,7 @@ use core::sync::atomic::{AtomicUsize, Ordering::Relaxed};
 //          v
 //      }
 // the effects of c() or writes to shared memory will not necessarily be
-// observed and additional synchronization methods with be needed.
+// observed and additional synchronization methods may be needed.
 pub(crate) struct LazyUsize(AtomicUsize);
 
 impl LazyUsize {
@@ -28,8 +28,8 @@ impl LazyUsize {
     // The initialization is not completed.
     pub const UNINIT: usize = usize::max_value();
 
-    // Runs the init() function at least once, returning the value of some run
-    // of init(). Multiple callers can run their init() functions in parallel.
+    // Runs the init() function at most once, returning the value of some run of
+    // init(). Multiple callers can run their init() functions in parallel.
     // init() should always return the same value, if it succeeds.
     pub fn unsync_init(&self, init: impl FnOnce() -> usize) -> usize {
         // Relaxed ordering is fine, as we only have a single atomic variable.


### PR DESCRIPTION
This corrects a couple comments in the LazyUsize struct. This code was only moved between files recently. I removed a reference to the now-nonexistent sync_init, and fixed an "at least"/"at most" typo.