### PR TITLE
Fix build for wasm32/64-unknown-unknown without std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ js-sys = { version = "0.3", optional = true }
 wasm-bindgen-test = "0.3.18"
 
 [features]
+default = ["std"]
 # Implement std-only traits for getrandom::Error
 std = []
 # Feature to enable fallback RDRAND-based implementation on x86/x86_64

--- a/src/js.rs
+++ b/src/js.rs
@@ -31,7 +31,7 @@ std::thread_local!(
 #[thread_local]
 static RNG_SOURCE: RefCell<Option<RngSource>> = RefCell::new(None);
 
- pub(crate) fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub(crate) fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let mut getrandom_impl = |source: &RngSource| {
         match source {
             RngSource::Node(n) => {
@@ -85,9 +85,7 @@ static RNG_SOURCE: RefCell<Option<RngSource>> = RefCell::new(None);
     }
 
     #[cfg(std)]
-    RNG_SOURCE.with(|result| {
-        getrandom_impl(result.as_ref().map_err(|&e| e)?)
-    })
+    RNG_SOURCE.with(|result| getrandom_impl(result.as_ref().map_err(|&e| e)?))
 }
 
 fn getrandom_init() -> Result<RngSource, Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,10 +192,12 @@
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(
-    all(not(std),
+    all(
+        not(std),
         feature = "js",
         any(target_arch = "wasm32", target_arch = "wasm64"),
-        target_os = "unknown"),
+        target_os = "unknown"
+    ),
     feature(thread_local)
 )]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -188,9 +188,16 @@
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
     html_root_url = "https://docs.rs/getrandom/0.2.12"
 )]
-#![no_std]
+#![cfg_attr(not(std), no_std)]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(
+    all(not(std),
+        feature = "js",
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        target_os = "unknown"),
+    feature(thread_local)
+)]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
fixes #394 

- specify default feature
- use `thread_local` attribute for no_std wasm*-unknown-unknown
- use core::mem::MaybeUninit
- refactor getrandom_inner accordingly