### PR TITLE
Release v0.2.13

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,9 +1,1 @@
-# Allow normal use of "cargo run" and "cargo test" on these wasm32 platforms.
-[target.wasm32-unknown-unknown]
-runner = 'wasm-bindgen-test-runner'
-[target.wasm32-wasi]
-runner = 'wasmtime'
-
-# Just run on node by default (that's where emscripten is tested)
-[target.'cfg(target_os = "emscripten")']
-runner = 'node'
+.cargo/config.toml

--- a/.cargo/config
+++ b/.cargo/config
@@ -1,1 +1,1 @@
-.cargo/config.toml
+config.toml

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,9 @@
+# Allow normal use of "cargo run" and "cargo test" on these wasm32 platforms.
+[target.wasm32-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'
+[target.wasm32-wasi]
+runner = 'wasmtime'
+
+# Just run on node by default (that's where emscripten is tested)
+[target.'cfg(target_os = "emscripten")']
+runner = 'node'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -229,6 +229,9 @@ jobs:
             host: x86_64-unknown-linux-musl
           - os: windows-2022
             host: x86_64-pc-windows-msvc
+            # We get spurious failures on Windows, see:
+            # https://github.com/rust-random/getrandom/issues/400
+            continue-on-error: true
           - os: macos-12
             host: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
@@ -250,14 +253,8 @@ jobs:
       - name: Test (Firefox)
         run: wasm-pack test --headless --firefox --features=js,test-in-browser
       - name: Test (Chrome)
-        # We get spurious failures, see:
-        # https://github.com/rust-random/getrandom/issues/400
-        continue-on-error: true
         run: wasm-pack test --headless --chrome --features=js,test-in-browser
       - name: Test (Edge)
-        if: runner.os == 'Windows'
-        # Edge has flaky failures: "driver failed to bind port during startup"
-        continue-on-error: true
         run: wasm-pack test --headless --chrome --chromedriver $Env:EDGEWEBDRIVER\msedgedriver.exe --features=js,test-in-browser
       - name: Test (Safari)
         if: runner.os == 'macOS'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=v0.11.0
+          VERSION=v0.12.1
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-${{ matrix.host }}.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -250,6 +250,9 @@ jobs:
       - name: Test (Firefox)
         run: wasm-pack test --headless --firefox --features=js,test-in-browser
       - name: Test (Chrome)
+        # We get spurious failures, see:
+        # https://github.com/rust-random/getrandom/issues/400
+        continue-on-error: true
         run: wasm-pack test --headless --chrome --features=js,test-in-browser
       - name: Test (Edge)
         if: runner.os == 'Windows'
@@ -258,8 +261,6 @@ jobs:
         run: wasm-pack test --headless --chrome --chromedriver $Env:EDGEWEBDRIVER\msedgedriver.exe --features=js,test-in-browser
       - name: Test (Safari)
         if: runner.os == 'macOS'
-        # Safari tests are broken: https://github.com/rustwasm/wasm-bindgen/issues/3004
-        continue-on-error: true
         run: wasm-pack test --headless --safari --features=js,test-in-browser
       - name: Test (custom getrandom)
         run: wasm-pack test --node --features=custom

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -255,6 +255,7 @@ jobs:
       - name: Test (Chrome)
         run: wasm-pack test --headless --chrome --features=js,test-in-browser
       - name: Test (Edge)
+        if: runner.os == 'Windows'
         run: wasm-pack test --headless --chrome --chromedriver $Env:EDGEWEBDRIVER\msedgedriver.exe --features=js,test-in-browser
       - name: Test (Safari)
         if: runner.os == 'macOS'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.13] - 2024-04-07
+## [0.2.13] - 2024-04-06
 ### Added
 - `linux_disable_fallback` crate feature to disable `/dev/urandom`-based fallback on Linux and
   Android targets. Enabling this feature bumps minimum supported Linux kernel version to 3.17 and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.2.13] - 2024-04-07
 ### Added
 - `linux_disable_fallback` crate feature to disable `/dev/urandom`-based fallback on Linux and
-  Android targets. Enabling this feature bumps minimum supported Linux kernel version to 4.17 and
+  Android targets. Enabling this feature bumps minimum supported Linux kernel version to 3.17 and
   Android API level to 23 (Marshmallow). [#396]
 
 ### Changed
@@ -433,6 +433,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.13]: https://github.com/rust-random/getrandom/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/rust-random/getrandom/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/rust-random/getrandom/compare/v0.2.10...v0.2.11
 [0.2.10]: https://github.com/rust-random/getrandom/compare/v0.2.9...v0.2.10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.12" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.13" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,21 @@
 //! This prevents a crate from overriding a secure source of randomness
 //! (either accidentally or intentionally).
 //!
+//! ## `/dev/urandom` fallback on Linux and Android
+//!
+//! On Linux targets the fallback is present only for the following `target_arch`es:
+//! `aarch64`, `arm`, `powerpc`, `powerpc64`, `s390x`, `x86`, `x86_64`. Other supported
+//! `target_arch`es [require](https://doc.rust-lang.org/stable/rustc/platform-support.html)
+//! kernel versions which support `getrandom` system call, so fallback is not needed.
+//!
+//! On Android targets the fallback is present only for the following `target_arch`es:
+//! `aarch64`, `arm`, `x86`, `x86_64`. Other `target_arch`es (e.g. RISC-V) require
+//! sufficiently high API levels.
+//!
+//! The fallback can be disabled by enabling the `linux_disable_fallback` crate feature.
+//! Note that doing so will bump minimum supported Linux kernel version to 3.17 and
+//! Android API level to 23 (Marshmallow).
+//!
 //! ### RDRAND on x86
 //!
 //! *If the `rdrand` Cargo feature is enabled*, `getrandom` will fallback to using
@@ -189,7 +204,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.12"
+    html_root_url = "https://docs.rs/getrandom/0.2.13"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
### Added
- `linux_disable_fallback` crate feature to disable `/dev/urandom`-based fallback on Linux and Android targets. Enabling this feature bumps minimum supported Linux kernel version to 3.17 and Android API level to 23 (Marshmallow). [#396]

### Changed
- Disable `/dev/urandom` fallback for Linux targets outside of the following `target_arch`es: `aarch64`, `arm`, `powerpc`, `powerpc64`, `s390x`, `x86`, `x86_64` [#396]
- Do not catch `EPERM` error code on Android while checking availability of the `getrandom` syscall [#396]

[#396]: https://github.com/rust-random/getrandom/pull/396