### PR TITLE
Enable `/dev/urandom` fallback for MUSL-based Linux targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.14] - 2024-04-08
+### Fixed
+- Enable `/dev/urandom` fallback for MUSL-based Linux targets [#408]
+
+[#408]: https://github.com/rust-random/getrandom/pull/408
+
 ## [0.2.13] - 2024-04-06
 ### Added
 - `linux_disable_fallback` crate feature to disable `/dev/urandom`-based fallback on Linux and
@@ -433,6 +439,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.14]: https://github.com/rust-random/getrandom/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/rust-random/getrandom/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/rust-random/getrandom/compare/v0.2.11...v0.2.12
 [0.2.11]: https://github.com/rust-random/getrandom/compare/v0.2.10...v0.2.11

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.13" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.14" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,9 +49,9 @@
 //!
 //! ## `/dev/urandom` fallback on Linux and Android
 //!
-//! On Linux targets the fallback is present only for the following `target_arch`es:
-//! `aarch64`, `arm`, `powerpc`, `powerpc64`, `s390x`, `x86`, `x86_64`. Other supported
-//! `target_arch`es [require](https://doc.rust-lang.org/stable/rustc/platform-support.html)
+//! On Linux targets the fallback is present only if either `target_env` is `musl`,
+//! or `target_arch` is one of the following: `aarch64`, `arm`, `powerpc`, `powerpc64`,
+//! `s390x`, `x86`, `x86_64`. Other supported targets [require][platform-support]
 //! kernel versions which support `getrandom` system call, so fallback is not needed.
 //!
 //! On Android targets the fallback is present only for the following `target_arch`es:
@@ -200,11 +200,12 @@
 //! [CommonJS modules]: https://nodejs.org/api/modules.html
 //! [ES modules]: https://nodejs.org/api/esm.html
 //! [`sys_read_entropy`]: https://github.com/hermit-os/kernel/blob/315f58ff5efc81d9bf0618af85a59963ff55f8b1/src/syscalls/entropy.rs#L47-L55
+//! [platform-support]: https://doc.rust-lang.org/stable/rustc/platform-support.html
 
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.13"
+    html_root_url = "https://docs.rs/getrandom/0.2.14"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
@@ -270,6 +271,10 @@ cfg_if! {
                     target_arch = "s390x",
                     target_arch = "x86",
                     target_arch = "x86_64",
+                    // Minimum supported Linux kernel version for MUSL targets
+                    // is not specified explicitly (as of Rust 1.77) and they
+                    // are used in practice to target pre-3.17 kernels.
+                    target_env = "musl",
                 ),
             )
         ),


### PR DESCRIPTION
Closes #407