### PR TITLE
Release v0.2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Apple visionOS support [#410]
 
 ### Changed
-- Use `libc::getrandom` on DragonflyBSD [#411]
-- Use `libc::getrandom` on FreeBSD [#416]
-- Use `libc::getrandom` on Illumos [#417]
-- Use `libc::getentropy` on Solaris [#417]
+- Use `libc::getrandom` on DragonflyBSD, FreeBSD, illumos, and Solaris [#411] [#416] [#417] [#420]
 - Unify `libc::getentropy`-based implementations [#418]
 
 [#410]: https://github.com/rust-random/getrandom/pull/410
@@ -20,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#416]: https://github.com/rust-random/getrandom/pull/416
 [#417]: https://github.com/rust-random/getrandom/pull/417
 [#418]: https://github.com/rust-random/getrandom/pull/418
+[#420]: https://github.com/rust-random/getrandom/pull/420
 
 ## [0.2.14] - 2024-04-08
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.15] - 2024-05-06
+### Added
+- Apple visionOS support [#410]
+
+### Changed
+- Use `libc::getrandom` on DragonflyBSD [#411]
+- Use `libc::getrandom` on FreeBSD [#416]
+- Use `libc::getrandom` on Illumos [#417]
+- Use `libc::getentropy` on Solaris [#417]
+- Unify `libc::getentropy`-based implementations [#418]
+
+[#410]: https://github.com/rust-random/getrandom/pull/410
+[#411]: https://github.com/rust-random/getrandom/pull/411
+[#416]: https://github.com/rust-random/getrandom/pull/416
+[#417]: https://github.com/rust-random/getrandom/pull/417
+[#418]: https://github.com/rust-random/getrandom/pull/418
+
 ## [0.2.14] - 2024-04-08
 ### Fixed
 - Enable `/dev/urandom` fallback for MUSL-based Linux targets [#408]
@@ -439,6 +456,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.15]: https://github.com/rust-random/getrandom/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/rust-random/getrandom/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/rust-random/getrandom/compare/v0.2.12...v0.2.13
 [0.2.12]: https://github.com/rust-random/getrandom/compare/v0.2.11...v0.2.12

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.14" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.15" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,7 +201,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.14"
+    html_root_url = "https://docs.rs/getrandom/0.2.15"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
### Added
- Apple visionOS support [#410]

### Changed
- Use `libc::getrandom` on DragonflyBSD, FreeBSD, illumos, and Solaris [#411] [#416] [#417] [#420]
- Unify `libc::getentropy`-based implementations [#418]

[#410]: https://github.com/rust-random/getrandom/pull/410
[#411]: https://github.com/rust-random/getrandom/pull/411
[#416]: https://github.com/rust-random/getrandom/pull/416
[#417]: https://github.com/rust-random/getrandom/pull/417
[#418]: https://github.com/rust-random/getrandom/pull/418
[#420]: https://github.com/rust-random/getrandom/pull/420