### PR TITLE
Remove .cargo/config

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,1 +1,0 @@
-config.toml


### PR DESCRIPTION
The `.cargo/config.toml` file has been supported since Rust 1.39, and is only needed for testing, not for actually building the crate. There's no harm in it being ignored.

This eliminates a warning caused by both `.cargo/config.toml` and `.cargo/config` being present.