### PR TITLE
fix: Downgrade `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.15" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.15"                                                                           # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
@@ -18,7 +18,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 [target.'cfg(unix)'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.153", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
 wasi = { version = "0.11", default-features = false }
@@ -58,10 +58,10 @@ rustdoc-args = ["--cfg", "docsrs"]
 # workaround for https://github.com/cross-rs/cross/issues/1345
 [package.metadata.cross.target.x86_64-unknown-netbsd]
 pre-build = [
-    "mkdir -p /tmp/netbsd",
-    "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
-    "tar -C /tmp/netbsd -xJf base.tar.xz",
-    "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
-    "rm base.tar.xz",
-    "rm -rf /tmp/netbsd",
+  "mkdir -p /tmp/netbsd",
+  "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
+  "tar -C /tmp/netbsd -xJf base.tar.xz",
+  "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
+  "rm base.tar.xz",
+  "rm -rf /tmp/netbsd",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.15"                                                                           # Also update html_root_url in lib.rs when bumping this
+version = "0.2.16"                                                                           # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Overview
The most recent release of `getrandom` is dependent on `libc` ^0.2.154, which has been yanked from crates.io: https://crates.io/crates/libc/0.2.154. This PR downgrades `libc` to a version that is still on `crates.io`, 0.2.153.


Projects that are dependent on `getrandom` need to downgrade to a previous version of `getrandom` (ex. v0.2.14) to avoid seeing the following:

```bash
Updating crates.io index
error: failed to select a version for the requirement `libc = "^0.2.154"`
candidate versions found which didn't match: 0.2.153, 0.2.152, 0.2.151, ...
location searched: crates.io index
required by package `getrandom v0.2.15`
    ... which satisfies dependency `getrandom = "^0.2.15"` of package ...`
    ... which satisfies git dependency ... of package ... 
    (/home/runner/_work/...)`
perhaps a crate was updated and forgotten to be re-vendored
```