### PR TITLE
Clarify safety properties of casts between `[MaybeUninit<T>]` <-> `[T]`.

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -5,9 +5,11 @@ use core::{mem::MaybeUninit, ptr};
 /// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
 /// been initialized.
 #[inline(always)]
+#[allow(unused_unsafe)] // TODO(MSRV 1.65): Remove this.
 pub unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
+    let ptr = ptr_from_mut::<[MaybeUninit<T>]>(slice) as *mut [T];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    &mut *(slice as *mut [MaybeUninit<T>] as *mut [T])
+    unsafe { &mut *ptr }
 }
 
 #[inline]
@@ -18,10 +20,9 @@ pub fn uninit_slice_fill_zero(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
 
 #[inline(always)]
 pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
+    let ptr = ptr_from_ref::<[T]>(slice) as *const [MaybeUninit<T>];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    // There is no risk of writing a `MaybeUninit<T>` into the result since
-    // the result isn't mutable.
-    unsafe { &*(slice as *const [T] as *const [MaybeUninit<T>]) }
+    unsafe { &*ptr }
 }
 
 /// View an mutable initialized array as potentially-uninitialized.
@@ -29,7 +30,19 @@ pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
 /// This is unsafe because it allows assigning uninitialized values into
 /// `slice`, which would be undefined behavior.
 #[inline(always)]
+#[allow(unused_unsafe)] // TODO(MSRV 1.65): Remove this.
 pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
+    let ptr = ptr_from_mut::<[T]>(slice) as *mut [MaybeUninit<T>];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    &mut *(slice as *mut [T] as *mut [MaybeUninit<T>])
+    unsafe { &mut *ptr }
+}
+
+// TODO: MSRV(1.76.0): Replace with `core::ptr::from_mut`.
+fn ptr_from_mut<T: ?Sized>(r: &mut T) -> *mut T {
+    r
+}
+
+// TODO: MSRV(1.76.0): Replace with `core::ptr::from_ref`.
+fn ptr_from_ref<T: ?Sized>(r: &T) -> *const T {
+    r
 }


### PR DESCRIPTION
Reduce the scope of the `unsafe` blocks to the unsafe operations.