### PR TITLE
Help the compiler avoid inlining lazy init functions.

### DIFF
--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -44,11 +44,12 @@ impl LazyUsize {
         }
 
         // Relaxed ordering is fine, as we only have a single atomic variable.
-        let mut val = self.0.load(Ordering::Relaxed);
-        if val == Self::UNINIT {
-            val = do_init(self, init);
+        let val = self.0.load(Ordering::Relaxed);
+        if val != Self::UNINIT {
+            val
+        } else {
+            do_init(self, init)
         }
-        val
     }
 }
 
@@ -111,10 +112,11 @@ impl LazyPtr {
         // the returned pointer (which occurs when the function is called).
         // Our implementation mirrors that of the one in libstd, meaning that
         // the use of non-Relaxed operations is probably unnecessary.
-        let mut val = self.addr.load(Ordering::Acquire);
-        if val == Self::UNINIT {
-            val = do_init(self, init);
+        let val = self.addr.load(Ordering::Acquire);
+        if val != Self::UNINIT {
+            val
+        } else {
+            do_init(self, init)
         }
-        val
     }
 }

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -19,6 +19,9 @@ use core::{
 const FILE_PATH: &[u8] = b"/dev/urandom\0";
 const FD_UNINIT: usize = usize::max_value();
 
+// Do not inline this when it is the fallback implementation, but don't mark it
+// `#[cold]` because it is hot when it is actually used.
+#[cfg_attr(any(target_os = "android", target_os = "linux"), inline(never))]
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let fd = get_rng_fd()?;
     sys_fill_exact(dest, |buf| unsafe {

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -68,10 +68,10 @@ fn get_rng_fd() -> Result<libc::c_int, Error> {
 
     // Use double-checked locking to avoid acquiring the lock if possible.
     if let Some(fd) = get_fd() {
-        return Ok(fd);
+        Ok(fd)
+    } else {
+        get_fd_locked()
     }
-
-    get_fd_locked()
 }
 
 // Succeeds once /dev/urandom is safe to read from


### PR DESCRIPTION
Before this change, the compiler generates code that looks like this:

```
  if not initialized:
     goto init
do_work:
  do the actual work
  goto exit
init:
  inilned init()
  goto do_work
exit:
  ret
```

If the initialization code is small, this works fine. But, for (bad) reasons, is_rdrand_good is particularly huge. Thus, jumping over its inined code is wasteful because it puts bad pressure on the instruction cache.

With this change, the generated code looks like this:

```
  if not initialized:
     goto init
do_work:
  do the actual work
  goto exit
init:
  call init()
  goto do_work
exit:
  ret
```

I verified these claims by running:
```
$ cargo asm --rust getrandom_inner --lib --target=x86_64-fortanix-unknown-sgx
```

This is also what other implementations (e.g. OnceCell) do.

While here, I made the analogous change to LazyPtr, and rewrote LazyPtr to the same form as LazyUsize. I didn't check the generated code for LazyPtr though.

(Why is `is_rdrand_good` huge? The compiler unrolls the 10 iteration retry loop, and then it unrolls the 8 iteration self-test loop, so the result is `rdrand()` is inlined 80 times inside is_rdrand_good. This is something to address separately as it also affects `getrandom_inner` itself.)