### PR TITLE
Delegate to `linux_android` from `linux_android_with_fallback`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ cfg_if! {
         mod util_libc;
         mod use_file;
         mod lazy;
+        mod linux_android;
         #[path = "linux_android_with_fallback.rs"] mod imp;
     } else if #[cfg(any(target_os = "android", target_os = "linux"))] {
         mod util_libc;

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -3,5 +3,17 @@ use crate::{util_libc, Error};
 use core::mem::MaybeUninit;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    util_libc::sys_fill_exact(dest, util_libc::getrandom_syscall)
+    util_libc::sys_fill_exact(dest, getrandom_syscall)
+}
+
+// Also used by linux_android_with_fallback to check if the syscall is available.
+pub fn getrandom_syscall(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
+    unsafe {
+        libc::syscall(
+            libc::SYS_getrandom,
+            buf.as_mut_ptr().cast::<core::ffi::c_void>(),
+            buf.len(),
+            0,
+        ) as libc::ssize_t
+    }
 }

--- a/src/linux_android_with_fallback.rs
+++ b/src/linux_android_with_fallback.rs
@@ -1,10 +1,5 @@
 //! Implementation for Linux / Android with `/dev/urandom` fallback
-use crate::{
-    lazy::LazyBool,
-    linux_android, use_file,
-    util_libc::{getrandom_syscall, last_os_error},
-    Error,
-};
+use crate::{lazy::LazyBool, linux_android, use_file, util_libc::last_os_error, Error};
 use core::mem::MaybeUninit;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
@@ -18,7 +13,7 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
 }
 
 fn is_getrandom_available() -> bool {
-    if getrandom_syscall(&mut []) < 0 {
+    if linux_android::getrandom_syscall(&mut []) < 0 {
         match last_os_error().raw_os_error() {
             Some(libc::ENOSYS) => false, // No kernel support
             // The fallback on EPERM is intentionally not done on Android since this workaround

--- a/src/linux_android_with_fallback.rs
+++ b/src/linux_android_with_fallback.rs
@@ -1,8 +1,9 @@
 //! Implementation for Linux / Android with `/dev/urandom` fallback
 use crate::{
     lazy::LazyBool,
-    util_libc::{getrandom_syscall, last_os_error, sys_fill_exact},
-    {use_file, Error},
+    linux_android, use_file,
+    util_libc::{getrandom_syscall, last_os_error},
+    Error,
 };
 use core::mem::MaybeUninit;
 
@@ -10,7 +11,7 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // getrandom(2) was introduced in Linux 3.17
     static HAS_GETRANDOM: LazyBool = LazyBool::new();
     if HAS_GETRANDOM.unsync_init(is_getrandom_available) {
-        sys_fill_exact(dest, getrandom_syscall)
+        linux_android::getrandom_inner(dest)
     } else {
         use_file::getrandom_inner(dest)
     }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -99,16 +99,3 @@ pub fn open_readonly(path: &[u8]) -> Result<libc::c_int, Error> {
         }
     }
 }
-
-/// Thin wrapper around the `getrandom()` Linux system call
-#[cfg(any(target_os = "android", target_os = "linux"))]
-pub fn getrandom_syscall(buf: &mut [MaybeUninit<u8>]) -> libc::ssize_t {
-    unsafe {
-        libc::syscall(
-            libc::SYS_getrandom,
-            buf.as_mut_ptr().cast::<core::ffi::c_void>(),
-            buf.len(),
-            0,
-        ) as libc::ssize_t
-    }
-}


### PR DESCRIPTION
Instead of duplicating the implementation of `linux_android::getrandom_inner` inline, call `linux_android::getrandom_inner`, like we do for `use_file::getrandom_inner`. This way, there is no doubt that they do exactly the same thing. This then allows us to move `getrandom_syscall` to linux_android, which is where it belongs, since it is Linux/Android-specific.