### PR TITLE
CI: Build for `x86_64-unknown-linux-gnux32`.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,6 +316,7 @@ jobs:
       matrix:
         target: [
           x86_64-unknown-fuchsia,
+          x86_64-unknown-linux-gnux32,
           x86_64-unknown-redox,
           x86_64-fortanix-unknown-sgx,
         ]


### PR DESCRIPTION
We cannot run the tests on the Ubuntu runners but we can build for the target.