### PR TITLE
Avoid depending on "rustc-dep-of-std" features of dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,8 +49,6 @@ custom = []
 rustc-dep-of-std = [
   "compiler_builtins",
   "core",
-  "libc/rustc-dep-of-std",
-  "wasi/rustc-dep-of-std",
 ]
 # Unstable/test-only feature to run wasm-bindgen tests in a browser
 test-in-browser = []


### PR DESCRIPTION
AFAICT, this is not needed. When libstd builds libc, it will activate that feature for it. This makes it easier to make libc a conditional dependency. Do the same for WASI.