### PR TITLE
Cleanup Auxiliary Linux tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,20 +71,26 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        target: [
-          x86_64-unknown-linux-musl,
-          i686-unknown-linux-gnu,
-          i686-unknown-linux-musl,
-        ]
+        target: [x86_64-unknown-linux-musl, i686-unknown-linux-musl]
+        include:
+          - target: i686-unknown-linux-gnu
+            packages: libc6-dev-i386 lib32gcc-11-dev
+          - target: x86_64-unknown-linux-gnux32
+            packages: libc6-dev-x32 libx32gcc-11-dev
+            # TODO: Find a Linux image/runner with CONFIG_X86_X32_ABI set
+            cargo_test_opts: --no-run
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
-      - name: Install multilib
-        run: sudo apt-get update && sudo apt-get install gcc-multilib
+      - name: Install libc and libgcc
+        if: matrix.packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends ${{ matrix.packages }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --target=${{ matrix.target }} --features=std
+      - run: cargo test ${{ matrix.cargo_test_opts }} --target=${{ matrix.target }} --features=std
 
   ios-tests:
     name: iOS Simulator Test


### PR DESCRIPTION
This PR merges the "extra" Linux tests into a single job. This reduces the number of jobs we have to run as part of the CI. We also explictly install libc and libgcc (to make it clear these are the only extra dev dependancies).

I also added building/linking of the x32 target. As noted in #464, this will not run in the current github actions runner due to an incompatible kernel config. CC @briansmith 