### PR TITLE
Cleanup Custom Tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,9 +38,9 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
       - run: cargo test
-      - run: cargo test --features=std
+      # Make sure enabling the std and custom features don't break anything
+      - run: cargo test --features=std,custom
       - run: cargo test --features=linux_disable_fallback
-      - run: cargo test --features=custom # custom should do nothing here
       - if: ${{ matrix.toolchain == 'nightly' }}
         run: cargo test --benches
 
@@ -260,6 +260,8 @@ jobs:
         run: wasm-pack test --headless --safari --features=js,test-in-browser
       - name: Test (custom getrandom)
         run: wasm-pack test --node --features=custom
+      - name: Test (JS overrides custom)
+        run: wasm-pack test --node --features=custom,js
 
   wasm64-tests:
     name: wasm64 Build/Link

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,10 @@ rustc-dep-of-std = [
 # Unstable/test-only feature to run wasm-bindgen tests in a browser
 test-in-browser = []
 
+[[test]]
+name = "custom"
+required-features = ["custom"]
+
 [package.metadata.docs.rs]
 features = ["std", "custom"]
 rustdoc-args = ["--cfg", "docsrs"]


### PR DESCRIPTION
This moves the tests for the custom RNG registration into custom.rs. It also:
  - Simplifies the registered custom RNG
  - Makes sure the custom RNG _is not_ used on supported platforms
  - Makes sure the custom RNG _is_ used on unsupported platforms

Split out from #471 CC @briansmith 