### PR TITLE
CI: run Clippy for all backends, rework the rustdoc job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           - os: macos-14
             toolchain: stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -58,7 +58,7 @@ jobs:
             # TODO: Find a Linux image/runner with CONFIG_X86_X32_ABI set
             cargo_test_opts: --no-run
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -89,7 +89,7 @@ jobs:
             target: aarch64-apple-ios-sim
             ios_platform: auto-ios-aarch64-sim
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -136,7 +136,7 @@ jobs:
           stable-i686-msvc,
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.toolchain }}
@@ -147,7 +147,7 @@ jobs:
     name: Test Windows 7 impl on Windows 10
     runs-on: windows-2022
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       # Win7 targets are Tier3, so pin a nightly where libstd builds.
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -171,7 +171,7 @@ jobs:
           wasm32-unknown-emscripten,
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install precompiled cross
         run: |
           VERSION=v0.2.5
@@ -185,7 +185,7 @@ jobs:
     name: macOS ARM64 Build/Link
     runs-on: macos-12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
         with:
           targets: aarch64-apple-darwin, aarch64-apple-ios
@@ -207,7 +207,7 @@ jobs:
           x86_64-unknown-netbsd,
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install precompiled cross
         run: |
           VERSION=v0.2.5
@@ -234,7 +234,7 @@ jobs:
             host: x86_64-apple-darwin
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - run: choco install wget
         if: runner.os == 'Windows'
@@ -265,7 +265,7 @@ jobs:
     name: wasm64 Build/Link
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
         with:
           components: rust-src
@@ -280,7 +280,7 @@ jobs:
     name: WASI Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-wasi
@@ -304,7 +304,7 @@ jobs:
           x86_64-fortanix-unknown-sgx,
         ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -346,7 +346,7 @@ jobs:
           - target: i686-unknown-hurd-gnu
             features: ["std"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
           components: rust-src
@@ -357,7 +357,7 @@ jobs:
     name: No Atomics Build
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: riscv32i-unknown-none-elf

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,28 +16,6 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  check-doc:
-    name: Docs, deadlinks, minimal dependencies
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v3
-      - uses: dtolnay/rust-toolchain@nightly # Needed for -Z minimal-versions and doc_cfg
-      - name: Install precompiled cargo-deadlinks
-        run: |
-          VERSION=0.8.1
-          URL="https://github.com/deadlinks/cargo-deadlinks/releases/download/${VERSION}/cargo-deadlinks-linux"
-          wget -O ~/.cargo/bin/cargo-deadlinks $URL
-          chmod +x ~/.cargo/bin/cargo-deadlinks
-          cargo deadlinks --version
-      - uses: Swatinem/rust-cache@v2
-      - name: Generate Docs
-        env:
-          RUSTDOCFLAGS: --cfg docsrs
-        run: cargo deadlinks -- --features=custom,std
-      - run: |
-          cargo generate-lockfile -Z minimal-versions
-          cargo test --features=custom,std
-
   main-tests:
     name: Tier 1 Test
     runs-on: ${{ matrix.os }}
@@ -385,17 +363,3 @@ jobs:
           targets: riscv32i-unknown-none-elf
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --features custom --target riscv32i-unknown-none-elf
-
-  clippy-fmt:
-    name: Clippy + rustfmt
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v1
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-      - name: clippy
-        run: cargo clippy --all --features=custom,std
-      - name: fmt
-        run: cargo fmt --all -- --check

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       RUSTFLAGS: "-Dwarnings"
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@master
       with:
         # We need Nightly for -Zbuild-std.
@@ -70,7 +70,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -82,7 +82,7 @@ jobs:
     name: rustdoc
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
           # We need Nightly for doc_auto_cfg

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -70,7 +70,7 @@ jobs:
     name: rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -1,0 +1,94 @@
+name: Workspace
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
+
+permissions:
+  contents: read
+
+jobs:
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-Dwarnings"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        # We need Nightly for -Zbuild-std.
+        # Fixed Nigthly version is used to prevent
+        # CI failures which are not relevant to PR changes
+        # on introduction of new Clippy lints.
+        toolchain: nightly-2024-06-11
+        components: clippy,rust-src
+    - name: std feature
+      run: cargo clippy --features std
+    - name: custom feature
+      run: cargo clippy -Zbuild-std=core --target riscv32i-unknown-none-elf --features custom
+    - name: iOS (apple-other.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-apple-ios
+    - name: ESP-IDF (espidf.rs)
+      run: cargo clippy -Zbuild-std=core --target riscv32imc-esp-espidf
+    - name: Fuchsia (fuchsia.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-fuchsia
+    - name: OpenBSD (getentropy.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-openbsd
+    - name: FreeBSD (getrandom.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-freebsd
+    - name: Hermit (hermit.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-hermit
+    - name: Web WASM (js.rs)
+      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown --features js
+    - name: Linux (linux_android.rs)
+      run: cargo clippy --target x86_64-unknown-linux-gnu --features linux_disable_fallback
+    - name: Linux (linux_android_with_fallback.rs)
+      run: cargo clippy --target x86_64-unknown-linux-gnu
+    - name: NetBSD (netbsd.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-netbsd
+    - name: Fortranix SGX (rdrand.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-fortanix-unknown-sgx
+    - name: Solaris (solaris.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-pc-solaris
+    - name: SOLID (solid.rs)
+      run: cargo clippy -Zbuild-std=core --target aarch64-kmc-solid_asp3
+    - name: Redox (use_file.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-unknown-redox
+    - name: VxWorks (vxworks.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-wrs-vxworks
+    - name: WASI (wasi.rs)
+      run: cargo clippy -Zbuild-std=core --target wasm32-wasip2
+    - name: Windows 7 (windows7.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-win7-windows-msvc
+    - name: Windows (windows.rs)
+      run: cargo clippy -Zbuild-std=core --target x86_64-pc-windows-msvc
+
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - name: fmt
+        run: cargo fmt --all -- --check
+
+  check-doc:
+    name: rustdoc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          # We need Nightly for doc_auto_cfg
+          toolchain: nightly-2024-06-11
+      - uses: Swatinem/rust-cache@v2
+      - name: Generate Docs
+        env:
+          RUSTDOCFLAGS: "-Dwarnings --cfg docsrs"
+        run: cargo doc --no-deps --features custom

--- a/src/lazy.rs
+++ b/src/lazy.rs
@@ -26,7 +26,7 @@ pub(crate) struct LazyUsize(AtomicUsize);
 
 impl LazyUsize {
     // The initialization is not completed.
-    const UNINIT: usize = usize::max_value();
+    const UNINIT: usize = usize::MAX;
 
     pub const fn new() -> Self {
         Self(AtomicUsize::new(Self::UNINIT))

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -17,7 +17,7 @@ use core::{
 ///   - On AIX, /dev/urandom will "provide cryptographically secure output".
 ///   - On Haiku and QNX Neutrino they are identical.
 const FILE_PATH: &[u8] = b"/dev/urandom\0";
-const FD_UNINIT: usize = usize::max_value();
+const FD_UNINIT: usize = usize::MAX;
 
 // Do not inline this when it is the fallback implementation, but don't mark it
 // `#[cold]` because it is hot when it is actually used.

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -1,6 +1,7 @@
 //! Implementation for VxWorks
 use crate::{util_libc::last_os_error, Error};
 use core::{
+    cmp::Ordering::{Equal, Greater, Less},
     mem::MaybeUninit,
     sync::atomic::{AtomicBool, Ordering::Relaxed},
 };
@@ -9,17 +10,21 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };
-        if ret < 0 {
-            return Err(Error::VXWORKS_RAND_SECURE);
-        } else if ret > 0 {
-            RNG_INIT.store(true, Relaxed);
-            break;
+        match ret.cmp(&0) {
+            Greater => {
+                RNG_INIT.store(true, Relaxed);
+                break;
+            }
+            Equal => unsafe {
+                libc::usleep(10);
+            },
+            Less => return Err(Error::VXWORKS_RAND_SECURE),
         }
-        unsafe { libc::usleep(10) };
     }
 
     // Prevent overflow of i32
-    for chunk in dest.chunks_mut(i32::max_value() as usize) {
+    let chunk_size = usize::try_from(i32::MAX).expect("VxWorks does not support 16-bit targets");
+    for chunk in dest.chunks_mut(chunk_size) {
         let ret = unsafe { libc::randABytes(chunk.as_mut_ptr().cast::<u8>(), chunk.len() as i32) };
         if ret != 0 {
             return Err(last_os_error());

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -18,6 +18,7 @@
 //!     - Requires advapi32.dll (in addition to bcryptprimitives.dll)
 //!     - Requires using name "SystemFunction036"
 //!     - Thin wrapper around ProcessPrng
+//!
 //! For more information see the Windows RNG Whitepaper: https://aka.ms/win10rng
 use crate::Error;
 use core::mem::MaybeUninit;

--- a/src/windows7.rs
+++ b/src/windows7.rs
@@ -25,7 +25,7 @@ const TRUE: BOOLEAN = 1u8;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
-    for chunk in dest.chunks_mut(u32::max_value() as usize) {
+    for chunk in dest.chunks_mut(u32::MAX as usize) {
         let ret = unsafe { RtlGenRandom(chunk.as_mut_ptr().cast::<c_void>(), chunk.len() as u32) };
         if ret != TRUE {
             return Err(Error::WINDOWS_RTL_GEN_RANDOM);

--- a/src/windows7.rs
+++ b/src/windows7.rs
@@ -25,7 +25,8 @@ const TRUE: BOOLEAN = 1u8;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
-    for chunk in dest.chunks_mut(u32::MAX as usize) {
+    let chunk_size = usize::try_from(i32::MAX).expect("Windows does not support 16-bit targets");
+    for chunk in dest.chunks_mut(chunk_size) {
         let ret = unsafe { RtlGenRandom(chunk.as_mut_ptr().cast::<c_void>(), chunk.len() as u32) };
         if ret != TRUE {
             return Err(Error::WINDOWS_RTL_GEN_RANDOM);


### PR DESCRIPTION
Consolidates Clippy runs into one job which uses fixed Nightly version. Moves Clippy, rustdoc, and rustfmt jobs into a separate workflow file. 

Additionally, tweaks the rustdoc job to use only rustdoc with `-Dwarnings` flag. Minimal versions job has nothing to do with docs and should be done separately for each target. `cargo deadlinks` was not used to check external links and internal links are checked by rustdoc.

Closes #446 