### PR TITLE
Update Cargo.toml to declare libc dependency for target_os=emscripten

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ cfg-if = "1"
 compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(any(unix, target_os = "emscripten"))'.dependencies]
 libc = { version = "0.2.154", default-features = false }
 
 [target.'cfg(target_os = "wasi")'.dependencies]


### PR DESCRIPTION
When targetting wasm32-unknown-emscripten, there is a dependency on libc.
The Cargo.toml should reflect that.