### PR TITLE
wasm: Depend on wasm-bindgen 0.2.89 or higher

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,10 +28,10 @@ wasi = { version = "0.11", default-features = false }
 windows-targets = "0.52"
 
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
-wasm-bindgen = { version = "0.2.62", default-features = false, optional = true }
+wasm-bindgen = { version = "0.2.89", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
 [target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dev-dependencies]
-wasm-bindgen-test = "0.3.18"
+wasm-bindgen-test = "0.3.39"
 
 [features]
 # Implement std-only traits for getrandom::Error


### PR DESCRIPTION
wasm-bindgen 0.2.62 is not compatible with a wasm ABI change that rustc wishes to enable by default for wasm32-unknown-unknown, currently gated behind passing the -Zwasm-c-abi flag to rustc.

wasm-bindgen 0.2.89 should exhibit seamless behavior before and after the ABI change to match the C ABI, so depend on that.

For more information, see
- https://github.com/rust-lang/rust/issues/115666
- https://github.com/rust-lang/rust/pull/117918
- https://github.com/rust-lang/rust/issues/122532