### PR TITLE
Test file fallback on Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,6 +72,9 @@ jobs:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
         run: cargo test ${{ matrix.cargo_test_opts }} --target=${{ matrix.target }} --features=std
       - env:
+          RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
+        run: cargo test --features=std
+      - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
         run: cargo test --features=std
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ level = "warn"
 check-cfg = [
   'cfg(getrandom_backend, values("custom", "rdrand", "linux_getrandom", "wasm_js", "esp_idf"))',
   'cfg(getrandom_browser_test)',
+  'cfg(getrandom_test_linux_fallback)',
 ]
 
 [package.metadata.docs.rs]

--- a/src/linux_android_with_fallback.rs
+++ b/src/linux_android_with_fallback.rs
@@ -19,7 +19,9 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
 }
 
 fn is_getrandom_available() -> bool {
-    if linux_android::getrandom_syscall(&mut []) < 0 {
+    if cfg!(getrandom_test_linux_fallback) {
+        false
+    } else if linux_android::getrandom_syscall(&mut []) < 0 {
         match last_os_error().raw_os_error() {
             Some(libc::ENOSYS) => false, // No kernel support
             // The fallback on EPERM is intentionally not done on Android since this workaround


### PR DESCRIPTION
Introduces new configuration flag `getrandom_test_linux_fallback` which forces `is_getrandom_available` to always return `false`. This flag is used in CI to test that file fallback works correctly in the `linux_android_with_fallback` backend.