### PR TITLE
Tweak opt-in backends

### DIFF
--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -45,7 +45,7 @@ jobs:
       run: cargo clippy -Zbuild-std=core --target x86_64-unknown-freebsd
     - name: Hermit (hermit.rs)
       run: cargo clippy -Zbuild-std=core --target x86_64-unknown-hermit
-    - name: Web WASM (js.rs)
+    - name: Web WASM (wasm_js.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
       run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown

--- a/src/esp_idf.rs
+++ b/src/esp_idf.rs
@@ -2,6 +2,9 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
+#[cfg(not(target_os = "espidf"))]
+compile_error!("`esp_idf` backend can be enabled only for ESP-IDF targets!");
+
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,29 +284,17 @@ cfg_if! {
     if #[cfg(getrandom_backend = "custom")] {
         #[path = "custom.rs"] mod imp;
     } else if #[cfg(getrandom_backend = "linux_getrandom")] {
-        #[cfg(not(any(target_os = "android", target_os = "linux")))]
-        compile_error!("`linux_getrandom` backend can be enabled only for Linux/Android targets!");
         mod util_libc;
         #[path = "linux_android.rs"] mod imp;
     } else if #[cfg(getrandom_backend = "rdrand")] {
-        #[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-        compile_error!("`rdrand` backend can be enabled only for x86 and x86-64 targets!");
-
         mod lazy;
         #[path = "rdrand.rs"] mod imp;
     } else if #[cfg(getrandom_backend = "rndr")] {
         #[path = "rndr.rs"] mod imp;
     } else if #[cfg(getrandom_backend = "wasm_js")] {
-        #[cfg(not(all(
-            any(target_arch = "wasm32", target_arch = "wasm64"),
-            target_os = "unknown",
-        )))]
-        compile_error!("`wasm_js` backend can be enabled only on OS-less WASM targets!");
-        #[path = "js.rs"] mod imp;
+        #[path = "wasm_js.rs"] mod imp;
     } else if #[cfg(getrandom_backend = "esp_idf")] {
-        #[cfg(not(target_os = "espidf"))]
-        compile_error!("`esp_idf` backend can be enabled only for ESP-IDF targets!");
-        #[path = "espidf.rs"] mod imp;
+        #[path = "esp_idf.rs"] mod imp;
     } else if #[cfg(any(
         target_os = "haiku",
         target_os = "redox",

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -2,6 +2,9 @@
 use crate::{util_libc, Error};
 use core::mem::MaybeUninit;
 
+#[cfg(not(any(target_os = "android", target_os = "linux")))]
+compile_error!("`linux_getrandom` backend can be enabled only for Linux/Android targets!");
+
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     util_libc::sys_fill_exact(dest, getrandom_syscall)
 }

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -2,6 +2,9 @@
 use crate::{lazy::LazyBool, util::slice_as_uninit, Error};
 use core::mem::{size_of, MaybeUninit};
 
+#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
+compile_error!("`rdrand` backend can be enabled only for x86 and x86-64 targets!");
+
 cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
         use core::arch::x86_64 as arch;

--- a/src/rndr.rs
+++ b/src/rndr.rs
@@ -1,13 +1,13 @@
 //! RNDR register backend for aarch64 targets
-// Arm Architecture Reference Manual for A-profile architecture
-// ARM DDI 0487K.a, ID032224, D23.2.147 RNDR, Random Number
-
-#[cfg(not(target_arch = "aarch64"))]
-compile_error!("the `rndr` backend can be enabled only for AArch64 targets!");
-
+//!
+//! Arm Architecture Reference Manual for A-profile architecture:
+//! ARM DDI 0487K.a, ID032224, D23.2.147 RNDR, Random Number
 use crate::{util::slice_as_uninit, Error};
 use core::arch::asm;
 use core::mem::{size_of, MaybeUninit};
+
+#[cfg(not(target_arch = "aarch64"))]
+compile_error!("the `rndr` backend can be enabled only for AArch64 targets!");
 
 const RETRY_LIMIT: usize = 5;
 

--- a/src/wasm_js.rs
+++ b/src/wasm_js.rs
@@ -4,6 +4,12 @@ use crate::Error;
 extern crate std;
 use std::{mem::MaybeUninit, thread_local};
 
+#[cfg(not(all(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    target_os = "unknown",
+)))]
+compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
+
 use js_sys::{global, Function, Uint8Array};
 use wasm_bindgen::{prelude::wasm_bindgen, JsCast, JsValue};
 


### PR DESCRIPTION
Move `compile_error!`s from lib.rs into opt-in backend modules. Rename `js.rs` to `wasm_js.rs` and `espidf.rs` to `esp_idf.rs` for consistency with backend names.