### PR TITLE
netbsd: fix potential panic

### DIFF
--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -74,12 +74,9 @@ jobs:
           toolchain: stable
           components: rust-src
           targets: aarch64-unknown-linux-gnu,x86_64-unknown-netbsd,x86_64-unknown-freebsd,x86_64-pc-solaris
-      - name: Install precompiled cross
-        run: |
-          VERSION=v0.2.5
-          URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
-          wget -O - $URL | tar -xz -C ~/.cargo/bin
-          cross --version
+      # TODO: use pre-compiled cross after a new (post-0.2.5) release
+      - name: Install cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build (rndr.rs)
         env:

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -89,10 +89,10 @@ jobs:
       - name: Check (getrandom.rs)
         run: ret=$(grep panic target/x86_64-unknown-freebsd/release/libgetrandom_wrapper.so; echo $?); [ $ret -eq 1 ]
 
-      # - name: Build (netbsd.rs)
-      #   run: cross build --release --target=x86_64-unknown-netbsd
-      # - name: Check (netbsd.rs)
-      #   run: ret=$(grep panic target/x86_64-unknown-netbsd/release/libgetrandom_wrapper.so; echo $?); [ $ret -eq 1 ]
+      - name: Build (netbsd.rs)
+        run: cross build --release --target=x86_64-unknown-netbsd
+      - name: Check (netbsd.rs)
+        run: ret=$(grep panic target/x86_64-unknown-netbsd/release/libgetrandom_wrapper.so; echo $?); [ $ret -eq 1 ]
 
       # - name: Build (solaris.rs)
       #   run: cross build --release --target=x86_64-pc-solaris

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -74,8 +74,12 @@ jobs:
           toolchain: stable
           components: rust-src
           targets: aarch64-unknown-linux-gnu,x86_64-unknown-netbsd,x86_64-unknown-freebsd,x86_64-pc-solaris
-      - name: Install cross
-        run: cargo install cross --git https://github.com/cross-rs/cross
+      - name: Install precompiled cross
+        run: |
+          VERSION=v0.2.5
+          URL=https://github.com/cross-rs/cross/releases/download/${VERSION}/cross-x86_64-unknown-linux-gnu.tar.gz
+          wget -O - $URL | tar -xz -C ~/.cargo/bin
+          cross --version
 
       - name: Build (rndr.rs)
         env:


### PR DESCRIPTION
The code was assuming that syscall returns either -1 or provided length. Fix code to account for potential bad return results.