### PR TITLE
Add memory sanitizer support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -159,6 +159,20 @@ jobs:
       - run: cargo test --target=x86_64-win7-windows-msvc -Z build-std --features=std
       - run: cargo test --target=i686-win7-windows-msvc -Z build-std --features=std
 
+  sanitizer-test:
+    name: Sanitizer Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-10-08
+          components: rust-src
+      - env:
+          RUSTFLAGS: -Dwarnings -Zsanitizer=memory --cfg getrandom_sanitize
+        # `--all-targets` is used to skip doc tests which currently fail linking
+        run: cargo test -Zbuild-std --target=x86_64-unknown-linux-gnu --all-targets
+
   cross-tests:
     name: Cross Test
     runs-on: ubuntu-22.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Error::new_custom` method [#507]
 - `rndr` opt-in backend [#512]
 - `linux_rustix` opt-in backend [#520]
+- Memory sanitizer support gated behind `getrandom_sanitize` configuration flag [#521]
 
 [#415]: https://github.com/rust-random/getrandom/pull/415
 [#440]: https://github.com/rust-random/getrandom/pull/440
@@ -42,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#507]: https://github.com/rust-random/getrandom/pull/507
 [#512]: https://github.com/rust-random/getrandom/pull/512
 [#520]: https://github.com/rust-random/getrandom/pull/520
+[#521]: https://github.com/rust-random/getrandom/pull/521
 
 ## [0.2.15] - 2024-05-06
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ rustc-dep-of-std = ["compiler_builtins", "core"]
 level = "warn"
 check-cfg = [
   'cfg(getrandom_backend, values("custom", "rdrand", "rndr", "linux_getrandom", "linux_rustix", "wasm_js", "esp_idf"))',
+  'cfg(getrandom_sanitize)',
   'cfg(getrandom_browser_test)',
   'cfg(getrandom_test_linux_fallback)',
 ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,7 +212,7 @@
 //! configuration flag for `getrandom_uninit` to unpoison destination buffer.
 //!
 //! For example, it can be done like this (requires Nightly compiler):
-//! ```
+//! ```text
 //! RUSTFLAGS="-Zsanitizer=memory --cfg getrandom_sanitize" cargo test -Zbuild-std --target=x86_64-unknown-linux-gnu
 //! ```
 //!


### PR DESCRIPTION
Add new `getrandom_sanitize` flag which enables unpoisoning of buffer passed to `getrandom_uninit`.