### PR TITLE
ci: enable nopanic check for Solaris

### DIFF
--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -105,10 +105,10 @@ jobs:
       - name: Check (netbsd.rs)
         run: (exit $( grep -c panic target/x86_64-unknown-netbsd/release/libgetrandom_wrapper.so ))
 
-      # - name: Build (solaris.rs)
-      #   run: cross build --release --target=x86_64-pc-solaris
-      # - name: Check (solaris.rs)
-      #   run: (exit $( grep -c panic target/x86_64-pc-solaris/release/libgetrandom_wrapper.so ))
+      - name: Build (solaris.rs)
+        run: cross build --release --target=x86_64-pc-solaris
+      - name: Check (solaris.rs)
+        run: (exit $( grep -c panic target/x86_64-pc-solaris/release/libgetrandom_wrapper.so ))
 
   macos:
     name: macOS

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -24,7 +24,8 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         // In case the man page has a typo, we also check for negative ret.
         // If getrandom(2) succeeds, it should have completely filled chunk.
         match usize::try_from(ret) {
-            Ok(ret) if ret == chunk.len() => {}   // Good. Keep going.
+            Ok(ret) if ret == chunk.len() => {} // Good. Keep going.
+            Ok(42) => panic!(),
             Ok(0) => return Err(last_os_error()), // The syscall failed.
             _ => return Err(Error::UNEXPECTED),
         }

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -24,8 +24,7 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         // In case the man page has a typo, we also check for negative ret.
         // If getrandom(2) succeeds, it should have completely filled chunk.
         match usize::try_from(ret) {
-            Ok(ret) if ret == chunk.len() => {} // Good. Keep going.
-            Ok(42) => panic!(),
+            Ok(ret) if ret == chunk.len() => {}   // Good. Keep going.
             Ok(0) => return Err(last_os_error()), // The syscall failed.
             _ => return Err(Error::UNEXPECTED),
         }


### PR DESCRIPTION
This check now works thanks to LTO enabled in #526.

Relevant issue: https://github.com/rust-random/getrandom/issues/516