### PR TITLE
ci: use VM to test BSD targets

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -216,6 +216,20 @@ jobs:
       - run: sudo xcode-select -switch /Applications/Xcode_15.2.app
       - run: cargo test --no-run --target=aarch64-apple-visionos -Zbuild-std --features=std
 
+  freebsd:
+    name: FreeBSD Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test in FreeBSD
+        uses: vmactions/freebsd-vm@v1
+        with:
+          envs: 'RUSTFLAGS'
+          usesh: true
+          prepare: |
+            pkg install -y rust
+          run: cargo test
+
   cross-link:
     name: Cross Build/Link
     runs-on: ubuntu-22.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -217,12 +217,54 @@ jobs:
       - run: cargo test --no-run --target=aarch64-apple-visionos -Zbuild-std --features=std
 
   freebsd:
-    name: FreeBSD Test
-    runs-on: ubuntu-latest
+    name: FreeBSD VM Test
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Test in FreeBSD
         uses: vmactions/freebsd-vm@v1
+        with:
+          envs: 'RUSTFLAGS'
+          usesh: true
+          prepare: |
+            pkg install -y rust
+          run: cargo test
+
+  openbsd:
+    name: OpenBSD VM Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test in OpenBSD
+        uses: vmactions/openbsd-vm@v1
+        with:
+          envs: 'RUSTFLAGS'
+          usesh: true
+          prepare: |
+            pkg_add rust
+          run: cargo test
+
+  netbsd:
+    name: NetBSD VM Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test in NetBSD
+        uses: vmactions/netbsd-vm@v1
+        with:
+          envs: 'RUSTFLAGS'
+          usesh: true
+          prepare: |
+            /usr/sbin/pkg_add rust
+          run: cargo test
+
+  dragonflybsd:
+    name: DragonflyBSD VM Test
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test in DragonflyBSD
+        uses: vmactions/dragonflybsd-vm@v1
         with:
           envs: 'RUSTFLAGS'
           usesh: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,19 +258,21 @@ jobs:
             /usr/sbin/pkg_add rust
           run: cargo test
 
-  dragonflybsd:
-    name: DragonflyBSD VM Test
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test in DragonflyBSD
-        uses: vmactions/dragonflybsd-vm@v1
-        with:
-          envs: 'RUSTFLAGS'
-          usesh: true
-          prepare: |
-            pkg install -y rust
-          run: cargo test
+  # This job currently fails:
+  # https://github.com/rust-random/getrandom/actions/runs/11405005618/job/31735653874?pr=528
+  # dragonflybsd:
+  #   name: DragonflyBSD VM Test
+  #   runs-on: ubuntu-22.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Test in DragonflyBSD
+  #       uses: vmactions/dragonflybsd-vm@v1
+  #       with:
+  #         envs: 'RUSTFLAGS'
+  #         usesh: true
+  #         prepare: |
+  #           pkg install -y rust
+  #         run: cargo test
 
   cross-link:
     name: Cross Build/Link


### PR DESCRIPTION
Add CI jobs for FreeBSD, OpenBSD, and NetBSD.

Solaris is not tested because it lacks pre-compiled host tools.

DragonflyBSD job is currently disabled because cargo fails to update crates.io index.

Closes #430