### PR TITLE
Rename `__getrandom_custom` to `__getrandom_v03_custom`

### DIFF
--- a/nopanic_check/src/lib.rs
+++ b/nopanic_check/src/lib.rs
@@ -19,7 +19,7 @@ pub extern "C" fn getrandom_wrapper(buf_ptr: *mut u8, buf_len: usize) -> u32 {
 
 #[cfg(getrandom_backend = "custom")]
 #[no_mangle]
-unsafe extern "Rust" fn __getrandom_custom(
+unsafe extern "Rust" fn __getrandom_v03_custom(
     dest: *mut u8,
     len: usize,
 ) -> Result<(), getrandom::Error> {

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -4,7 +4,7 @@ use core::mem::MaybeUninit;
 
 pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     extern "Rust" {
-        fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
+        fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
     }
-    unsafe { __getrandom_custom(dest.as_mut_ptr().cast(), dest.len()) }
+    unsafe { __getrandom_v03_custom(dest.as_mut_ptr().cast(), dest.len()) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,10 @@
 //! use getrandom::Error;
 //!
 //! #[no_mangle]
-//! unsafe extern "Rust" fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
+//! unsafe extern "Rust" fn __getrandom_v03_custom(
+//!     dest: *mut u8,
+//!     len: usize,
+//! ) -> Result<(), Error> {
 //!     todo!()
 //! }
 //! ```
@@ -133,7 +136,10 @@
 //! use getrandom::Error;
 //!
 //! #[no_mangle]
-//! unsafe extern "Rust" fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
+//! unsafe extern "Rust" fn __getrandom_v03_custom(
+//!     dest: *mut u8,
+//!     len: usize,
+//! ) -> Result<(), Error> {
 //!     Err(Error::UNSUPPORTED)
 //! }
 //! ```

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -206,7 +206,7 @@ mod custom {
     //
     // WARNING: this custom implementation is for testing purposes ONLY!
     #[no_mangle]
-    unsafe extern "Rust" fn __getrandom_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
+    unsafe extern "Rust" fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error> {
         use std::time::{SystemTime, UNIX_EPOCH};
 
         assert_ne!(len, 0);


### PR DESCRIPTION
This is done to prevent potential conflicts between getrandom v0.2 and v0.3 in the case when users rely on a custom backend and have both versions in their dependency tree.