### PR TITLE
Rename `getrandom(_uninit)` to `fill(_uninit)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 - Update MSRV to 1.60 [#472]
 
+#### Changed
+- `getrandom` and `getrandom_uninit` functions are renamed to `fill` and `fill_uninit` respectively [#532]
+
 #### Removed
 - `wasm32-wasi` target support (use `wasm32-wasip1` or `wasm32-wasip2` instead) [#499]
 - `linux_disable_fallback`, `rdrand`, `js`, `test-in-browser`, and `custom` crate features
@@ -46,6 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#520]: https://github.com/rust-random/getrandom/pull/520
 [#521]: https://github.com/rust-random/getrandom/pull/521
 [#522]: https://github.com/rust-random/getrandom/pull/522
+[#532]: https://github.com/rust-random/getrandom/pull/532
 
 ## [0.2.15] - 2024-05-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking Changes
 
 #### Changed
-- Update MSRV to 1.60 [#472]
-- `getrandom` and `getrandom_uninit` functions are renamed to `fill` and `fill_uninit` respectively [#532]
+- Bump MSRV to 1.60 [#472]
+- Rename `getrandom` and `getrandom_uninit` functions to `fill` and `fill_uninit` respectively [#532]
 
 #### Removed
 - `wasm32-wasi` target support (use `wasm32-wasip1` or `wasm32-wasip2` instead) [#499]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Breaking Changes
-- Update MSRV to 1.60 [#472]
 
 #### Changed
+- Update MSRV to 1.60 [#472]
 - `getrandom` and `getrandom_uninit` functions are renamed to `fill` and `fill_uninit` respectively [#532]
 
 #### Removed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Then invoke the `getrandom` function:
 ```rust
 fn get_random_buf() -> Result<[u8; 32], getrandom::Error> {
     let mut buf = [0u8; 32];
-    getrandom::getrandom(&mut buf)?;
+    getrandom::fill(&mut buf)?;
     Ok(buf)
 }
 ```

--- a/benches/buffer.rs
+++ b/benches/buffer.rs
@@ -5,15 +5,15 @@ use std::mem::MaybeUninit;
 
 // Call getrandom on a zero-initialized stack buffer
 #[inline(always)]
-fn bench_getrandom<const N: usize>() {
+fn bench_fill<const N: usize>() {
     let mut buf = [0u8; N];
     getrandom::fill(&mut buf).unwrap();
     test::black_box(&buf[..]);
 }
 
-// Call getrandom_uninit on an uninitialized stack buffer
+// Call fill_uninit on an uninitialized stack buffer
 #[inline(always)]
-fn bench_getrandom_uninit<const N: usize>() {
+fn bench_fill_uninit<const N: usize>() {
     let mut uninit = [MaybeUninit::uninit(); N];
     let buf: &[u8] = getrandom::fill_uninit(&mut uninit).unwrap();
     test::black_box(buf);
@@ -30,20 +30,20 @@ macro_rules! bench {
     ( $name:ident, $size:expr ) => {
         pub mod $name {
             #[bench]
-            pub fn bench_getrandom(b: &mut test::Bencher) {
+            pub fn bench_fill(b: &mut test::Bencher) {
                 #[inline(never)]
                 fn inner() {
-                    super::bench_getrandom::<{ $size }>()
+                    super::bench_fill::<{ $size }>()
                 }
 
                 b.bytes = $size as u64;
                 b.iter(inner);
             }
             #[bench]
-            pub fn bench_getrandom_uninit(b: &mut test::Bencher) {
+            pub fn bench_fill_uninit(b: &mut test::Bencher) {
                 #[inline(never)]
                 fn inner() {
-                    super::bench_getrandom_uninit::<{ $size }>()
+                    super::bench_fill_uninit::<{ $size }>()
                 }
 
                 b.bytes = $size as u64;

--- a/benches/buffer.rs
+++ b/benches/buffer.rs
@@ -7,7 +7,7 @@ use std::mem::MaybeUninit;
 #[inline(always)]
 fn bench_getrandom<const N: usize>() {
     let mut buf = [0u8; N];
-    getrandom::getrandom(&mut buf).unwrap();
+    getrandom::fill(&mut buf).unwrap();
     test::black_box(&buf[..]);
 }
 
@@ -15,7 +15,7 @@ fn bench_getrandom<const N: usize>() {
 #[inline(always)]
 fn bench_getrandom_uninit<const N: usize>() {
     let mut uninit = [MaybeUninit::uninit(); N];
-    let buf: &[u8] = getrandom::getrandom_uninit(&mut uninit).unwrap();
+    let buf: &[u8] = getrandom::fill_uninit(&mut uninit).unwrap();
     test::black_box(buf);
 }
 

--- a/nopanic_check/src/lib.rs
+++ b/nopanic_check/src/lib.rs
@@ -13,7 +13,7 @@ fn panic(_info: &core::panic::PanicInfo) -> ! {
 #[no_mangle]
 pub extern "C" fn getrandom_wrapper(buf_ptr: *mut u8, buf_len: usize) -> u32 {
     let buf = unsafe { core::slice::from_raw_parts_mut(buf_ptr.cast(), buf_len) };
-    let res = getrandom::getrandom_uninit(buf).map(|_| ());
+    let res = getrandom::fill_uninit(buf).map(|_| ());
     unsafe { core::mem::transmute(res) }
 }
 

--- a/src/apple-other.rs
+++ b/src/apple-other.rs
@@ -2,7 +2,7 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let dst_ptr = dest.as_mut_ptr().cast::<c_void>();
     let ret = unsafe { libc::CCRandomGenerateBytes(dst_ptr, dest.len()) };
     if ret == libc::kCCSuccess {

--- a/src/custom.rs
+++ b/src/custom.rs
@@ -2,7 +2,7 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     extern "Rust" {
         fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
     }

--- a/src/esp_idf.rs
+++ b/src/esp_idf.rs
@@ -9,7 +9,7 @@ extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
     // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
     // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html

--- a/src/fuchsia.rs
+++ b/src/fuchsia.rs
@@ -7,7 +7,7 @@ extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     unsafe { zx_cprng_draw(dest.as_mut_ptr().cast::<u8>(), dest.len()) }
     Ok(())
 }

--- a/src/getentropy.rs
+++ b/src/getentropy.rs
@@ -10,7 +10,7 @@
 use crate::{util_libc::last_os_error, Error};
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr().cast::<c_void>(), chunk.len()) };
         if ret != 0 {

--- a/src/getrandom.rs
+++ b/src/getrandom.rs
@@ -18,7 +18,7 @@
 use crate::{util_libc::sys_fill_exact, Error};
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr().cast::<c_void>(), buf.len(), 0)
     })

--- a/src/hermit.rs
+++ b/src/hermit.rs
@@ -6,7 +6,7 @@ extern "C" {
     fn sys_read_entropy(buffer: *mut u8, length: usize, flags: u32) -> isize;
 }
 
-pub fn getrandom_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     while !dest.is_empty() {
         let res = unsafe { sys_read_entropy(dest.as_mut_ptr().cast::<u8>(), dest.len(), 0) };
         match res {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -458,8 +458,10 @@ cfg_if! {
 /// # Examples
 ///
 /// ```
+/// # fn main() -> Result<(), getrandom::Error> {
 /// let mut buf = [0u8; 32];
 /// getrandom::fill(&mut buf)?;
+/// # Ok(()) }
 /// ```
 #[inline]
 pub fn fill(dest: &mut [u8]) -> Result<(), Error> {
@@ -489,7 +491,7 @@ pub fn fill(dest: &mut [u8]) -> Result<(), Error> {
 /// #![feature(maybe_uninit_uninit_array)]
 /// # fn main() -> Result<(), getrandom::Error> {
 /// let mut buf = core::mem::MaybeUninit::uninit_array::<1024>();
-/// let buf: &mut [u8] = getrandom::getrandom_uninit(&mut buf)?;
+/// let buf: &mut [u8] = getrandom::fill_uninit(&mut buf)?;
 /// # Ok(()) }
 /// ```
 #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,7 @@
 //!
 //! ## Sanitizer support
 //!
-//! If your code uses `getrandom_uninit` and you use memory sanitizer
+//! If your code uses [`fill_uninit`] and you use memory sanitizer
 //! (i.e. `-Zsanitizer=memory`), then you need to pass `getrandom_sanitize`
 //! configuration flag for `getrandom_uninit` to unpoison destination buffer.
 //!
@@ -304,8 +304,8 @@ use crate::util::{slice_as_uninit_mut, slice_assume_init_mut};
 
 // System-specific implementations.
 //
-// These should all provide getrandom_inner with the signature
-// `fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`.
+// These should all provide fill_inner with the signature
+// `fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`.
 // The function MUST fully initialize `dest` when `Ok(())` is returned.
 // The function MUST NOT ever write uninitialized bytes into `dest`,
 // regardless of what value it returns.
@@ -442,8 +442,7 @@ cfg_if! {
     }
 }
 
-/// Fill `dest` with random bytes from the system's preferred random number
-/// source.
+/// Fill `dest` with random bytes from the system's preferred random number source.
 ///
 /// This function returns an error on any failure, including partial reads. We
 /// make no guarantees regarding the contents of `dest` on error. If `dest` is
@@ -455,17 +454,25 @@ cfg_if! {
 /// In general, `getrandom` will be fast enough for interactive usage, though
 /// significantly slower than a user-space CSPRNG; for the latter consider
 /// [`rand::thread_rng`](https://docs.rs/rand/*/rand/fn.thread_rng.html).
+///
+/// # Examples
+///
+/// ```
+/// let mut buf = [0u8; 32];
+/// getrandom::fill(&mut buf)?;
+/// ```
 #[inline]
-pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
-    // SAFETY: The `&mut MaybeUninit<_>` reference doesn't escape, and
-    // `getrandom_uninit` guarantees it will never de-initialize any part of
-    // `dest`.
-    getrandom_uninit(unsafe { slice_as_uninit_mut(dest) })?;
+pub fn fill(dest: &mut [u8]) -> Result<(), Error> {
+    // SAFETY: The `&mut MaybeUninit<_>` reference doesn't escape,
+    // and `fill_uninit` guarantees it will never de-initialize
+    // any part of `dest`.
+    fill_uninit(unsafe { slice_as_uninit_mut(dest) })?;
     Ok(())
 }
 
-/// Version of the `getrandom` function which fills `dest` with random bytes
-/// returns a mutable reference to those bytes.
+/// Fill potentially uninitialized buffer `dest` with random bytes from
+/// the system's preferred random number source and return a mutable
+/// reference to those bytes.
 ///
 /// On successful completion this function is guaranteed to return a slice
 /// which points to the same memory as `dest` and has the same length.
@@ -486,9 +493,9 @@ pub fn getrandom(dest: &mut [u8]) -> Result<(), Error> {
 /// # Ok(()) }
 /// ```
 #[inline]
-pub fn getrandom_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error> {
     if !dest.is_empty() {
-        imp::getrandom_inner(dest)?;
+        imp::fill_inner(dest)?;
     }
 
     #[cfg(getrandom_sanitize)]
@@ -497,7 +504,7 @@ pub fn getrandom_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<&mut [u8], Error
         fn __msan_unpoison(a: *mut core::ffi::c_void, size: usize);
     }
 
-    // SAFETY: `dest` has been fully initialized by `imp::getrandom_inner`
+    // SAFETY: `dest` has been fully initialized by `imp::fill_inner`
     // since it returned `Ok`.
     Ok(unsafe {
         #[cfg(getrandom_sanitize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -215,7 +215,7 @@
 //!
 //! If your code uses [`fill_uninit`] and you use memory sanitizer
 //! (i.e. `-Zsanitizer=memory`), then you need to pass `getrandom_sanitize`
-//! configuration flag for `getrandom_uninit` to unpoison destination buffer.
+//! configuration flag for `fill_uninit` to unpoison destination buffer.
 //!
 //! For example, it can be done like this (requires Nightly compiler):
 //! ```text

--- a/src/linux_android.rs
+++ b/src/linux_android.rs
@@ -5,7 +5,7 @@ use core::mem::MaybeUninit;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 compile_error!("`linux_getrandom` backend can be enabled only for Linux/Android targets!");
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     util_libc::sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr().cast(), buf.len(), 0)
     })

--- a/src/linux_android_with_fallback.rs
+++ b/src/linux_android_with_fallback.rs
@@ -52,10 +52,10 @@ fn init() -> NonNull<c_void> {
 // prevent inlining of the fallback implementation
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    use_file::getrandom_inner(dest)
+    use_file::fill_inner(dest)
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Despite being only a single atomic variable, we still cannot always use
     // Ordering::Relaxed, as we need to make sure a successful call to `init`
     // is "ordered before" any data read through the returned pointer (which

--- a/src/linux_rustix.rs
+++ b/src/linux_rustix.rs
@@ -5,7 +5,7 @@ use rustix::rand::{getrandom_uninit, GetRandomFlags};
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 compile_error!("`linux_rustix` backend can be enabled only for Linux/Android targets!");
 
-pub fn getrandom_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     loop {
         let res = getrandom_uninit(dest, GetRandomFlags::empty()).map(|(res, _)| res.len());
         match res {

--- a/src/netbsd.rs
+++ b/src/netbsd.rs
@@ -57,7 +57,7 @@ fn init() -> *mut c_void {
     ptr
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Despite being only a single atomic variable, we still cannot always use
     // Ordering::Relaxed, as we need to make sure a successful call to `init`
     // is "ordered before" any data read through the returned pointer (which

--- a/src/rdrand.rs
+++ b/src/rdrand.rs
@@ -96,7 +96,7 @@ fn is_rdrand_good() -> bool {
     unsafe { self_test() }
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RDRAND_GOOD: LazyBool = LazyBool::new();
     if !RDRAND_GOOD.unsync_init(is_rdrand_good) {
         return Err(Error::NO_RDRAND);

--- a/src/rndr.rs
+++ b/src/rndr.rs
@@ -101,7 +101,7 @@ fn is_rndr_available() -> bool {
     }
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if is_rndr_available() {
         // SAFETY: after this point, we know the `rand` target feature is enabled
         unsafe { rndr_fill(dest).ok_or(Error::RNDR_FAILURE) }

--- a/src/solaris.rs
+++ b/src/solaris.rs
@@ -17,7 +17,7 @@ use core::{ffi::c_void, mem::MaybeUninit};
 
 const MAX_BYTES: usize = 1024;
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(MAX_BYTES) {
         let ptr = chunk.as_mut_ptr().cast::<c_void>();
         let ret = unsafe { libc::getrandom(ptr, chunk.len(), libc::GRND_RANDOM) };

--- a/src/solid.rs
+++ b/src/solid.rs
@@ -6,7 +6,7 @@ extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr().cast::<u8>(), dest.len()) };
     if ret >= 0 {
         Ok(())

--- a/src/use_file.rs
+++ b/src/use_file.rs
@@ -37,7 +37,7 @@ const FD_ONGOING_INIT: libc::c_int = -2;
 // `Ordering::Acquire` to synchronize with it.
 static FD: AtomicI32 = AtomicI32::new(FD_UNINIT);
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let mut fd = FD.load(Ordering::Acquire);
     if fd == FD_UNINIT || fd == FD_ONGOING_INIT {
         fd = open_or_wait()?;

--- a/src/vxworks.rs
+++ b/src/vxworks.rs
@@ -6,7 +6,7 @@ use core::{
     sync::atomic::{AtomicBool, Ordering::Relaxed},
 };
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };

--- a/src/wasi.rs
+++ b/src/wasi.rs
@@ -12,7 +12,7 @@ compile_error!(
 );
 
 #[cfg(target_env = "p1")]
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // This linking is vendored from the wasi crate:
     // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2344-2350
     #[link(wasm_import_module = "wasi_snapshot_preview1")]
@@ -38,7 +38,7 @@ pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
 }
 
 #[cfg(target_env = "p2")]
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use core::ptr::copy_nonoverlapping;
     use wasi::random::random::get_random_u64;
 

--- a/src/wasm_js.rs
+++ b/src/wasm_js.rs
@@ -30,7 +30,7 @@ thread_local!(
     static RNG_SOURCE: Result<RngSource, Error> = getrandom_init();
 );
 
-pub(crate) fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub(crate) fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     RNG_SOURCE.with(|result| {
         let source = result.as_ref().map_err(|&e| e)?;
 

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -31,7 +31,7 @@ windows_targets::link!("bcryptprimitives.dll" "system" fn ProcessPrng(pbdata: *m
 pub type BOOL = i32;
 pub const TRUE: BOOL = 1i32;
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // ProcessPrng should always return TRUE, but we check just in case.
     match unsafe { ProcessPrng(dest.as_mut_ptr().cast::<u8>(), dest.len()) } {
         TRUE => Ok(()),

--- a/src/windows7.rs
+++ b/src/windows7.rs
@@ -23,7 +23,7 @@ extern "system" {
 type BOOLEAN = u8;
 const TRUE: BOOLEAN = 1u8;
 
-pub fn getrandom_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
     let chunk_size = usize::try_from(i32::MAX).expect("Windows does not support 16-bit targets");
     for chunk in dest.chunks_mut(chunk_size) {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,5 +1,5 @@
 use core::mem::MaybeUninit;
-use getrandom::{getrandom, getrandom_uninit};
+use getrandom::{fill, fill_uninit};
 
 #[cfg(getrandom_browser_test)]
 use wasm_bindgen_test::wasm_bindgen_test as test;
@@ -9,8 +9,8 @@ wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 #[test]
 fn test_zero() {
     // Test that APIs are happy with zero-length requests
-    getrandom(&mut [0u8; 0]).unwrap();
-    let res = getrandom_uninit(&mut []).unwrap();
+    fill(&mut [0u8; 0]).unwrap();
+    let res = fill_uninit(&mut []).unwrap();
     assert!(res.is_empty());
 }
 
@@ -35,13 +35,13 @@ fn test_diff() {
     const N: usize = 1000;
     let mut v1 = [0u8; N];
     let mut v2 = [0u8; N];
-    getrandom(&mut v1).unwrap();
-    getrandom(&mut v2).unwrap();
+    fill(&mut v1).unwrap();
+    fill(&mut v2).unwrap();
 
     let mut t1 = uninit_vec(N);
     let mut t2 = uninit_vec(N);
-    let r1 = getrandom_uninit(&mut t1).unwrap();
-    let r2 = getrandom_uninit(&mut t2).unwrap();
+    let r1 = fill_uninit(&mut t1).unwrap();
+    let r2 = fill_uninit(&mut t2).unwrap();
     assert_eq!(r1.len(), N);
     assert_eq!(r2.len(), N);
 
@@ -71,8 +71,8 @@ fn test_small() {
             let s1 = &mut buf1[..size];
             let s2 = &mut buf2[..size];
 
-            getrandom(s1).unwrap();
-            getrandom(s2).unwrap();
+            fill(s1).unwrap();
+            fill(s2).unwrap();
 
             num_bytes += size;
             diff_bits += num_diff_bits(s1, s2);
@@ -99,8 +99,8 @@ fn test_small_uninit() {
             let s1 = &mut buf1[..size];
             let s2 = &mut buf2[..size];
 
-            let r1 = getrandom_uninit(s1).unwrap();
-            let r2 = getrandom_uninit(s2).unwrap();
+            let r1 = fill_uninit(s1).unwrap();
+            let r2 = fill_uninit(s2).unwrap();
             assert_eq!(r1.len(), size);
             assert_eq!(r2.len(), size);
 
@@ -115,14 +115,14 @@ fn test_small_uninit() {
 #[test]
 fn test_huge() {
     let mut huge = [0u8; 100_000];
-    getrandom(&mut huge).unwrap();
+    fill(&mut huge).unwrap();
 }
 
 #[test]
 fn test_huge_uninit() {
     const N: usize = 100_000;
     let mut huge = uninit_vec(N);
-    let res = getrandom_uninit(&mut huge).unwrap();
+    let res = fill_uninit(&mut huge).unwrap();
     assert_eq!(res.len(), N);
 }
 
@@ -146,7 +146,7 @@ fn test_multithreading() {
             let mut v = [0u8; 1000];
 
             for _ in 0..100 {
-                getrandom(&mut v).unwrap();
+                fill(&mut v).unwrap();
                 thread::yield_now();
             }
         });
@@ -236,7 +236,7 @@ mod custom {
     #[test]
     fn test_custom() {
         let mut buf = [0u8; 142];
-        let res = getrandom::getrandom(&mut buf);
+        let res = getrandom::fill(&mut buf);
         assert!(res.is_err());
     }
 }


### PR DESCRIPTION
The new names are shorter and easier to understand (i.e. compare `getrandom::fill` vs `getrandom::getrandom`).