### PR TITLE
Enable nopanic check for `linux_rustix`

### DIFF
--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -49,13 +49,12 @@ jobs:
       - name: Check (linux_android.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
-      # TODO: re-enable after https://github.com/bytecodealliance/rustix/pull/1184 is released
-      # - name: Build (linux_rustix.rs)
-      #   env:
-      #     RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_rustix"
-      #   run: cargo build --release
-      # - name: Check (linux_rustix.rs)
-      #   run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
+      - name: Build (linux_rustix.rs)
+        env:
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_rustix"
+        run: cargo build --release
+      - name: Check (linux_rustix.rs)
+        run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (rdrand.rs)
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libc = { version = "0.2.154", default-features = false }
 
 # linux_rustix
 [target.'cfg(all(any(target_os = "linux", target_os = "android"), any(target_env = "", getrandom_backend = "linux_rustix")))'.dependencies]
-rustix = { version = "0.38", default-features = false, features = ["rand"] }
+rustix = { version = "0.38.38", default-features = false, features = ["rand"] }
 
 # apple-other
 [target.'cfg(any(target_os = "ios", target_os = "visionos", target_os = "watchos", target_os = "tvos"))'.dependencies]


### PR DESCRIPTION
The `linux_rustix` opt-in backend should be panic-free in rustix v0.38.38.

Relevant issue #516