### PR TITLE
Add `wasm32v1-none` support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,8 @@
 # Allow normal use of "cargo run" and "cargo test" on these wasm32 platforms.
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+[target.wasm32v1-unknown]
+runner = 'wasm-bindgen-test-runner'
 [target.wasm32-wasip1]
 runner = 'wasmtime'
 [target.wasm32-wasip2]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,33 +245,33 @@ jobs:
       - name: Test (Node)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --node
+        run: wasm-pack test --node -- --features std
       - name: Test (Firefox)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (Chrome)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --chrome
+        run: wasm-pack test --headless --chrome -- --features std
       - name: Test (dedicated worker)
         env:
           WASM_BINDGEN_USE_DEDICATED_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (shared worker)
         env:
           WASM_BINDGEN_USE_SHARED_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (service worker)
         env:
           WASM_BINDGEN_USE_SERVICE_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
         # Firefox doesn't support module service workers and therefor can't import scripts
-        run: wasm-pack test --headless --chrome
+        run: wasm-pack test --headless --chrome -- --features std
 
   wasi:
     name: WASI

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
         # Fixed Nigthly version is used to prevent
         # CI failures which are not relevant to PR changes
         # on introduction of new Clippy lints.
-        toolchain: nightly-2024-10-08
+        toolchain: nightly-2024-10-24
         components: clippy,rust-src
     - name: std feature
       run: cargo clippy --features std
@@ -48,7 +48,15 @@ jobs:
     - name: Web WASM (wasm_js.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown
+      run: cargo clippy --features std -Zbuild-std=panic_abort,std --target wasm32-unknown-unknown
+    - name: Web WASM no_std (wasm_js.rs)
+      env:
+        RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+      run: cargo clippy -Zbuild-std=core,alloc --target wasm32-unknown-unknown
+    - name: Web WASM no_std with atomics (wasm_js.rs)
+      env:
+        RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory
+      run: cargo clippy -Zbuild-std=core,alloc --target wasm32-unknown-unknown
     - name: Linux (linux_android.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -57,6 +57,14 @@ jobs:
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory
       run: cargo clippy -Zbuild-std=core,alloc --target wasm32-unknown-unknown
+    - name: Web WASMv1 (wasm_js.rs)
+      env:
+        RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+      run: cargo clippy -Zbuild-std=core,alloc --target wasm32v1-none
+    - name: Web WASMv1 with atomics (wasm_js.rs)
+      env:
+        RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory
+      run: cargo clippy -Zbuild-std=core,alloc --target wasm32v1-none
     - name: Linux (linux_android.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,11 +63,11 @@ wasi = { version = "0.13", default-features = false }
 windows-targets = "0.52"
 
 # wasm_js
-[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dependencies]
+[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
 wasm-bindgen = { version = "0.2.96", default-features = false }
 js-sys = { version = "0.3.73", default-features = false }
 once_cell = { version = "1", default-features = false }
-[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = { version = "0.3", default-features = false }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,15 +64,16 @@ windows-targets = "0.52"
 
 # wasm_js
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-wasm-bindgen = { version = "0.2.89", default-features = false }
-js-sys = "0.3"
+wasm-bindgen = { version = "0.2.96", default-features = false }
+js-sys = { version = "0.3.73", default-features = false }
+once_cell = { version = "1", default-features = false }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
-wasm-bindgen-test = "0.3.39"
+wasm-bindgen-test = { version = "0.3", default-features = false }
 
 [features]
 # Implement std::error::Error for getrandom::Error and
 # use std to retrieve OS error descriptions
-std = []
+std = ["wasm-bindgen/std", "js-sys/std", "wasm-bindgen-test/std"]
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["compiler_builtins", "core"]
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Pull Requests that add support for new targets to `getrandom` are always welcome
 `getrandom` also provides optional (opt-in) backends, which allow users to customize the source
 of randomness based on their specific needs:
 
-| Backend name      | Target               | Target Triple            | Implementation
-| ----------------- | -------------------- | ------------------------ | --------------
-| `linux_getrandom` | Linux, Android       | `*‑linux‑*`              | [`getrandom`][1] system call (without `/dev/urandom` fallback). Bumps minimum supported Linux kernel version to 3.17 and Android API level to 23 (Marshmallow).
-| `linux_rustix`    | Linux, Android       | `*‑linux‑*`              | Same as `linux_getrandom`, but uses [`rustix`] instead of `libc`.
-| `rdrand`          | x86, x86-64          | `x86_64-*`, `i686-*`     | [`RDRAND`] instruction
-| `rndr`            | AArch64              | `aarch64-*`              | [`RNDR`] register
-| `esp_idf`         | ESP-IDF              | `*‑espidf`               | [`esp_fill_random`]. WARNING: can return low-quality entropy without proper hardware configuration!
-| `wasm_js`         | Web Browser, Node.js | `wasm32‑unknown‑unknown` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js (see [WebAssembly support])
-| `custom`          | All targets          | `*`                      | User-provided custom implementation (see [custom backend])
+| Backend name      | Target               | Target Triple                             | Implementation
+| ----------------- | -------------------- | ----------------------------------------- | --------------
+| `linux_getrandom` | Linux, Android       | `*‑linux‑*`                               | [`getrandom`][1] system call (without `/dev/urandom` fallback). Bumps minimum supported Linux kernel version to 3.17 and Android API level to 23 (Marshmallow).
+| `linux_rustix`    | Linux, Android       | `*‑linux‑*`                               | Same as `linux_getrandom`, but uses [`rustix`] instead of `libc`.
+| `rdrand`          | x86, x86-64          | `x86_64-*`, `i686-*`                      | [`RDRAND`] instruction
+| `rndr`            | AArch64              | `aarch64-*`                               | [`RNDR`] register
+| `esp_idf`         | ESP-IDF              | `*‑espidf`                                | [`esp_fill_random`]. WARNING: can return low-quality entropy without proper hardware configuration!
+| `wasm_js`         | Web Browser, Node.js | `wasm32‑unknown‑unknown`, `wasm32v1-none` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js (see [WebAssembly support])
+| `custom`          | All targets          | `*`                                       | User-provided custom implementation (see [custom backend])
 
 Opt-in backends can be enabled using the `getrandom_backend` configuration flag.
 The flag can be set either by specifying the `rustflags` field in

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -150,11 +150,12 @@ cfg_if! {
         pub use rdrand::*;
     } else if #[cfg(all(
         target_arch = "wasm32",
-        target_os = "unknown",
+        any(target_os = "unknown", target_os = "none"),
     ))] {
-        compile_error!("the wasm32-unknown-unknown targets are not supported \
-                        by default, you may need to enable the \"wasm_js\" \
-                        configuration flag. For more information see: \
+        compile_error!("the wasm32-unknown-unknown and wasm32v1-none targets \
+                        are not supported by default, you may need to enable \
+                        the \"wasm_js\" configuration flag. For more \
+                        information see: \
                         https://docs.rs/getrandom/#webassembly-support");
     } else {
         compile_error!("target is not supported. You may need to define \

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -7,7 +7,7 @@ use core::mem::MaybeUninit;
 
 pub use crate::util::{inner_u32, inner_u64};
 
-#[cfg(not(all(target_arch = "wasm32", target_os = "unknown",)))]
+#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"),)))]
 compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
 
 use js_sys::{global, Function, Uint8Array};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,16 @@
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![cfg_attr(getrandom_sanitize, feature(cfg_sanitize))]
+#![cfg_attr(
+    all(
+        getrandom_backend = "wasm_js",
+        target_arch = "wasm32",
+        target_os = "unknown",
+        not(feature = "std"),
+        target_feature = "atomics"
+    ),
+    feature(thread_local)
+)]
 #![deny(
     clippy::cast_lossless,
     clippy::cast_possible_truncation,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
     all(
         getrandom_backend = "wasm_js",
         target_arch = "wasm32",
-        target_os = "unknown",
+        any(target_os = "unknown", target_os = "none"),
         not(feature = "std"),
         target_feature = "atomics"
     ),


### PR DESCRIPTION
Changes:
- Add `default-features = false` to the `js-sys` and `wasm-bindgen-test` dependencies, enabling `no_std` support.
- The crate feature `std` now enabled `std` crate features of `wasm-bindgen`, `js-sys` and `wasm-bindgen-test`.
- Use `any(target_os = "unknown", target_os = "none")` instead of `target_os = "unknown"`.
- `thread_local!` is only supported with `std`, so a fallback to `static` with `once_cell::unsync::Lazy` is added. This is safe because Wasm doesn't support threads without `target_feature = "atomics"`.
- When detecting `target_feature = "atomics"` without `feature = "std"`, use [`#[thread_local]`](https://doc.rust-lang.org/1.82.0/unstable-book/language-features/thread-local.html?highlight=thread_lo#thread_local).
- Now `wasm32-unknown-unknown` is properly supported without pulling in `std`.

I was unable to add actual `no_std` tests without some ugly modifications to it. Especially because of the whole `harness = false` thing. Let me know how you want me to proceed.

~~This depends on https://github.com/rustwasm/wasm-bindgen/pull/4277 and a new `wasm-bindgen` release.~~
Was released.