### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, windows-2022]
-        toolchain: [nightly, beta, stable, "1.60"]
+        toolchain: [nightly, beta, stable, "1.63"]
         # Only Test macOS on stable to reduce macOS CI jobs
         include:
           # aarch64-apple-darwin.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "getrandom"
 version = "0.2.15" # Also update html_root_url in lib.rs when bumping this
 edition = "2021"
-rust-version = "1.60" # Sync .clippy.toml, tests.yml, and README.md.
+rust-version = "1.63" # Sync tests.yml and README.md.
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"
 description = "A small cross-platform library for retrieving random data from system source"

--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ RUSTFLAGS="-Zsanitizer=memory --cfg getrandom_sanitize" \
 
 ## Minimum Supported Rust Version
 
-This crate requires Rust 1.60.0 or later.
+This crate requires Rust 1.63 or later.
 
 ## License
 


### PR DESCRIPTION
This follows the MSRV bump in `libc`: https://github.com/rust-lang/libc/pull/4040