### PR TITLE
ci: do not test std feature in tier 3 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,7 +98,6 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        # Supported tier 3 targets without libstd support
         target: [
           aarch64-kmc-solid_asp3,
           aarch64-unknown-nto-qnx710,
@@ -107,7 +106,6 @@ jobs:
           i686-unknown-hurd-gnu,
           x86_64-unknown-hermit,
           x86_64-wrs-vxworks,
-          x86_64-unknown-openbsd,
           x86_64-unknown-dragonfly,
           x86_64-unknown-haiku,
         ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,32 +100,24 @@ jobs:
       matrix:
         # Supported tier 3 targets without libstd support
         target: [
-          x86_64-unknown-hermit,
-          x86_64-wrs-vxworks,
           aarch64-kmc-solid_asp3,
+          aarch64-unknown-nto-qnx710,
           armv6k-nintendo-3ds,
           armv7-sony-vita-newlibeabihf,
-          aarch64-unknown-nto-qnx710,
+          i686-unknown-hurd-gnu,
+          x86_64-unknown-hermit,
+          x86_64-wrs-vxworks,
+          x86_64-unknown-openbsd,
+          x86_64-unknown-dragonfly,
+          x86_64-unknown-haiku,
         ]
-        # Supported tier 3 targets with libstd support
-        include:
-          - target: aarch64-unknown-nto-qnx710
-            features: ["std"]
-          - target: x86_64-unknown-openbsd
-            features: ["std"]
-          - target: x86_64-unknown-dragonfly
-            features: ["std"]
-          - target: x86_64-unknown-haiku
-            features: ["std"]
-          - target: i686-unknown-hurd-gnu
-            features: ["std"]
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly # Required to build libcore
         with:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -Z build-std=${{ contains(matrix.features, 'std') && 'std' || 'core'}} --target=${{ matrix.target }} --features="${{ join(matrix.features, ',') }}"
+      - run: cargo build -Z build-std=core --target=${{ matrix.target }}
 
   rdrand:
     name: RDRAND


### PR DESCRIPTION
Rust CI does not test `std` build for tier 3 targets, which means that breakage can go unnoticed for a long time (see rust-lang/rust#123032 and rust-lang/rust#133401). This results in unrelated CI breakages on our side.

Additionally, removes OpenBSD from the tier3 build-only job since we test this target properly using VM.