### PR TITLE
Impl core::error::Error for Error on no_std

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -152,6 +152,8 @@ impl fmt::Display for Error {
     }
 }
 
+impl core::error::Error for Error {}
+
 fn internal_desc(error: Error) -> Option<&'static str> {
     let desc = match error {
         Error::UNSUPPORTED => "getrandom: this target is not supported",

--- a/src/error_std_impls.rs
+++ b/src/error_std_impls.rs
@@ -11,5 +11,3 @@ impl From<Error> for io::Error {
         }
     }
 }
-
-impl std::error::Error for Error {}


### PR DESCRIPTION
I assume this is an oversight and not deliberate.