### PR TITLE
Add "insecure" functions

### DIFF
--- a/src/backends.rs
+++ b/src/backends.rs
@@ -1,10 +1,16 @@
 //! System-specific implementations.
 //!
-//! This module should provide `fill_inner` with the signature
-//! `fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`.
-//! The function MUST fully initialize `dest` when `Ok(())` is returned.
-//! The function MUST NOT ever write uninitialized bytes into `dest`,
-//! regardless of what value it returns.
+//! This module should provide the following functions:
+//! - `fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`
+//! - `fn insecure_fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error>`
+//! - `fn u32() -> Result<u32, Error>`
+//! - `fn insecure_u32() -> Result<u32, Error>`
+//! - `fn u64() -> Result<u64, Error>`
+//! - `fn insecure_u64() -> Result<u64, Error>`
+//!
+//! `fill_uninit` and `insecure_fill_uninit` MUST fully initialize `dest`
+//! when `Ok(())` is returned. The functions MUST NOT ever write uninitialized
+//! bytes into `dest`, regardless of what value it returns.
 
 cfg_if! {
     if #[cfg(getrandom_backend = "custom")] {

--- a/src/backends/apple_other.rs
+++ b/src/backends/apple_other.rs
@@ -2,9 +2,9 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let dst_ptr = dest.as_mut_ptr().cast::<c_void>();
     let ret = unsafe { libc::CCRandomGenerateBytes(dst_ptr, dest.len()) };
     if ret == libc::kCCSuccess {

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -2,9 +2,9 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     extern "Rust" {
         fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
     }

--- a/src/backends/esp_idf.rs
+++ b/src/backends/esp_idf.rs
@@ -1,23 +1,36 @@
-//! Implementation for ESP-IDF
+//! Implementation for ESP-IDF.
+//!
+//! Note that NOT enabling WiFi, BT, or the voltage noise entropy source
+//! (via `bootloader_random_enable`) will cause ESP-IDF to return pseudo-random numbers based on
+//! the voltage noise entropy, after the initial boot process:
+//! https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
+//!
+//! However tracking if some of these entropy sources is enabled is way too difficult
+//! to implement here.
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64};
 
 #[cfg(not(target_os = "espidf"))]
 compile_error!("`esp_idf` backend can be enabled only for ESP-IDF targets!");
 
 extern "C" {
-    fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
+    fn esp_random() -> u32;
+    fn esp_fill_random(buf: *mut c_void, len: usize);
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
-    // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
-    // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
-    //
-    // However tracking if some of these entropy sources is enabled is way too difficult to implement here
-    unsafe { esp_fill_random(dest.as_mut_ptr().cast(), dest.len()) };
+pub fn u32() -> Result<u32, Error> {
+    Ok(unsafe { esp_random() })
+}
 
+pub fn u64() -> Result<u64, Error> {
+    let (a, b) = unsafe { (esp_random(), esp_random()) };
+    let res = (u64::from(a) << 32) | u64::from(b);
+    Ok(res)
+}
+
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { esp_fill_random(dest.as_mut_ptr().cast(), dest.len()) };
     Ok(())
 }

--- a/src/backends/fuchsia.rs
+++ b/src/backends/fuchsia.rs
@@ -2,14 +2,14 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[link(name = "zircon")]
 extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     unsafe { zx_cprng_draw(dest.as_mut_ptr().cast::<u8>(), dest.len()) }
     Ok(())
 }

--- a/src/backends/getentropy.rs
+++ b/src/backends/getentropy.rs
@@ -10,12 +10,12 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(256) {
         let ret = unsafe { libc::getentropy(chunk.as_mut_ptr().cast::<c_void>(), chunk.len()) };
         if ret != 0 {

--- a/src/backends/getrandom.rs
+++ b/src/backends/getrandom.rs
@@ -18,12 +18,12 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     util_libc::sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr().cast::<c_void>(), buf.len(), 0)
     })

--- a/src/backends/hermit.rs
+++ b/src/backends/hermit.rs
@@ -2,6 +2,8 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64};
+
 extern "C" {
     fn sys_read_entropy(buffer: *mut u8, length: usize, flags: u32) -> isize;
     // Note that `sys_secure_rand32/64` are implemented using `sys_read_entropy`:
@@ -12,7 +14,7 @@ extern "C" {
     fn sys_secure_rand64(value: *mut u64) -> i32;
 }
 
-pub fn inner_u32() -> Result<u32, Error> {
+pub fn u32() -> Result<u32, Error> {
     let mut res = MaybeUninit::uninit();
     let ret = unsafe { sys_secure_rand32(res.as_mut_ptr()) };
     match ret {
@@ -22,7 +24,7 @@ pub fn inner_u32() -> Result<u32, Error> {
     }
 }
 
-pub fn inner_u64() -> Result<u64, Error> {
+pub fn u64() -> Result<u64, Error> {
     let mut res = MaybeUninit::uninit();
     let ret = unsafe { sys_secure_rand64(res.as_mut_ptr()) };
     match ret {
@@ -32,7 +34,7 @@ pub fn inner_u64() -> Result<u64, Error> {
     }
 }
 
-pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     while !dest.is_empty() {
         let res = unsafe { sys_read_entropy(dest.as_mut_ptr().cast::<u8>(), dest.len(), 0) };
         match res {

--- a/src/backends/linux_android.rs
+++ b/src/backends/linux_android.rs
@@ -2,7 +2,7 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
@@ -10,7 +10,7 @@ mod util_libc;
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 compile_error!("`linux_getrandom` backend can be enabled only for Linux/Android targets!");
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     util_libc::sys_fill_exact(dest, |buf| unsafe {
         libc::getrandom(buf.as_mut_ptr().cast(), buf.len(), 0)
     })

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -9,7 +9,7 @@ use core::{
 };
 use use_file::util_libc;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 type GetRandomFn = unsafe extern "C" fn(*mut c_void, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
@@ -56,10 +56,10 @@ fn init() -> NonNull<c_void> {
 // prevent inlining of the fallback implementation
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    use_file::fill_inner(dest)
+    use_file::fill_uninit(dest)
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Despite being only a single atomic variable, we still cannot always use
     // Ordering::Relaxed, as we need to make sure a successful call to `init`
     // is "ordered before" any data read through the returned pointer (which

--- a/src/backends/linux_rustix.rs
+++ b/src/backends/linux_rustix.rs
@@ -2,12 +2,12 @@
 use crate::{Error, MaybeUninit};
 use rustix::rand::{getrandom_uninit, GetRandomFlags};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 compile_error!("`linux_rustix` backend can be enabled only for Linux/Android targets!");
 
-pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     loop {
         let res = getrandom_uninit(dest, GetRandomFlags::empty()).map(|(res, _)| res.len());
         match res {

--- a/src/backends/netbsd.rs
+++ b/src/backends/netbsd.rs
@@ -12,7 +12,7 @@ use core::{
     sync::atomic::{AtomicPtr, Ordering},
 };
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
@@ -62,7 +62,7 @@ fn init() -> *mut c_void {
     ptr
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Despite being only a single atomic variable, we still cannot always use
     // Ordering::Relaxed, as we need to make sure a successful call to `init`
     // is "ordered before" any data read through the returned pointer (which

--- a/src/backends/rdrand.rs
+++ b/src/backends/rdrand.rs
@@ -2,6 +2,8 @@
 use crate::{util::slice_as_uninit, Error};
 use core::mem::{size_of, MaybeUninit};
 
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64};
+
 #[path = "../lazy.rs"]
 mod lazy;
 
@@ -147,7 +149,7 @@ unsafe fn rdrand_u64() -> Option<u64> {
     Some((u64::from(a) << 32) || u64::from(b))
 }
 
-pub fn inner_u32() -> Result<u32, Error> {
+pub fn u32() -> Result<u32, Error> {
     if !RDRAND_GOOD.unsync_init(is_rdrand_good) {
         return Err(Error::NO_RDRAND);
     }
@@ -155,7 +157,7 @@ pub fn inner_u32() -> Result<u32, Error> {
     unsafe { rdrand_u32() }.ok_or(Error::FAILED_RDRAND)
 }
 
-pub fn inner_u64() -> Result<u64, Error> {
+pub fn u64() -> Result<u64, Error> {
     if !RDRAND_GOOD.unsync_init(is_rdrand_good) {
         return Err(Error::NO_RDRAND);
     }
@@ -163,7 +165,7 @@ pub fn inner_u64() -> Result<u64, Error> {
     unsafe { rdrand_u64() }.ok_or(Error::FAILED_RDRAND)
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if !RDRAND_GOOD.unsync_init(is_rdrand_good) {
         return Err(Error::NO_RDRAND);
     }

--- a/src/backends/rndr.rs
+++ b/src/backends/rndr.rs
@@ -9,6 +9,8 @@ use crate::{
 use core::arch::asm;
 use core::mem::{size_of, MaybeUninit};
 
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64};
+
 #[cfg(not(target_arch = "aarch64"))]
 compile_error!("the `rndr` backend can be enabled only for AArch64 targets!");
 
@@ -104,7 +106,7 @@ fn is_rndr_available() -> bool {
     }
 }
 
-pub fn inner_u32() -> Result<u32, Error> {
+pub fn u32() -> Result<u32, Error> {
     if is_rndr_available() {
         // SAFETY: after this point, we know the `rand` target feature is enabled
         let res = unsafe { rndr() };
@@ -114,7 +116,7 @@ pub fn inner_u32() -> Result<u32, Error> {
     }
 }
 
-pub fn inner_u64() -> Result<u64, Error> {
+pub fn u64() -> Result<u64, Error> {
     if is_rndr_available() {
         // SAFETY: after this point, we know the `rand` target feature is enabled
         let res = unsafe { rndr() };
@@ -124,7 +126,7 @@ pub fn inner_u64() -> Result<u64, Error> {
     }
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if is_rndr_available() {
         // SAFETY: after this point, we know the `rand` target feature is enabled
         unsafe { rndr_fill(dest).ok_or(Error::RNDR_FAILURE) }

--- a/src/backends/solaris.rs
+++ b/src/backends/solaris.rs
@@ -15,14 +15,14 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
 
 const MAX_BYTES: usize = 1024;
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     for chunk in dest.chunks_mut(MAX_BYTES) {
         let ptr = chunk.as_mut_ptr().cast::<c_void>();
         let ret = unsafe { libc::getrandom(ptr, chunk.len(), libc::GRND_RANDOM) };

--- a/src/backends/solid.rs
+++ b/src/backends/solid.rs
@@ -2,13 +2,13 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr().cast::<u8>(), dest.len()) };
     if ret >= 0 {
         Ok(())

--- a/src/backends/use_file.rs
+++ b/src/backends/use_file.rs
@@ -7,7 +7,7 @@ use core::{
 };
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[path = "../util_libc.rs"]
 pub(super) mod util_libc;
@@ -40,7 +40,7 @@ const FD_ONGOING_INIT: libc::c_int = -2;
 // `Ordering::Acquire` to synchronize with it.
 static FD: AtomicI32 = AtomicI32::new(FD_UNINIT);
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let mut fd = FD.load(Ordering::Acquire);
     if fd == FD_UNINIT || fd == FD_ONGOING_INIT {
         fd = open_or_wait()?;

--- a/src/backends/vxworks.rs
+++ b/src/backends/vxworks.rs
@@ -9,9 +9,9 @@ use core::{
 #[path = "../util_libc.rs"]
 mod util_libc;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     static RNG_INIT: AtomicBool = AtomicBool::new(false);
     while !RNG_INIT.load(Relaxed) {
         let ret = unsafe { libc::randSecure() };

--- a/src/backends/wasi_p1.rs
+++ b/src/backends/wasi_p1.rs
@@ -2,7 +2,7 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 // This linking is vendored from the wasi crate:
 // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2344-2350
@@ -11,7 +11,7 @@ extern "C" {
     fn random_get(arg0: i32, arg1: i32) -> i32;
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Based on the wasi code:
     // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2046-2062
     // Note that size of an allocated object can not be bigger than isize::MAX bytes.

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -3,16 +3,18 @@ use crate::Error;
 use core::mem::MaybeUninit;
 use wasi::random::random::get_random_u64;
 
-pub fn inner_u32() -> Result<u32, Error> {
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64};
+
+pub fn u32() -> Result<u32, Error> {
     let val = get_random_u64();
     Ok(crate::util::truncate(val))
 }
 
-pub fn inner_u64() -> Result<u64, Error> {
+pub fn u64() -> Result<u64, Error> {
     Ok(get_random_u64())
 }
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use core::ptr::copy_nonoverlapping;
     use wasi::random::random::get_random_u64;
 

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -4,7 +4,7 @@ use crate::Error;
 extern crate std;
 use std::{mem::MaybeUninit, thread_local};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 #[cfg(not(all(
     any(target_arch = "wasm32", target_arch = "wasm64"),
@@ -32,7 +32,7 @@ thread_local!(
     static RNG_SOURCE: Result<RngSource, Error> = getrandom_init();
 );
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     RNG_SOURCE.with(|result| {
         let source = result.as_ref().map_err(|&e| e)?;
 

--- a/src/backends/windows.rs
+++ b/src/backends/windows.rs
@@ -23,7 +23,7 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 // Binding to the Windows.Win32.Security.Cryptography.ProcessPrng API. As
 // bcryptprimitives.dll lacks an import library, we use the windows-targets
@@ -33,7 +33,7 @@ windows_targets::link!("bcryptprimitives.dll" "system" fn ProcessPrng(pbdata: *m
 pub type BOOL = i32;
 pub const TRUE: BOOL = 1i32;
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // ProcessPrng should always return TRUE, but we check just in case.
     match unsafe { ProcessPrng(dest.as_mut_ptr().cast::<u8>(), dest.len()) } {
         TRUE => Ok(()),

--- a/src/backends/windows7.rs
+++ b/src/backends/windows7.rs
@@ -12,7 +12,7 @@
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub use crate::default_impls::{insecure_fill_uninit, insecure_u32, insecure_u64, u32, u64};
 
 // Binding to the Windows.Win32.Security.Authentication.Identity.RtlGenRandom
 // API. Don't use windows-targets as it doesn't support Windows 7 targets.
@@ -25,7 +25,7 @@ extern "system" {
 type BOOLEAN = u8;
 const TRUE: BOOLEAN = 1u8;
 
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+pub fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     // Prevent overflow of u32
     let chunk_size = usize::try_from(i32::MAX).expect("Windows does not support 16-bit targets");
     for chunk in dest.chunks_mut(chunk_size) {

--- a/src/default_impls.rs
+++ b/src/default_impls.rs
@@ -1,0 +1,47 @@
+#![allow(dead_code)]
+use crate::Error;
+use core::{mem::MaybeUninit, slice};
+
+#[inline(always)]
+#[allow(unused_unsafe)]
+unsafe fn default_impl<T>(secure: bool) -> Result<T, Error> {
+    let mut res = MaybeUninit::<T>::uninit();
+    // SAFETY: the created slice has the same size as `res`
+    let dst = unsafe {
+        let p: *mut MaybeUninit<u8> = res.as_mut_ptr().cast();
+        slice::from_raw_parts_mut(p, core::mem::size_of::<T>())
+    };
+    if secure {
+        crate::fill_uninit(dst)?;
+    } else {
+        crate::insecure_fill_uninit(dst)?;
+    }
+    // SAFETY: `dst` has been fully initialized by `imp::fill_inner`
+    // since it returned `Ok`.
+    Ok(unsafe { res.assume_init() })
+}
+
+/// Default implementation of `inner_u32` on top of `getrandom::fill_uninit`
+pub fn u32() -> Result<u32, Error> {
+    unsafe { default_impl(true) }
+}
+
+/// Default implementation of `inner_u64` on top of `getrandom::fill_uninit`
+pub fn u64() -> Result<u64, Error> {
+    unsafe { default_impl(true) }
+}
+
+/// Default implementation of `insecure_fill_inner` on top of `getrandom::fill_uninit`
+pub fn insecure_fill_uninit(dst: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    crate::fill_uninit(dst).map(|_| ())
+}
+
+/// Default implementation of `inner_u32` on top of `getrandom::insecure_fill_uninit`
+pub fn insecure_u32() -> Result<u32, Error> {
+    unsafe { default_impl(false) }
+}
+
+/// Default implementation of `inner_insecure_u64` on top of `getrandom::insecure_fill_uninit`
+pub fn insecure_u64() -> Result<u64, Error> {
+    unsafe { default_impl(false) }
+}


### PR DESCRIPTION
Adds 4 new functions: `insecure_fill`, `insecure_fill_uninit`, `insecure_u32`, and `insecure_u32`.

On some platforms these function can be less prone to blocking, but may return potentially "insecure" random data. Such data can be used for seeding `HashMap`s and non-security-sensitive PRNGs.

Closes #365