### PR TITLE
Remove faulty support for `wasm64-unknown-unknown`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,23 +58,6 @@ jobs:
       - name: Build Tests
         run: cross test --no-run --target=${{ matrix.target }} --features=std
 
-  wasm64:
-    name: Wasm64
-    runs-on: ubuntu-22.04
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@nightly # Need to build libstd
-        with:
-          components: rust-src
-      - uses: Swatinem/rust-cache@v2
-      - name: Build and Link tests (build-std)
-        env:
-          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        # This target is Tier 3, so we have to build libstd ourselves.
-        # We currently cannot run these tests because wasm-bindgen-test-runner
-        # does not yet support memory64.
-        run: cargo test --no-run -Z build-std=std,panic_abort --target=wasm64-unknown-unknown
-
   tier2:
     name: Tier 2
     runs-on: ubuntu-22.04

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ wasi = { version = "0.13", default-features = false }
 windows-targets = "0.52"
 
 # wasm_js
-[target.'cfg(all(getrandom_backend = "wasm_js", any(target_arch = "wasm32", target_arch = "wasm64"), target_os = "unknown"))'.dependencies]
+[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.89", default-features = false }
 js-sys = "0.3"
 [target.'cfg(all(getrandom_backend = "wasm_js", getrandom_browser_test, target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -76,15 +76,15 @@ Pull Requests that add support for new targets to `getrandom` are always welcome
 `getrandom` also provides optional (opt-in) backends, which allow users to customize the source
 of randomness based on their specific needs:
 
-| Backend name      | Target               | Target Triple        | Implementation
-| ----------------- | -------------------- | -------------------- | --------------
-| `linux_getrandom` | Linux, Android       | `*‑linux‑*`          | [`getrandom`][1] system call (without `/dev/urandom` fallback). Bumps minimum supported Linux kernel version to 3.17 and Android API level to 23 (Marshmallow).
-| `linux_rustix`    | Linux, Android       | `*‑linux‑*`          | Same as `linux_getrandom`, but uses [`rustix`] instead of `libc`.
-| `rdrand`          | x86, x86-64          | `x86_64-*`, `i686-*` | [`RDRAND`] instruction
-| `rndr`            | AArch64              | `aarch64-*`          | [`RNDR`] register
-| `esp_idf`         | ESP-IDF              | `*‑espidf`           | [`esp_fill_random`]. WARNING: can return low-quality entropy without proper hardware configuration!
-| `wasm_js`         | Web Browser, Node.js | `wasm*‑*‑unknown`    | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js (see [WebAssembly support])
-| `custom`          | All targets          | `*`                  | User-provided custom implementation (see [custom backend])
+| Backend name      | Target               | Target Triple            | Implementation
+| ----------------- | -------------------- | ------------------------ | --------------
+| `linux_getrandom` | Linux, Android       | `*‑linux‑*`              | [`getrandom`][1] system call (without `/dev/urandom` fallback). Bumps minimum supported Linux kernel version to 3.17 and Android API level to 23 (Marshmallow).
+| `linux_rustix`    | Linux, Android       | `*‑linux‑*`              | Same as `linux_getrandom`, but uses [`rustix`] instead of `libc`.
+| `rdrand`          | x86, x86-64          | `x86_64-*`, `i686-*`     | [`RDRAND`] instruction
+| `rndr`            | AArch64              | `aarch64-*`              | [`RNDR`] register
+| `esp_idf`         | ESP-IDF              | `*‑espidf`               | [`esp_fill_random`]. WARNING: can return low-quality entropy without proper hardware configuration!
+| `wasm_js`         | Web Browser, Node.js | `wasm32‑unknown‑unknown` | [`Crypto.getRandomValues`] if available, then [`crypto.randomFillSync`] if on Node.js (see [WebAssembly support])
+| `custom`          | All targets          | `*`                      | User-provided custom implementation (see [custom backend])
 
 Opt-in backends can be enabled using the `getrandom_backend` configuration flag.
 The flag can be set either by specifying the `rustflags` field in

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -149,11 +149,11 @@ cfg_if! {
         mod rdrand;
         pub use rdrand::*;
     } else if #[cfg(all(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
+        target_arch = "wasm32",
         target_os = "unknown",
     ))] {
-        compile_error!("the wasm*-unknown-unknown targets are not supported by \
-                        default, you may need to enable the \"wasm_js\" \
+        compile_error!("the wasm32-unknown-unknown targets are not supported \
+                        by default, you may need to enable the \"wasm_js\" \
                         configuration flag. For more information see: \
                         https://docs.rs/getrandom/#webassembly-support");
     } else {

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -6,10 +6,7 @@ use std::{mem::MaybeUninit, thread_local};
 
 pub use crate::util::{inner_u32, inner_u64};
 
-#[cfg(not(all(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    target_os = "unknown",
-)))]
+#[cfg(not(all(target_arch = "wasm32", target_os = "unknown",)))]
 compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
 
 use js_sys::{global, Function, Uint8Array};


### PR DESCRIPTION
This removes the previously in #303 added support for `wasm64-unknown-unknown`.

`wasm-bindgen` does in fact not support the Memory64 proposal. The reason it still compiled is that `wasm-bindgen` emits panicking stubs for any target it doesn't support. However, during runtime this would have failed.