### PR TITLE
Run Wasm tests in workers as well

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,16 +240,14 @@ jobs:
 
   web:
     name: Web
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: choco install wget
-        if: runner.os == 'Windows'
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=v0.12.1
+          VERSION=v0.13.1
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-x86_64-unknown-linux-musl.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version
@@ -260,11 +258,29 @@ jobs:
         run: wasm-pack test --node
       - name: Test (Firefox)
         env:
-          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" --cfg getrandom_browser_test
+          WASM_BINDGEN_USE_BROWSER: 1
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
         run: wasm-pack test --headless --firefox
       - name: Test (Chrome)
         env:
-          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" --cfg getrandom_browser_test
+          WASM_BINDGEN_USE_BROWSER: 1
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+        run: wasm-pack test --headless --chrome
+      - name: Test (dedicated worker)
+        env:
+          WASM_BINDGEN_USE_DEDICATED_WORKER: 1
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+        run: wasm-pack test --headless --firefox
+      - name: Test (shared worker)
+        env:
+          WASM_BINDGEN_USE_SHARED_WORKER: 1
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+        run: wasm-pack test --headless --firefox
+      - name: Test (service worker)
+        env:
+          WASM_BINDGEN_USE_SERVICE_WORKER: 1
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
+        # Firefox doesn't support module service workers and therefor can't import scripts
         run: wasm-pack test --headless --chrome
 
   wasi:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ windows-targets = "0.52"
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2.89", default-features = false }
 js-sys = "0.3"
-[target.'cfg(all(getrandom_backend = "wasm_js", getrandom_browser_test, target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+[target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
 wasm-bindgen-test = "0.3.39"
 
 [features]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,10 +1,8 @@
 use core::mem::MaybeUninit;
 use getrandom::{fill, fill_uninit};
 
-#[cfg(getrandom_browser_test)]
+#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
-#[cfg(getrandom_browser_test)]
-wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
 
 #[test]
 fn test_zero() {

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,11 @@
 use core::mem::MaybeUninit;
 use getrandom::{fill, fill_uninit};
 
-#[cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(
+    getrandom_backend = "wasm_js",
+    target_arch = "wasm32",
+    target_os = "unknown"
+))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -1,7 +1,7 @@
 use core::mem::MaybeUninit;
 use getrandom::{fill, fill_uninit};
 
-#[cfg(all(target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", target_os = "unknown"))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]


### PR DESCRIPTION
This change runs Wasm tests in workers as well.

- Fix Node tests not actually running any tests. It was already broken because of an interaction with the latest Rust version and an old Node.js version.
- Test dedicated, shared and service worker by using the newly added environment variables: https://github.com/rustwasm/wasm-bindgen/pull/4295.

Fixes #319.