### PR TITLE
wasm_js: remove IE 11 workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   in favor of configuration flags [#504]
 - `register_custom_getrandom!` macro [#504]
 - Implementation of `From<NonZeroU32>` for `Error` and `Error::code` method [#507]
+- Internet Explorer 11 support [#554]
 
 ### Changed
 - Use `ProcessPrng` on Windows 10 and up, and use RtlGenRandom on older legacy Windows versions [#415]
@@ -52,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#532]: https://github.com/rust-random/getrandom/pull/532
 [#542]: https://github.com/rust-random/getrandom/pull/542
 [#544]: https://github.com/rust-random/getrandom/pull/544
+[#554]: https://github.com/rust-random/getrandom/pull/554
 
 ## [0.2.15] - 2024-05-06
 ### Added


### PR DESCRIPTION
Internet Explorer is superseded by Edge (which has 3-5% usage share) and effectively no longer supported. Citing Wikipedia:

>For SAC versions of Windows 10, Internet Explorer 11 support ended on June 15, 2022, Internet Explorer was permanently disabled on February 14, 2023, and any remaining icons or shortcuts were due to be removed on June 13, 2023.

Technically, it's still supported on LTSC, but Microsoft discourages the use of LTSC editions outside of "special-purpose devices" that perform a fixed function and thus do not require new user experience features, so I think we can ignore it.