### PR TITLE
ci: do not build FreeBSD and NetBSD in the cross job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,6 @@ jobs:
         target: [
           sparcv9-sun-solaris,
           x86_64-unknown-illumos,
-          x86_64-unknown-freebsd,
-          x86_64-unknown-netbsd,
         ]
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The targets already tested using VM jobs.