### PR TITLE
Add `no_std` support for Web

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,40 @@ jobs:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
         run: cargo build --features=std
 
+  web:
+    name: ${{ matrix.target.description }} ${{ matrix.feature.description }} ${{ matrix.atomic.description }}
+    runs-on: ubuntu-24.04
+    env:
+        RUSTFLAGS: --cfg getrandom_backend="wasm_js" ${{ matrix.atomic.flags }}
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [
+          { description: Web, target: wasm32-unknown-unknown },
+          { description: WasmV1, target: wasm32v1-none },
+        ]
+        feature: [
+          { description: no_std, feature: "", build-std: "core,alloc", std: false },
+          { feature: --features std, build-std: "panic_abort,std", std: true },
+        ]
+        atomic: [
+          { flags: "" },
+          { description: with Atomics, flags: "-Ctarget-feature=+atomics,bulk-memory" },
+        ]
+        exclude:
+          - target: { target: wasm32v1-none }
+            feature: { std: true }
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          targets: ${{ matrix.target.target }}
+          toolchain: nightly-2024-10-24
+          components: rust-src
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --target ${{ matrix.target.target }} ${{ matrix.feature.feature }} -Zbuild-std=${{ matrix.feature.build-std }}
+
   rdrand:
     name: RDRAND
     runs-on: ubuntu-24.04

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -245,33 +245,33 @@ jobs:
       - name: Test (Node)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --node
+        run: wasm-pack test --node -- --features std
       - name: Test (Firefox)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (Chrome)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --chrome
+        run: wasm-pack test --headless --chrome -- --features std
       - name: Test (dedicated worker)
         env:
           WASM_BINDGEN_USE_DEDICATED_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (shared worker)
         env:
           WASM_BINDGEN_USE_SHARED_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-        run: wasm-pack test --headless --firefox
+        run: wasm-pack test --headless --firefox -- --features std
       - name: Test (service worker)
         env:
           WASM_BINDGEN_USE_SERVICE_WORKER: 1
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
         # Firefox doesn't support module service workers and therefor can't import scripts
-        run: wasm-pack test --headless --chrome
+        run: wasm-pack test --headless --chrome -- --features std
 
   wasi:
     name: WASI

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ windows-targets = "0.52"
 # wasm_js
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
 wasm-bindgen = { version = "0.2.96", default-features = false }
-js-sys = "0.3.73"
+js-sys = { version = "0.3.73", default-features = false }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 


### PR DESCRIPTION
In #557 we forgot to port the `no_std` support from #541.

This also adds running Clippy for `wasm32v1-none`.