### PR TITLE
Use dep: style features for rustc-dep-of-std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ wasm-bindgen-test = "0.3"
 # use std to retrieve OS error descriptions
 std = []
 # Unstable feature to support being a libstd dependency
-rustc-dep-of-std = ["compiler_builtins", "core"]
+rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"


### PR DESCRIPTION
This prevents this crate from having features `compiler_builtins` and `core`. I didn't initially add this because it requires an MSRV of 1.60, but our MSRV is 1.63 now, so this is OK.