### PR TITLE
Remove explicit docsrs configuration flag from docs.rs metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,7 +88,6 @@ check-cfg = [
 
 [package.metadata.docs.rs]
 features = ["std"]
-rustdoc-args = ["--cfg", "docsrs"]
 
 # workaround for https://github.com/cross-rs/cross/issues/1345
 [package.metadata.cross.target.x86_64-unknown-netbsd]


### PR DESCRIPTION
The flag is passed automatically for all docs.rs builds. See: https://github.com/rust-lang/docs.rs/pull/2390