### PR TITLE
fix compilation on uefi (with std feature enabled) or i686

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -173,6 +173,7 @@ jobs:
         target: [
           x86_64-unknown-uefi,
           x86_64-unknown-l4re-uclibc,
+          i686-unknown-uefi,
         ]
     steps:
       - uses: actions/checkout@v4

--- a/src/backends/rdrand.rs
+++ b/src/backends/rdrand.rs
@@ -144,7 +144,7 @@ unsafe fn rdrand_u32() -> Option<u32> {
 unsafe fn rdrand_u64() -> Option<u64> {
     let a = rdrand()?;
     let b = rdrand()?;
-    Some((u64::from(a) << 32) || u64::from(b))
+    Some((u64::from(a) << 32) | u64::from(b))
 }
 
 pub fn inner_u32() -> Result<u32, Error> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,35 @@
 #[cfg(feature = "std")]
 extern crate std;
 
-use core::{fmt, num::NonZeroU32};
+use core::fmt;
+
+#[cfg(not(target_os = "uefi"))]
+pub type RawOsError = i32;
+
+#[cfg(target_os = "uefi")]
+pub type RawOsError = usize;
+
+#[cfg(not(target_os = "uefi"))]
+type InternalError = u32;
+
+#[cfg(target_os = "uefi")]
+#[cfg(target_pointer_width = "32")]
+type InternalError = u64;
+
+#[cfg(target_os = "uefi")]
+#[cfg(target_pointer_width = "64")]
+type InternalError = u128;
+
+#[cfg(not(target_os = "uefi"))]
+type NonZeroInternalError = core::num::NonZeroU32;
+
+#[cfg(target_os = "uefi")]
+#[cfg(target_pointer_width = "32")]
+type NonZeroInternalError = core::num::NonZeroU64;
+
+#[cfg(target_os = "uefi")]
+#[cfg(target_pointer_width = "64")]
+type NonZeroInternalError = core::num::NonZeroU128;
 
 /// A small and `no_std` compatible error type
 ///
@@ -18,7 +46,7 @@ use core::{fmt, num::NonZeroU32};
 /// - [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) implements
 ///   [`From<getrandom::Error>`](https://doc.rust-lang.org/std/convert/trait.From.html).
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct Error(NonZeroU32);
+pub struct Error(NonZeroInternalError);
 
 impl Error {
     /// This target/platform is not supported by `getrandom`.
@@ -31,11 +59,11 @@ impl Error {
     /// Codes below this point represent OS Errors (i.e. positive i32 values).
     /// Codes at or above this point, but below [`Error::CUSTOM_START`] are
     /// reserved for use by the `rand` and `getrandom` crates.
-    pub const INTERNAL_START: u32 = 1 << 31;
+    pub const INTERNAL_START: InternalError = 0b10 << (InternalError::BITS - 2);
 
     /// Codes at or above this point can be used by users to define their own
     /// custom errors.
-    pub const CUSTOM_START: u32 = (1 << 31) + (1 << 30);
+    pub const CUSTOM_START: InternalError = 0b11 << (InternalError::BITS - 2);
 
     /// Creates a new instance of an `Error` from a particular OS error code.
     ///
@@ -48,7 +76,10 @@ impl Error {
     /// [1]: https://doc.rust-lang.org/std/io/struct.Error.html#method.from_raw_os_error
     #[allow(dead_code)]
     pub(super) fn from_os_error(code: u32) -> Self {
-        match NonZeroU32::new(code) {
+        match InternalError::try_from(code)
+            .ok()
+            .and_then(NonZeroInternalError::new)
+        {
             Some(code) if code.get() < Self::INTERNAL_START => Self(code),
             _ => Self::UNEXPECTED,
         }
@@ -62,29 +93,30 @@ impl Error {
     ///
     /// [1]: https://doc.rust-lang.org/std/io/struct.Error.html#method.raw_os_error
     #[inline]
-    pub fn raw_os_error(self) -> Option<i32> {
-        i32::try_from(self.0.get()).ok().map(|errno| {
-            // On SOLID, negate the error code again to obtain the original error code.
-            if cfg!(target_os = "solid_asp3") {
-                -errno
-            } else {
-                errno
-            }
-        })
+    pub fn raw_os_error(self) -> Option<RawOsError> {
+        #[cfg(not(target_os = "solid_asp3"))]
+        {
+            RawOsError::try_from(self.0.get()).ok()
+        }
+        // On SOLID, negate the error code again to obtain the original error code.
+        #[cfg(target_os = "solid_asp3")]
+        {
+            RawOsError::try_from(self.0.get()).ok().map(|errno| -errno)
+        }
     }
 
     /// Creates a new instance of an `Error` from a particular custom error code.
     pub const fn new_custom(n: u16) -> Error {
         // SAFETY: code > 0 as CUSTOM_START > 0 and adding n won't overflow a u32.
-        let code = Error::CUSTOM_START + (n as u32);
-        Error(unsafe { NonZeroU32::new_unchecked(code) })
+        let code = Error::CUSTOM_START + (n as InternalError);
+        Error(unsafe { NonZeroInternalError::new_unchecked(code) })
     }
 
     /// Creates a new instance of an `Error` from a particular internal error code.
     pub(crate) const fn new_internal(n: u16) -> Error {
         // SAFETY: code > 0 as INTERNAL_START > 0 and adding n won't overflow a u32.
-        let code = Error::INTERNAL_START + (n as u32);
-        Error(unsafe { NonZeroU32::new_unchecked(code) })
+        let code = Error::INTERNAL_START + (n as InternalError);
+        Error(unsafe { NonZeroInternalError::new_unchecked(code) })
     }
 
     fn internal_desc(&self) -> Option<&'static str> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -134,7 +134,7 @@ impl fmt::Debug for Error {
         let mut dbg = f.debug_struct("Error");
         if let Some(errno) = self.raw_os_error() {
             dbg.field("os_error", &errno);
-            #[cfg(feature = "std")]
+            #[cfg(all(feature = "std", not(target_os = "uefi")))]
             dbg.field("description", &std::io::Error::from_raw_os_error(errno));
         } else if let Some(desc) = self.internal_desc() {
             dbg.field("internal_code", &self.0.get());
@@ -150,7 +150,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if let Some(errno) = self.raw_os_error() {
             cfg_if! {
-                if #[cfg(feature = "std")] {
+                if #[cfg(all(feature = "std", not(target_os = "uefi")))] {
                     std::io::Error::from_raw_os_error(errno).fmt(f)
                 } else {
                     write!(f, "OS Error: {}", errno)

--- a/src/error_std_impls.rs
+++ b/src/error_std_impls.rs
@@ -5,9 +5,14 @@ use std::io;
 
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {
+        #[cfg(not(target_os = "uefi"))]
         match err.raw_os_error() {
             Some(errno) => io::Error::from_raw_os_error(errno),
             None => io::Error::new(io::ErrorKind::Other, err),
+        }
+        #[cfg(target_os = "uefi")]
+        {
+            io::Error::new(io::ErrorKind::Other, err)
         }
     }
 }


### PR DESCRIPTION
According to https://uefi.org/specs/UEFI/2.10/Apx_D_Status_Codes.html, there is no more space for internal errors, so use a wider integer on UEFI.