### PR TITLE
Allow `Error::raw_os_error` to return non-`i32` codes

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -79,15 +79,13 @@ impl Error {
     #[inline]
     pub fn raw_os_error(self) -> Option<RawOsError> {
         let code = self.0.get();
-        if code < Self::INTERNAL_START {
-            let res = RawOsError::try_from(code).ok();
-            // On SOLID, negate the error code again to obtain the original error code.
-            #[cfg(target_os = "solid_asp3")]
-            let res = res.map(|errno| -errno);
-            res
-        } else {
-            None
+        if code >= Self::INTERNAL_START {
+            return None;
         }
+        let errno = RawOsError::try_from(code).ok()?;
+        #[cfg(target_os = "solid_asp3")]
+        let errno = -errno;
+        Some(errno)
     }
 
     /// Creates a new instance of an `Error` from a particular custom error code.

--- a/src/error.rs
+++ b/src/error.rs
@@ -80,14 +80,11 @@ impl Error {
     pub fn raw_os_error(self) -> Option<RawOsError> {
         let code = self.0.get();
         if code < Self::INTERNAL_START {
-            RawOsError::try_from(code).ok().map(|errno| {
-                // On SOLID, negate the error code again to obtain the original error code.
-                if cfg!(target_os = "solid_asp3") {
-                    -errno
-                } else {
-                    errno
-                }
-            })
+            let res = RawOsError::try_from(code).ok();
+            // On SOLID, negate the error code again to obtain the original error code.
+            #[cfg(target_os = "solid_asp3")]
+            let res = res.map(|errno| -errno);
+            res
         } else {
             None
         }

--- a/src/error_std_impls.rs
+++ b/src/error_std_impls.rs
@@ -5,14 +5,9 @@ use std::io;
 
 impl From<Error> for io::Error {
     fn from(err: Error) -> Self {
-        #[cfg(not(target_os = "uefi"))]
         match err.raw_os_error() {
             Some(errno) => io::Error::from_raw_os_error(errno),
             None => io::Error::new(io::ErrorKind::Other, err),
-        }
-        #[cfg(target_os = "uefi")]
-        {
-            io::Error::new(io::ErrorKind::Other, err)
         }
     }
 }


### PR DESCRIPTION
This allows us to remove some UEFI-specific exceptions from the code.

This PR only partially resolves #568 since we still use `NonZeroU32` on UEFI targets, but it should be sufficient to future-proof ourselves for the v0.3 release.