### PR TITLE
Fix broken link for NetBSD 9.2 base source used by cross workaround

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ features = ["std"]
 [package.metadata.cross.target.x86_64-unknown-netbsd]
 pre-build = [
   "mkdir -p /tmp/netbsd",
-  "curl https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz -O",
+  "curl -fO https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/amd64/binary/sets/base.tar.xz",
   "tar -C /tmp/netbsd -xJf base.tar.xz",
   "cp /tmp/netbsd/usr/lib/libexecinfo.so /usr/local/x86_64-unknown-netbsd/lib",
   "rm base.tar.xz",


### PR DESCRIPTION
Recently NetBSD 9.2 source was archived affecting the `base.tar.xz` link used by the `libexecinfo.so` **cross** workaround (https://github.com/cross-rs/cross/issues/1345).

This small patch prefers `NetBSD 9.3` as it is the latest `9.x`.

- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.2/amd64/binary/sets/base.tar.xz (broken)
- https://archive.netbsd.org/pub/NetBSD-archive/NetBSD-9.2/amd64/binary/sets/base.tar.xz (archived)
- https://cdn.netbsd.org/pub/NetBSD/NetBSD-9.3/amd64/binary/sets/base.tar.xz (new)

Additionally, I added a `-f, --fail` to curl to fail in case a `4xx` or greater happens again.