### PR TITLE
Remove the link to PS Vita `getentropy` from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ fn get_random_u128() -> Result<u128, getrandom::Error> {
 | WASI 0.2           | `wasm32‑wasip2`    | [`get-random-u64`]
 | SOLID              | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
 | Nintendo 3DS       | `*-nintendo-3ds`   | [`getrandom`][18]
-| PS Vita            | `*-vita-*`         | [`getentropy`][13]
+| PS Vita            | `*-vita-*`         | `getentropy`
 | QNX Neutrino       | `*‑nto-qnx*`       | [`/dev/urandom`][14] (identical to `/dev/random`)
 | AIX                | `*-ibm-aix`        | [`/dev/urandom`][15]
 


### PR DESCRIPTION
Hi ^^

Currently, PS Vita entry in the README links to the Emscripten issue tracker, likely by mistake. This pull request unlinks `getentropy` in the PS Vita entry.

Thank you for gathering platform-specific sources of entropy under one library! You're doing God's work. <3