### PR TITLE
ci: disable NetBSD VM test job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -193,21 +193,23 @@ jobs:
             pkg_add rust
           run: cargo test
 
-  netbsd:
-    name: NetBSD VM
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: Test in NetBSD
-        uses: vmactions/netbsd-vm@v1
-        with:
-          envs: 'RUSTFLAGS'
-          usesh: true
-          prepare: |
-            /usr/sbin/pkg_add rust
-          run: |
-            cargo test
-            RUSTFLAGS="--cfg getrandom_test_netbsd_fallback -D warnings" cargo test
+  # Rust installation currently fails:
+  # https://github.com/rust-random/getrandom/actions/runs/12590976993/job/35093395247
+  # netbsd:
+  #   name: NetBSD VM
+  #   runs-on: ubuntu-24.04
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - name: Test in NetBSD
+  #       uses: vmactions/netbsd-vm@v1
+  #       with:
+  #         envs: 'RUSTFLAGS'
+  #         usesh: true
+  #         prepare: |
+  #           /usr/sbin/pkg_add rust
+  #         run: |
+  #           cargo test
+  #           RUSTFLAGS="--cfg getrandom_test_netbsd_fallback -D warnings" cargo test
 
   # This job currently fails:
   # https://github.com/rust-random/getrandom/actions/runs/11405005618/job/31735653874?pr=528


### PR DESCRIPTION
The job fails after VM image update, see https://github.com/vmactions/netbsd-vm/issues/14.