### PR TITLE
Add `opt_in` crate feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,13 +121,13 @@ jobs:
       - run: cargo build --target=${{ matrix.target }} --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo build --target=${{ matrix.target }} --features=std
+        run: cargo build --target=${{ matrix.target }} --features=std,opt_in
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
         run: cargo build --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build --features=std
+        run: cargo build --features=std,opt_in
 
   web:
     name: ${{ matrix.target.description }} ${{ matrix.feature.description }} ${{ matrix.atomic.description }}
@@ -142,8 +142,8 @@ jobs:
           { description: WasmV1, target: wasm32v1-none },
         ]
         feature: [
-          { description: no_std, feature: "", build-std: "core,alloc", std: false },
-          { feature: --features std, build-std: "panic_abort,std", std: true },
+          { description: no_std, feature: "--features opt_in", build-std: "core,alloc", std: false },
+          { feature: "--features std,opt_in", build-std: "panic_abort,std", std: true },
         ]
         atomic: [
           { flags: "" },
@@ -180,10 +180,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build -Z build-std=core --target=${{ matrix.target }}
+        run: cargo build -Z build-std=core --target=${{ matrix.target }} --features opt_in
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std
+        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std,opt_in
 
   rndr:
     name: RNDR
@@ -198,15 +198,15 @@ jobs:
       - name: RNDR enabled at compile time (Linux)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr" -C target-feature=+rand
-        run: cargo build --target=aarch64-unknown-linux-gnu
+        run: cargo build --target=aarch64-unknown-linux-gnu --features opt_in
       - name: Runtime RNDR detection without std (Linux)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cargo build --target=aarch64-unknown-linux-gnu
+        run: cargo build --target=aarch64-unknown-linux-gnu --features opt_in
       - name: Runtime RNDR detection with std (macOS)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cargo build --target=aarch64-unknown-linux-gnu --features std
+        run: cargo build --target=aarch64-unknown-linux-gnu --features std,opt_in
 
   no-atomics:
     name: No Atomics
@@ -219,4 +219,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
-        run: cargo build --target riscv32i-unknown-none-elf
+        run: cargo build --target riscv32i-unknown-none-elf --features opt_in

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,13 +55,13 @@ jobs:
       - run: cargo test --target=${{ matrix.target }} --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo test --target=${{ matrix.target }} --features=std
+        run: cargo test --target=${{ matrix.target }} --features=std,opt_in
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
         run: cargo test --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo test --features=std
+        run: cargo test --features=std,opt_in
 
   ios:
     name: iOS Simulator
@@ -238,14 +238,14 @@ jobs:
               description: Web,
               version: stable,
               flags: -Dwarnings --cfg getrandom_backend="wasm_js",
-              args: --features=std,
+              args: '--features=std,opt_in',
             }
           - {
               description: Web with Atomics,
               version: nightly,
               components: rust-src,
               flags: '-Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory',
-              args: '--features=std -Zbuild-std=panic_abort,std',
+              args: '--features=std,opt_in -Zbuild-std=panic_abort,std',
             }
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -30,7 +30,7 @@ jobs:
     - name: custom backend
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
-      run: cargo clippy -Zbuild-std=core --target riscv32i-unknown-none-elf
+      run: cargo clippy -Zbuild-std=core --target riscv32i-unknown-none-elf --features=opt_in
     - name: iOS (apple-other.rs)
       run: cargo clippy -Zbuild-std=core --target x86_64-apple-ios
     - name: ESP-IDF (espidf.rs)
@@ -48,15 +48,15 @@ jobs:
     - name: Web WASM (wasm_js.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js"
-      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown
+      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown --features=opt_in
     - name: Web WASM with atomics (wasm_js.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory
-      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown
+      run: cargo clippy -Zbuild-std --target wasm32-unknown-unknown --features=opt_in
     - name: Linux (linux_android.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-      run: cargo clippy --target x86_64-unknown-linux-gnu
+      run: cargo clippy --target x86_64-unknown-linux-gnu --features=opt_in
     - name: Linux (linux_android_with_fallback.rs)
       run: cargo clippy --target x86_64-unknown-linux-gnu
     - name: NetBSD (netbsd.rs)
@@ -66,7 +66,7 @@ jobs:
     - name: RNDR (rndr.rs)
       env:
         RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-      run: cargo clippy -Zbuild-std=core --target aarch64-unknown-linux-gnu
+      run: cargo clippy -Zbuild-std=core --target aarch64-unknown-linux-gnu --features=opt_in
     - name: Solaris (solaris.rs)
       run: cargo clippy -Zbuild-std=core --target x86_64-pc-solaris
     - name: SOLID (solid.rs)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 # linux_android / linux_android_with_fallback
-[target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(target_env = "", getrandom_backend = "custom"))))'.dependencies]
+[target.'cfg(any(target_os = "linux", target_os = "android"))'.dependencies]
 libc = { version = "0.2.154", default-features = false }
 
 # apple-other
@@ -60,9 +60,9 @@ windows-targets = "0.52"
 
 # wasm_js
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
-wasm-bindgen = { version = "0.2.98", default-features = false }
+wasm-bindgen = { version = "0.2.98", default-features = false, optional = true }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
-js-sys = { version = "0.3.77", default-features = false }
+js-sys = { version = "0.3.77", default-features = false, optional = true }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
@@ -70,6 +70,8 @@ wasm-bindgen-test = "0.3"
 # Implement std::error::Error for getrandom::Error and
 # use std to retrieve OS error descriptions
 std = []
+# Enable opt-in backends
+opt_in = ["dep:wasm-bindgen", "dep:js-sys"]
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
 

--- a/nopanic_check/Cargo.toml
+++ b/nopanic_check/Cargo.toml
@@ -12,7 +12,7 @@ name = "getrandom_wrapper"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { path = ".." }
+getrandom = { path = "..", features = ["opt_in"] }
 
 [profile.release]
 panic = "abort"

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -7,19 +7,19 @@
 //! regardless of what value it returns.
 
 cfg_if! {
-    if #[cfg(getrandom_backend = "custom")] {
+    if #[cfg(all(feature = "opt_in",getrandom_backend = "custom"))] {
         mod custom;
         pub use custom::*;
-    } else if #[cfg(getrandom_backend = "linux_getrandom")] {
+    } else if #[cfg(all(feature = "opt_in", getrandom_backend = "linux_getrandom"))] {
         mod linux_android;
         pub use linux_android::*;
-    } else if #[cfg(getrandom_backend = "rdrand")] {
+    } else if #[cfg(all(feature = "opt_in", getrandom_backend = "rdrand"))] {
         mod rdrand;
         pub use rdrand::*;
-    } else if #[cfg(getrandom_backend = "rndr")] {
+    } else if #[cfg(all(feature = "opt_in", getrandom_backend = "rndr"))] {
         mod rndr;
         pub use rndr::*;
-    } else if #[cfg(getrandom_backend = "wasm_js")] {
+    } else if #[cfg(all(feature = "opt_in", getrandom_backend = "wasm_js"))] {
         mod wasm_js;
         pub use wasm_js::*;
     } else if #[cfg(target_os = "espidf")] {


### PR DESCRIPTION
This feature resolves the lock file bloat issue at the cost of less ergonomic use of opt-in backends.

TODO: update docs