### PR TITLE
Web: use safe method to copy to `MaybeUninit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ windows-targets = "0.52"
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
 wasm-bindgen = { version = "0.2.98", default-features = false }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
-js-sys = { version = "0.3.75", default-features = false }
+js-sys = { version = "0.3.77", default-features = false }
 [target.'cfg(all(getrandom_backend = "wasm_js", target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -49,8 +49,7 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
             return Err(Error::WEB_CRYPTO);
         }
 
-        // SAFETY: `sub_buf`'s length is the same length as `chunk`
-        unsafe { sub_buf.raw_copy_to_ptr(chunk.as_mut_ptr().cast::<u8>()) };
+        sub_buf.copy_to_uninit(chunk);
     }
     Ok(())
 }


### PR DESCRIPTION
This removes the last `unsafe` call in the Web implementation.
See [`Uint8Array::copy_to_uninit`](https://docs.rs/js-sys/0.3.77/js_sys/struct.Uint8Array.html#method.copy_to_uninit).