### PR TITLE
rndr: minor tweaks

### DIFF
--- a/src/backends/rndr.rs
+++ b/src/backends/rndr.rs
@@ -67,8 +67,9 @@ fn is_rndr_available() -> bool {
 
 #[cfg(not(target_feature = "rand"))]
 fn is_rndr_available() -> bool {
-    use crate::lazy::LazyBool;
-    static RNDR_GOOD: LazyBool = LazyBool::new();
+    #[path = "../lazy.rs"]
+    mod lazy;
+    static RNDR_GOOD: lazy::LazyBool = lazy::LazyBool::new();
 
     cfg_if::cfg_if! {
         if #[cfg(feature = "std")] {


### PR DESCRIPTION
The most notable change is that `is_aarch64_feature_detected!` now takes precedence over `asm!`-based detection.

Based on #581