### PR TITLE
Fix build error on Android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,7 @@ jobs:
     strategy:
       matrix:
         target: [
+          aarch64-linux-android,
           x86_64-unknown-fuchsia,
           x86_64-unknown-redox,
           x86_64-fortanix-unknown-sgx,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,12 +55,15 @@ jobs:
       - run: cargo test --target=${{ matrix.target }} --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
+          RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
         run: cargo test --target=${{ matrix.target }} --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
+          RUSTDOCFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
         run: cargo test --features=std
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
+          RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
         run: cargo test --features=std
 
   ios:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 # linux_android / linux_android_with_fallback
-[target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom"))))'.dependencies]
+[target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(getrandom_backend = "custom", getrandom_backend = "rdrand", getrandom_backend = "rndr"))))'.dependencies]
 libc = { version = "0.2.154", default-features = false }
 
 # apple-other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ compiler_builtins = { version = "0.1", optional = true }
 core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 # linux_android / linux_android_with_fallback
-[target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(target_env = "", getrandom_backend = "custom"))))'.dependencies]
+[target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom"))))'.dependencies]
 libc = { version = "0.2.154", default-features = false }
 
 # apple-other


### PR DESCRIPTION
Currently building for Android fails with the following errors:

```console
$ cargo build --target=aarch64-linux-android --features=std
   Compiling getrandom v0.3.0 (/Users/taiki/projects/forks/others/getrandom)
   Compiling cfg-if v1.0.0
error[E0432]: unresolved import `libc`
 --> src/backends/../util_libc.rs:6:13
  |
6 |         use libc::__errno as errno_location;
  |             ^^^^ use of unresolved module or unlinked crate `libc`
  |
  = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
  --> src/backends/../util_libc.rs:68:47
   |
68 |                 if err.raw_os_error() != Some(libc::EINTR) {
   |                                               ^^^^ use of unresolved module or unlinked crate `libc`
   |
   = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`

<ommited>

error[E0433]: failed to resolve: use of unresolved module or unlinked crate `libc`
   --> src/backends/use_file.rs:207:23
    |
207 |         let mut pfd = libc::pollfd {
    |                       ^^^^ use of unresolved module or unlinked crate `libc`
    |
    = help: if you wanted to use a crate named `libc`, use `cargo add libc` to add it to your `Cargo.toml`
```

This is because android set `target_env` to `""`, but the following condition has `not(any(target_env = "", ..))` for both Linux and Android:

https://github.com/rust-random/getrandom/blob/aa9636349418ffa58bca6e2884d1bbc63fa1d2fa/Cargo.toml#L33-L35