### PR TITLE
linux_android_with_fallback: do not use dlsym on MUSL targets

### DIFF
--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -65,7 +65,6 @@ fn init() -> NonNull<c_void> {
 }
 
 // Prevent inlining of the fallback implementation
-#[cold]
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use_file::fill_inner(dest)

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -65,6 +65,7 @@ fn init() -> NonNull<c_void> {
 }
 
 // Prevent inlining of the fallback implementation
+#[cold]
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use_file::fill_inner(dest)

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -3,8 +3,8 @@ use super::use_file;
 use crate::Error;
 use core::{
     ffi::c_void,
-    mem::{self, MaybeUninit},
-    ptr::{self, NonNull},
+    mem::{transmute, MaybeUninit},
+    ptr::NonNull,
     sync::atomic::{AtomicPtr, Ordering},
 };
 use use_file::util_libc;
@@ -17,18 +17,28 @@ type GetRandomFn = unsafe extern "C" fn(*mut c_void, libc::size_t, libc::c_uint)
 /// or not supported by kernel.
 const NOT_AVAILABLE: NonNull<c_void> = unsafe { NonNull::new_unchecked(usize::MAX as *mut c_void) };
 
-static GETRANDOM_FN: AtomicPtr<c_void> = AtomicPtr::new(ptr::null_mut());
+static GETRANDOM_FN: AtomicPtr<c_void> = AtomicPtr::new(core::ptr::null_mut());
 
 #[cold]
 #[inline(never)]
 fn init() -> NonNull<c_void> {
-    static NAME: &[u8] = b"getrandom\0";
-    let name_ptr = NAME.as_ptr().cast::<libc::c_char>();
-    let raw_ptr = unsafe { libc::dlsym(libc::RTLD_DEFAULT, name_ptr) };
+    // Use static linking to `libc::getrandom` on MUSL targets and `dlsym` everywhere else
+    #[cfg(not(target_env = "musl"))]
+    let raw_ptr = {
+        static NAME: &[u8] = b"getrandom\0";
+        let name_ptr = NAME.as_ptr().cast::<libc::c_char>();
+        unsafe { libc::dlsym(libc::RTLD_DEFAULT, name_ptr) }
+    };
+    #[cfg(target_env = "musl")]
+    let raw_ptr = {
+        let fptr: GetRandomFn = libc::getrandom;
+        unsafe { transmute::<GetRandomFn, *mut c_void>(fptr) }
+    };
+
     let res_ptr = match NonNull::new(raw_ptr) {
         Some(fptr) => {
-            let getrandom_fn = unsafe { mem::transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
-            let dangling_ptr = ptr::NonNull::dangling().as_ptr();
+            let getrandom_fn = unsafe { transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
+            let dangling_ptr = NonNull::dangling().as_ptr();
             // Check that `getrandom` syscall is supported by kernel
             let res = unsafe { getrandom_fn(dangling_ptr, 0, 0) };
             if cfg!(getrandom_test_linux_fallback) {
@@ -54,7 +64,7 @@ fn init() -> NonNull<c_void> {
     res_ptr
 }
 
-// prevent inlining of the fallback implementation
+// Prevent inlining of the fallback implementation
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use_file::fill_inner(dest)
@@ -78,7 +88,7 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         use_file_fallback(dest)
     } else {
         // note: `transmute` is currently the only way to convert a pointer into a function reference
-        let getrandom_fn = unsafe { mem::transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
+        let getrandom_fn = unsafe { transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
         util_libc::sys_fill_exact(dest, |buf| unsafe {
             getrandom_fn(buf.as_mut_ptr().cast(), buf.len(), 0)
         })


### PR DESCRIPTION
Fixes #600