### PR TITLE
linux_android_with_fallback: add cfg to test that fallback is not triggered

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,10 @@ jobs:
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
         run: cargo test --features=std
       - env:
+          RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_without_fallback
+          RUSTDOCFLAGS: -Dwarnings --cfg getrandom_test_linux_without_fallback
+        run: cargo test --features=std
+      - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
         run: cargo test --features=std

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,7 @@ check-cfg = [
   'cfg(getrandom_backend, values("custom", "rdrand", "rndr", "linux_getrandom", "wasm_js"))',
   'cfg(getrandom_msan)',
   'cfg(getrandom_test_linux_fallback)',
+  'cfg(getrandom_test_linux_without_fallback)',
   'cfg(getrandom_test_netbsd_fallback)',
 ]
 

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -60,6 +60,11 @@ fn init() -> NonNull<c_void> {
         None => NOT_AVAILABLE,
     };
 
+    #[cfg(getrandom_test_linux_without_fallback)]
+    if res_ptr == NOT_AVAILABLE {
+        panic!("Fallback is triggered with enabled `getrandom_test_linux_without_fallback`")
+    }
+
     GETRANDOM_FN.store(res_ptr.as_ptr(), Ordering::Release);
     res_ptr
 }


### PR DESCRIPTION
The test is needed to prevent potential regressions like #600.