### PR TITLE
Tweak `Error` representation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not use `dlsym` on MUSL targets in the `linux_android_with_fallback` backend [#602]
 - Remove `linux_android.rs` and use `getrandom.rs` instead [#603]
 - Always use `RtlGenRandom` on Windows targets when compiling with pre-1.78 Rust [#610]
+- Internal representation of the `Error` type [#614]
+
+### Deprecated
+- `Error::INTERNAL_START` and `Error::CUSTOM_START` associated constants [#614]
 
 [#570]: https://github.com/rust-random/getrandom/pull/570
 [#572]: https://github.com/rust-random/getrandom/pull/572
@@ -33,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#603]: https://github.com/rust-random/getrandom/pull/603
 [#605]: https://github.com/rust-random/getrandom/pull/605
 [#610]: https://github.com/rust-random/getrandom/pull/610
+[#614]: https://github.com/rust-random/getrandom/pull/614
 
 ## [0.3.1] - 2025-01-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,7 +561,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
-[0.3.2]: https://github.com/rust-random/getrandom/compare/v0.3.0...v0.3.2
+[0.3.2]: https://github.com/rust-random/getrandom/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rust-random/getrandom/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-random/getrandom/compare/v0.2.15...v0.3.0
 [0.2.15]: https://github.com/rust-random/getrandom/compare/v0.2.14...v0.2.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Always use `RtlGenRandom` on Windows targets when compiling with pre-1.78 Rust [#610]
 - Internal representation of the `Error` type [#614]
 
-### Deprecated
+### Removed
 - `Error::INTERNAL_START` and `Error::CUSTOM_START` associated constants [#614]
 
 [#570]: https://github.com/rust-random/getrandom/pull/570

--- a/src/backends/efi_rng.rs
+++ b/src/backends/efi_rng.rs
@@ -43,7 +43,7 @@ fn init() -> Result<NonNull<rng::Protocol>, Error> {
     };
 
     if ret.is_error() {
-        return Err(Error::TEMP_EFI_ERROR);
+        return Err(Error::from_uefi_code(ret.as_usize()));
     }
 
     let handles_len = buf_size / HANDLE_SIZE;
@@ -112,7 +112,7 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     };
 
     if ret.is_error() {
-        Err(Error::TEMP_EFI_ERROR)
+        Err(Error::from_uefi_code(ret.as_usize()))
     } else {
         Ok(())
     }
@@ -121,5 +121,4 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
 impl Error {
     pub(crate) const BOOT_SERVICES_UNAVAILABLE: Error = Self::new_internal(10);
     pub(crate) const NO_RNG_HANDLE: Error = Self::new_internal(11);
-    pub(crate) const TEMP_EFI_ERROR: Error = Self::new_internal(12);
 }

--- a/src/backends/hermit.rs
+++ b/src/backends/hermit.rs
@@ -44,10 +44,8 @@ pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
                 dest = dest.get_mut(len..).ok_or(Error::UNEXPECTED)?;
             }
             code => {
-                let err = u32::try_from(code.unsigned_abs())
-                    .ok()
-                    .map_or(Error::UNEXPECTED, Error::from_os_error);
-                return Err(err);
+                let code = i32::try_from(code).map_err(|_| Error::UNEXPECTED)?;
+                return Err(Error::from_os_error(code));
             }
         }
     }

--- a/src/backends/hermit.rs
+++ b/src/backends/hermit.rs
@@ -45,7 +45,7 @@ pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
             }
             code => {
                 let code = i32::try_from(code).map_err(|_| Error::UNEXPECTED)?;
-                return Err(Error::from_os_error(code));
+                return Err(Error::from_neg_error_code(code));
             }
         }
     }

--- a/src/backends/linux_raw.rs
+++ b/src/backends/linux_raw.rs
@@ -128,10 +128,7 @@ pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
             }
             Err(_) if ret == EINTR => continue,
             Err(_) => {
-                let code: u32 = ret
-                    .wrapping_neg()
-                    .try_into()
-                    .map_err(|_| Error::UNEXPECTED)?;
+                let code = i32::try_from(ret).map_err(|_| Error::UNEXPECTED)?;
                 return Err(Error::from_os_error(code));
             }
         }

--- a/src/backends/linux_raw.rs
+++ b/src/backends/linux_raw.rs
@@ -129,7 +129,7 @@ pub fn fill_inner(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
             Err(_) if ret == EINTR => continue,
             Err(_) => {
                 let code = i32::try_from(ret).map_err(|_| Error::UNEXPECTED)?;
-                return Err(Error::from_os_error(code));
+                return Err(Error::from_neg_error_code(code));
             }
         }
     }

--- a/src/backends/solid.rs
+++ b/src/backends/solid.rs
@@ -14,6 +14,6 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if ret >= 0 {
         Ok(())
     } else {
-        Err(Error::from_os_error(ret))
+        Err(Error::from_neg_error_code(ret))
     }
 }

--- a/src/backends/solid.rs
+++ b/src/backends/solid.rs
@@ -14,8 +14,6 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     if ret >= 0 {
         Ok(())
     } else {
-        // ITRON error numbers are always negative, so we negate it so that it
-        // falls in the dedicated OS error range (1..INTERNAL_START).
-        Err(Error::from_os_error(ret.unsigned_abs()))
+        Err(Error::from_os_error(ret))
     }
 }

--- a/src/backends/wasi_p1.rs
+++ b/src/backends/wasi_p1.rs
@@ -21,6 +21,6 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let ret = unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) };
     match ret {
         0 => Ok(()),
-        code => Err(Error::from_os_error(code)),
+        code => Err(Error::from_neg_error_code(code)),
     }
 }

--- a/src/backends/wasi_p1.rs
+++ b/src/backends/wasi_p1.rs
@@ -21,11 +21,6 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     let ret = unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) };
     match ret {
         0 => Ok(()),
-        code => {
-            let err = u32::try_from(code)
-                .map(Error::from_os_error)
-                .unwrap_or(Error::UNEXPECTED);
-            Err(err)
-        }
+        code => Err(Error::from_os_error(code)),
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,6 +62,7 @@ impl Error {
 
     /// Creates a new instance of an `Error` from an UEFI error code.
     #[cfg(target_os = "uefi")]
+    #[allow(dead_code)]
     pub(super) fn from_uefi_code(code: RawOsError) -> Self {
         if code & UEFI_ERROR_FLAG != 0 {
             let code = NonZeroRawOsError::new(code).expect("The highest bit of `code` is set to 1");

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,6 +7,8 @@ use core::fmt;
 // https://doc.rust-lang.org/std/io/type.RawOsError.html)
 cfg_if::cfg_if!(
     if #[cfg(target_os = "uefi")] {
+        // See the UEFI spec for more information:
+        // https://uefi.org/specs/UEFI/2.10/Apx_D_Status_Codes.html
         type RawOsError = usize;
         type NonZeroRawOsError = core::num::NonZeroUsize;
         const UEFI_ERROR_FLAG: RawOsError = 1 << (RawOsError::BITS - 1);

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,18 +45,10 @@ impl Error {
     /// Encountered an unexpected situation which should not happen in practice.
     pub const UNEXPECTED: Error = Self::new_internal(2);
 
-    #[deprecated]
-    #[doc(hidden)]
-    pub const INTERNAL_START: u32 = 1 << 31;
-
-    #[deprecated]
-    #[doc(hidden)]
-    pub const CUSTOM_START: u32 = (1 << 31) + (1 << 30);
-
     /// Internal errors can be in the range of 2^16..2^17
-    const INTERNAL_START2: RawOsError = 1 << 16;
+    const INTERNAL_START: RawOsError = 1 << 16;
     /// Custom errors can be in the range of 2^17..(2^17 + 2^16)
-    const CUSTOM_START2: RawOsError = 1 << 17;
+    const CUSTOM_START: RawOsError = 1 << 17;
 
     /// Creates a new instance of an `Error` from a particular OS error code.
     ///
@@ -128,14 +120,14 @@ impl Error {
     /// Creates a new instance of an `Error` from a particular custom error code.
     pub const fn new_custom(n: u16) -> Error {
         // SAFETY: code > 0 as CUSTOM_START > 0 and adding `n` won't overflow `RawOsError`.
-        let code = Error::CUSTOM_START2 + (n as RawOsError);
+        let code = Error::CUSTOM_START + (n as RawOsError);
         Error(unsafe { NonZeroRawOsError::new_unchecked(code) })
     }
 
     /// Creates a new instance of an `Error` from a particular internal error code.
     pub(crate) const fn new_internal(n: u16) -> Error {
         // SAFETY: code > 0 as INTERNAL_START > 0 and adding `n` won't overflow `RawOsError`.
-        let code = Error::INTERNAL_START2 + (n as RawOsError);
+        let code = Error::INTERNAL_START + (n as RawOsError);
         Error(unsafe { NonZeroRawOsError::new_unchecked(code) })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,12 +45,12 @@ impl Error {
     /// Encountered an unexpected situation which should not happen in practice.
     pub const UNEXPECTED: Error = Self::new_internal(2);
 
-    /// Deprecated.
     #[deprecated]
+    #[doc(hidden)]
     pub const INTERNAL_START: u32 = 1 << 31;
 
-    /// Deprecated.
     #[deprecated]
+    #[doc(hidden)]
     pub const CUSTOM_START: u32 = (1 << 31) + (1 << 30);
 
     /// Internal errors can be in the range of 2^16..2^17

--- a/src/error.rs
+++ b/src/error.rs
@@ -199,15 +199,3 @@ impl fmt::Display for Error {
         }
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use super::Error;
-    use core::mem::size_of;
-
-    #[test]
-    fn test_size() {
-        assert_eq!(size_of::<Error>(), 4);
-        assert_eq!(size_of::<Result<(), Error>>(), 4);
-    }
-}

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,7 @@ impl Error {
     /// Creates a new instance of an `Error` from an UEFI error code.
     #[cfg(target_os = "uefi")]
     pub(super) fn from_uefi_code(code: RawOsError) -> Self {
-        if code.get() & UEFI_ERROR_FLAG != 0 {
+        if code & UEFI_ERROR_FLAG != 0 {
             let code = NonZeroRawOsError::new(code).expect("The highest bit of `code` is set to 1");
             Self(code)
         } else {

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,14 +24,12 @@ cfg_if::cfg_if!(
 /// if so, which error code the OS gave the application. If such an error is
 /// encountered, please consult with your system documentation.
 ///
-/// Internally this type is a NonZeroU32, with certain values reserved for
-/// certain purposes, see [`Error::INTERNAL_START`] and [`Error::CUSTOM_START`].
-///
 /// *If this crate's `"std"` Cargo feature is enabled*, then:
 /// - [`getrandom::Error`][Error] implements
 ///   [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html)
 /// - [`std::io::Error`](https://doc.rust-lang.org/std/io/struct.Error.html) implements
 ///   [`From<getrandom::Error>`](https://doc.rust-lang.org/std/convert/trait.From.html).
+
 // note: on non-UEFI targets OS errors are represented as negative integers,
 // while on UEFI targets OS errors have the highest bit set to 1.
 #[derive(Copy, Clone, Eq, PartialEq)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,7 @@ impl Error {
     const CUSTOM_START: RawOsError = 1 << 17;
 
     /// Creates a new instance of an `Error` from a negative error code.
+    #[cfg(not(target_os = "uefi"))]
     #[allow(dead_code)]
     pub(super) fn from_neg_error_code(code: RawOsError) -> Self {
         if code < 0 {

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -38,10 +38,7 @@ pub(crate) fn last_os_error() -> Error {
     let errno: i32 = unsafe { get_errno() };
 
     if errno > 0 {
-        let code = errno
-            .checked_neg()
-            .expect("Positive number can be always negated");
-        Error::from_os_error(code)
+        Error::from_os_error(errno)
     } else {
         Error::ERRNO_NOT_POSITIVE
     }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -38,7 +38,10 @@ pub(crate) fn last_os_error() -> Error {
     let errno: i32 = unsafe { get_errno() };
 
     if errno > 0 {
-        Error::from_os_error(errno)
+        let code = errno
+            .checked_neg()
+            .expect("Positive number can be always negated");
+        Error::from_os_error(code)
     } else {
         Error::ERRNO_NOT_POSITIVE
     }

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -34,8 +34,8 @@ cfg_if! {
 }
 
 pub(crate) fn last_os_error() -> Error {
-    // We assum that on all targets which use this function `c_int` is equal to `i32`
-    let errno: libc::c_int = unsafe { get_errno() };
+    // We assume that on all targets which use the `util_libc` module `c_int` is equal to `i32`
+    let errno: i32 = unsafe { get_errno() };
 
     if errno > 0 {
         let code = errno

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -34,14 +34,16 @@ cfg_if! {
 }
 
 pub(crate) fn last_os_error() -> Error {
+    // We assum that on all targets which use this function `c_int` is equal to `i32`
     let errno: libc::c_int = unsafe { get_errno() };
 
-    // c_int-to-u32 conversion is lossless for nonnegative values if they are the same size.
-    const _: () = assert!(core::mem::size_of::<libc::c_int>() == core::mem::size_of::<u32>());
-
-    match u32::try_from(errno) {
-        Ok(code) if code != 0 => Error::from_os_error(code),
-        _ => Error::ERRNO_NOT_POSITIVE,
+    if errno > 0 {
+        let code = errno
+            .checked_neg()
+            .expect("Positive number can be always negated");
+        Error::from_os_error(code)
+    } else {
+        Error::ERRNO_NOT_POSITIVE
     }
 }
 

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -41,7 +41,7 @@ pub(crate) fn last_os_error() -> Error {
         let code = errno
             .checked_neg()
             .expect("Positive number can be always negated");
-        Error::from_os_error(code)
+        Error::from_neg_error_code(code)
     } else {
         Error::ERRNO_NOT_POSITIVE
     }


### PR DESCRIPTION
On UEFI targets `Error` is now represented as `NonZeroUsize` and on other targets as `NonZeroI32`. In the former case OS errors have the highest bit set to 1, while in the latter case OS errors are represented as negative integers.

Additionally, this PR removes `Error::INTERNAL_START` and `Error::CUSTOM_START` associated constants since the constants are no longer relevant and the inner representation is an internal detail. This is technically a breaking change, but I highly doubt that downstream users rely on them since they can not be used for anything useful, so we can consider it as a "fix" of unintentionally exported constants.

Closes #568 