### PR TITLE
ci: fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,12 +2,6 @@ version: 2
 updates:
 - package-ecosystem: cargo
   directory: "/"
-  versioning-strategy: increase-if-necessary
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-- package-ecosystem: cargo
-  directory: "/"
   versioning-strategy: lockfile-only
   schedule:
     interval: weekly


### PR DESCRIPTION
Unfortunately, we can not have two separate "jobs" for bumping direct dependencies and for updating Cargo.lock. The old config results in the following error:
>Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'. Ecosystem 'cargo' has overlapping directories.