### PR TITLE
ci: fix Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
 - package-ecosystem: cargo
   directory: "/"
-  versioning-strategy: increase-if-necessary
+  versioning-strategy: lockfile-only
   allow:
     - dependency-type: "all"
   schedule:


### PR DESCRIPTION
It looks like Cargo does not support the `increase-if-necessary` versioning strategy.