### PR TITLE
ci: enable backtrace in tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   CARGO_INCREMENTAL: 0
+  RUST_BACKTRACE: 1
   RUSTFLAGS: "-Dwarnings"
 
 jobs:


### PR DESCRIPTION
This would give use more information from panicking tests, e.g. https://github.com/rust-lang/rust/issues/138984.