### PR TITLE
ci: temporarily allow warnings in the `web` job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -248,17 +248,19 @@ jobs:
       fail-fast: false
       matrix:
         rust:
+          # Temporarily allow warnings (i.e. remove `-Dwarnings`) until `wasm-bindgen` fixes the bug:
+          # https://github.com/rustwasm/wasm-bindgen/issues/4463
           - {
               description: Web,
               version: stable,
-              flags: '-Dwarnings --cfg getrandom_backend="wasm_js"',
+              flags: '--cfg getrandom_backend="wasm_js"',
               args: '--features=std,wasm_js',
             }
           - {
               description: Web with Atomics,
               version: nightly,
               components: rust-src,
-              flags: '-Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory',
+              flags: '--cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory',
               args: '--features=std,wasm_js -Zbuild-std=panic_abort,std',
             }
     steps:

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -1,9 +1,4 @@
 //! Implementation for WASM based on Web and Node.js
-
-// Temporarily allow the warning until `wasm-bindgen` fixes the bug:
-// https://github.com/rustwasm/wasm-bindgen/issues/4463
-#![allow(wasm_c_abi)]
-
 use crate::Error;
 use core::mem::MaybeUninit;
 

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -55,6 +55,9 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     Ok(())
 }
 
+// Temporarily allow the warning until `wasm-bindgen` fixes the bug:
+// https://github.com/rustwasm/wasm-bindgen/issues/4463
+#[allow(wasm_c_abi)]
 #[wasm_bindgen]
 extern "C" {
     // Crypto.getRandomValues()

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -1,4 +1,9 @@
 //! Implementation for WASM based on Web and Node.js
+
+// Temporarily allow the warning until `wasm-bindgen` fixes the bug:
+// https://github.com/rustwasm/wasm-bindgen/issues/4463
+#![allow(wasm_c_abi)]
+
 use crate::Error;
 use core::mem::MaybeUninit;
 
@@ -55,9 +60,6 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     Ok(())
 }
 
-// Temporarily allow the warning until `wasm-bindgen` fixes the bug:
-// https://github.com/rustwasm/wasm-bindgen/issues/4463
-#[allow(wasm_c_abi)]
 #[wasm_bindgen]
 extern "C" {
     // Crypto.getRandomValues()


### PR DESCRIPTION
Relevant `wasm-bindgen` issue: https://github.com/rustwasm/wasm-bindgen/issues/4463