### PR TITLE
ci: remove DragonFly BSD VM job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -223,22 +223,6 @@ jobs:
             cargo test
             RUSTFLAGS="--cfg getrandom_test_netbsd_fallback -D warnings" cargo test
 
-  # This job currently fails:
-  # https://github.com/rust-random/getrandom/actions/runs/11405005618/job/31735653874?pr=528
-  # dragonflybsd:
-  #   name: DragonflyBSD VM
-  #   runs-on: ubuntu-24.04
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - name: Test in DragonflyBSD
-  #       uses: vmactions/dragonflybsd-vm@v1
-  #       with:
-  #         envs: 'RUSTFLAGS'
-  #         usesh: true
-  #         prepare: |
-  #           pkg install -y rust
-  #         run: cargo test
-
   web:
     name: ${{ matrix.rust.description }}
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Cargo fails on this system with the following error:
> /usr/local/bin/../lib/libcurl.so.4: Undefined symbol "nghttp2_option_set_no_rfc9113_leading_and_trailing_ws_validation"

The OS did not have new releases the recent years and we do not gain much from testing on it since it uses the common `getrandom` backend tested through other OSes (including other BSD variants), so it looks like we can just remove this job.