### PR TITLE
Release v0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -460,6 +460,7 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
+[0.2.16]: https://github.com/rust-random/getrandom/compare/v0.2.15...v0.2.16
 [0.2.15]: https://github.com/rust-random/getrandom/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/rust-random/getrandom/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/rust-random/getrandom/compare/v0.2.12...v0.2.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.2.16] - 2025-04-22
 ### Added
-- Backport cygwin support [#654]
+- Cygwin support (backport of [#626]) [#654]
 
+[#626]: https://github.com/rust-random/getrandom/pull/626
 [#654]: https://github.com/rust-random/getrandom/pull/654
 
 ## [0.2.15] - 2024-05-06

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.2.15" # Also update html_root_url in lib.rs when bumping this
+version = "0.2.16" # Also update html_root_url in lib.rs when bumping this
 edition = "2018"
 authors = ["The Rand Project Developers"]
 license = "MIT OR Apache-2.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,7 +204,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/getrandom/0.2.15"
+    html_root_url = "https://docs.rs/getrandom/0.2.16"
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]


### PR DESCRIPTION
## [0.2.16] - 2025-04-22
### Added
- Cygwin support (backport of [#626]) [#654]

[#626]: https://github.com/rust-random/getrandom/pull/626
[#654]: https://github.com/rust-random/getrandom/pull/654

[0.2.16]: https://github.com/rust-random/getrandom/compare/v0.2.15...v0.2.16