### PR TITLE
Release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.3.3] - UNRELEASED
+## [0.3.3] - 2025-05-09
 
 ### Changed
 - Doc improvements [#632] [#634] [#635]
@@ -587,11 +587,11 @@ Publish initial implementation.
 ## [0.0.0] - 2019-01-19
 Publish an empty template library.
 
-[0.3.3]: https://github.com/rust-random/getrandom/compare/v0.3.2...HEAD
+[0.3.3]: https://github.com/rust-random/getrandom/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/rust-random/getrandom/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/rust-random/getrandom/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/rust-random/getrandom/compare/v0.2.15...v0.3.0
-[0.2.16]: https://github.com/rust-random/getrandom/compare/v0.2.16...v0.2.16
+[0.2.16]: https://github.com/rust-random/getrandom/compare/v0.2.15...v0.2.16
 [0.2.15]: https://github.com/rust-random/getrandom/compare/v0.2.14...v0.2.15
 [0.2.14]: https://github.com/rust-random/getrandom/compare/v0.2.13...v0.2.14
 [0.2.13]: https://github.com/rust-random/getrandom/compare/v0.2.12...v0.2.13
@@ -607,7 +607,7 @@ Publish an empty template library.
 [0.2.3]: https://github.com/rust-random/getrandom/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/rust-random/getrandom/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/rust-random/getrandom/compare/v0.2.0...v0.2.1
-[0.2.0]: https://github.com/rust-random/getrandom/compare/v0.1.15...v0.2.0
+[0.2.0]: https://github.com/rust-random/getrandom/compare/v0.1.16...v0.2.0
 [0.1.16]: https://github.com/rust-random/getrandom/compare/v0.1.15...v0.1.16
 [0.1.15]: https://github.com/rust-random/getrandom/compare/v0.1.14...v0.1.15
 [0.1.14]: https://github.com/rust-random/getrandom/compare/v0.1.13...v0.1.14

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.63" # Sync tests.yml and README.md.
 authors = ["The Rand Project Developers"]


### PR DESCRIPTION
### Changed
- Doc improvements [#632] [#634] [#635]
- Add crate version to docs.rs links used in `compile_error!`s [#639]

## Fixed
- Error handling in WASI p1 [#661]

[#632]: https://github.com/rust-random/getrandom/pull/632
[#634]: https://github.com/rust-random/getrandom/pull/634
[#635]: https://github.com/rust-random/getrandom/pull/635
[#639]: https://github.com/rust-random/getrandom/pull/639
[#661]: https://github.com/rust-random/getrandom/pull/661