### PR TITLE
Add no_op backend

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -273,3 +273,14 @@ jobs:
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
         run: cargo build --target riscv32i-unknown-none-elf
+
+  no-op:
+    name: No-op
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - env:
+          RUSTFLAGS: -Dwarnings --cfg getrandom_backend="no_op"
+        run: cargo build --target wasm32-unknown-unknown

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ wasm-bindgen-test = "0.3"
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [
-  'cfg(getrandom_backend, values("custom", "efi_rng", "rdrand", "rndr", "linux_getrandom", "linux_raw", "wasm_js"))',
+  'cfg(getrandom_backend, values("custom", "efi_rng", "rdrand", "rndr", "linux_getrandom", "linux_raw", "wasm_js", "no_op"))',
   'cfg(getrandom_msan)',
   'cfg(getrandom_windows_legacy)',
   'cfg(getrandom_test_linux_fallback)',

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ of randomness based on their specific needs:
 | `wasm_js`         | Web Browser, Node.js | `wasm32‑unknown‑unknown`, `wasm32v1-none` | [`Crypto.getRandomValues`]. Requires feature `wasm_js` ([see below](#webassembly-support)).
 | `efi_rng`         | UEFI                 | `*-unknown‑uefi`         | [`EFI_RNG_PROTOCOL`] with `EFI_RNG_ALGORITHM_RAW` (requires `std` and Nigthly compiler)
 | `custom`          | All targets          | `*`                      | User-provided custom implementation (see [custom backend])
+| `no_op`           | All targets          | `*`                      | A backend that provides no randomness.
 
 Opt-in backends can be enabled using the `getrandom_backend` configuration flag.
 The flag can be set either by specifying the `rustflags` field in [`.cargo/config.toml`]:

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -38,6 +38,9 @@ cfg_if! {
                 ));
             }
         }
+    } else if #[cfg(getrandom_backend = "no_op")] {
+        mod no_op;
+        pub use no_op::*;
     } else if #[cfg(all(target_os = "linux", target_env = ""))] {
         mod linux_raw;
         pub use linux_raw::*;

--- a/src/backends/no_op.rs
+++ b/src/backends/no_op.rs
@@ -1,0 +1,12 @@
+//! Implementation that's not random and does a no-op.
+use crate::Error;
+use core::mem::MaybeUninit;
+
+pub use crate::util::{inner_u32, inner_u64};
+
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    for byte in dest {
+        byte.write(0);
+    }
+    Ok(())
+}


### PR DESCRIPTION
There are times when I go to use a crate in Wasm and some dependency of a dependency uses this crate for randomness, but I'm not using the functionality that needs the randomness. Providing a custom backend doesn't work because then it creates a wasm export and I want my wasm interface clean. For scenarios like this, it's useful to be able to just have this crate not provide any randomness at all.