### PR TITLE
Allow external crates to define backends without `RUSTFLAGS`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
           targets: aarch64-apple-darwin, aarch64-apple-ios
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --no-run --target=aarch64-apple-darwin --features=std
-      - run: cargo test --no-run --target=aarch64-apple-ios --features=std
-      - run: cargo test --no-run --target=aarch64-apple-tvos -Zbuild-std --features=std
-      - run: cargo test --no-run --target=aarch64-apple-watchos -Zbuild-std --features=std
+      - run: cargo test --no-run --target=aarch64-apple-darwin --features=std,default-backends
+      - run: cargo test --no-run --target=aarch64-apple-ios --features=std,default-backends
+      - run: cargo test --no-run --target=aarch64-apple-tvos -Zbuild-std --features=std,default-backends
+      - run: cargo test --no-run --target=aarch64-apple-watchos -Zbuild-std --features=std,default-backends
       # visionOS requires Xcode 15.2+, GitHub Actions defaults to an older version.
       - run: sudo xcode-select -switch /Applications/Xcode_15.2.app
       # std is broken on visionOS right now
-      #- run: cargo test --no-run --target=aarch64-apple-visionos -Zbuild-std --features=std
+      #- run: cargo test --no-run --target=aarch64-apple-visionos -Zbuild-std --features=std,default-backends
 
   cross:
     name: Cross
@@ -56,7 +56,7 @@ jobs:
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
       - name: Build Tests
-        run: cross test --no-run --target=${{ matrix.target }} --features=std
+        run: cross test --no-run --target=${{ matrix.target }} --features=std,default-backends
 
   tier2:
     name: Tier 2
@@ -76,7 +76,7 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --target=${{ matrix.target }} --features=std
+        run: cargo build --target=${{ matrix.target }} --features=std,default-backends
 
   tier3:
     name: Tier 3
@@ -105,7 +105,7 @@ jobs:
         with:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build -Z build-std=core --target=${{ matrix.target }}
+      - run: cargo build -Z build-std=core --target=${{ matrix.target }} --features default-backends
 
   # Ubuntu does not support running x32 binaries:
   # https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1994516/comments/21
@@ -125,16 +125,16 @@ jobs:
           sudo apt-get update
           sudo apt-get install --no-install-recommends libc6-dev-x32 libx32gcc-11-dev
       - uses: Swatinem/rust-cache@v2
-      - run: cargo build --target=${{ matrix.target }} --features=std
+      - run: cargo build --target=${{ matrix.target }} --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo build --target=${{ matrix.target }} --features=std
+        run: cargo build --target=${{ matrix.target }} --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
-        run: cargo build --features=std
+        run: cargo build --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build --features=std
+        run: cargo build --features=std,default-backends
 
   linux-raw:
     name: Build Raw Linux
@@ -160,7 +160,7 @@ jobs:
           components: rust-src
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
-        run: cargo build -Zbuild-std=core --target=${{ matrix.target }}
+        run: cargo build -Zbuild-std=core --target=${{ matrix.target }} --features default-backends
 
   web:
     name: ${{ matrix.target.description }} ${{ matrix.feature.description }} ${{ matrix.atomic.description }}
@@ -194,7 +194,7 @@ jobs:
           components: rust-src
       - uses: Swatinem/rust-cache@v2
       - name: Build
-        run: cargo build --target ${{ matrix.target.target }} ${{ matrix.feature.feature }} -Zbuild-std=${{ matrix.feature.build-std }}
+        run: cargo build --target ${{ matrix.target.target }} ${{ matrix.feature.feature }} -Zbuild-std=${{ matrix.feature.build-std }} --features default-backends
 
   efi-rng:
     name: UEFI RNG Protocol
@@ -214,7 +214,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="efi_rng"
-        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std
+        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std,default-backends
 
   rdrand-uefi:
     name: RDRAND UEFI
@@ -233,10 +233,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build -Z build-std=core --target=${{ matrix.target }}
+        run: cargo build -Z build-std=core --target=${{ matrix.target }} --features default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std
+        run: cargo build -Z build-std=std --target=${{ matrix.target }} --features std,default-backends
 
   rndr:
     name: RNDR
@@ -251,15 +251,15 @@ jobs:
       - name: RNDR enabled at compile time (Linux)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr" -C target-feature=+rand
-        run: cargo build --target=aarch64-unknown-linux-gnu
+        run: cargo build --target=aarch64-unknown-linux-gnu --features default-backends
       - name: Runtime RNDR detection without std (Linux)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cargo build --target=aarch64-unknown-linux-gnu
+        run: cargo build --target=aarch64-unknown-linux-gnu --features default-backends
       - name: Runtime RNDR detection with std (macOS)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cargo build --target=aarch64-unknown-linux-gnu --features std
+        run: cargo build --target=aarch64-unknown-linux-gnu --features std,default-backends
 
   no-atomics:
     name: No Atomics
@@ -272,7 +272,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
-        run: cargo build --target riscv32i-unknown-none-elf
+        run: cargo build --target riscv32i-unknown-none-elf --features default-backends
 
   unsupported:
     name: Runtime error
@@ -285,4 +285,4 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="unsupported"
-        run: cargo build --target wasm32-unknown-unknown
+        run: cargo build --target wasm32-unknown-unknown --features default-backends

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -38,45 +38,45 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       
       - name: Build (linux_android_with_fallback.rs)
-        run: cargo build --release
+        run: cargo build --release --features default-backends
       - name: Check (linux_android_with_fallback.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (getrandom.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo build --release
+        run: cargo build --release --features default-backends
       - name: Check (getrandom.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (linux_raw.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
-        run: cargo build --release
+        run: cargo build --release --features default-backends
       - name: Check (linux_raw.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (rdrand.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build --release
+        run: cargo build --release --features default-backends
       - name: Check (rdrand.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (custom.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
-        run: cargo build --release
+        run: cargo build --release --features default-backends
       - name: Check (custom.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (wasi.rs, preview 1)
-        run: cargo build --release --target wasm32-wasip1
+        run: cargo build --release --target wasm32-wasip1 --features default-backends
       - name: Check (wasi.rs, preview 1)
         run: (exit $( grep -c panic target/wasm32-wasip1/release/getrandom_wrapper.wasm ))
 
       - name: Build (wasi.rs, preview 2)
-        run: cargo build --release --target wasm32-wasip2
+        run: cargo build --release --target wasm32-wasip2 --features default-backends
       - name: Check (wasi.rs, preview 2)
         run: (exit $( grep -c panic target/wasm32-wasip2/release/getrandom_wrapper.wasm ))
 
@@ -101,17 +101,17 @@ jobs:
       - name: Build (rndr.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cross build --release --target=aarch64-unknown-linux-gnu
+        run: cross build --release --target=aarch64-unknown-linux-gnu --features default-backends
       - name: Check (rndr.rs)
         run: (exit $( grep -c panic target/aarch64-unknown-linux-gnu/release/libgetrandom_wrapper.so ))
 
       - name: Build (netbsd.rs)
-        run: cross build --release --target=x86_64-unknown-netbsd
+        run: cross build --release --target=x86_64-unknown-netbsd --features default-backends
       - name: Check (netbsd.rs)
         run: (exit $( grep -c panic target/x86_64-unknown-netbsd/release/libgetrandom_wrapper.so ))
 
       - name: Build (solaris.rs)
-        run: cross build --release --target=x86_64-pc-solaris
+        run: cross build --release --target=x86_64-pc-solaris --features default-backends
       - name: Check (solaris.rs)
         run: (exit $( grep -c panic target/x86_64-pc-solaris/release/libgetrandom_wrapper.so ))
 
@@ -129,9 +129,9 @@ jobs:
       # We do not need the grep check since linker fails
       # if `panic_nonexistent` can not be eliminated
       - name: Build (getentropy.rs)
-        run: cargo build --release --target=aarch64-apple-darwin
+        run: cargo build --release --target=aarch64-apple-darwin --features default-backends
       - name: Build (apple-other.rs)
-        run: cargo build --release --target=aarch64-apple-ios
+        run: cargo build --release --target=aarch64-apple-ios --features default-backends
 
   windows:
     name: Windows
@@ -142,5 +142,5 @@ jobs:
         with:
           toolchain: nightly-2024-10-14
           components: rust-src
-      - run: cargo build --release
-      - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort"
+      - run: cargo build --release --features default-backends
+      - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort" --features default-backends

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -38,45 +38,45 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       
       - name: Build (linux_android_with_fallback.rs)
-        run: cargo build --release --features default-backends
+        run: cargo build --release
       - name: Check (linux_android_with_fallback.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (getrandom.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo build --release --features default-backends
+        run: cargo build --release
       - name: Check (getrandom.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (linux_raw.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
-        run: cargo build --release --features default-backends
+        run: cargo build --release
       - name: Check (linux_raw.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (rdrand.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo build --release --features default-backends
+        run: cargo build --release
       - name: Check (rdrand.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (custom.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
-        run: cargo build --release --features default-backends
+        run: cargo build --release
       - name: Check (custom.rs)
         run: (exit $( grep -c panic target/release/libgetrandom_wrapper.so ))
 
       - name: Build (wasi.rs, preview 1)
-        run: cargo build --release --target wasm32-wasip1 --features default-backends
+        run: cargo build --release --target wasm32-wasip1
       - name: Check (wasi.rs, preview 1)
         run: (exit $( grep -c panic target/wasm32-wasip1/release/getrandom_wrapper.wasm ))
 
       - name: Build (wasi.rs, preview 2)
-        run: cargo build --release --target wasm32-wasip2 --features default-backends
+        run: cargo build --release --target wasm32-wasip2
       - name: Check (wasi.rs, preview 2)
         run: (exit $( grep -c panic target/wasm32-wasip2/release/getrandom_wrapper.wasm ))
 
@@ -101,17 +101,17 @@ jobs:
       - name: Build (rndr.rs)
         env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rndr"
-        run: cross build --release --target=aarch64-unknown-linux-gnu --features default-backends
+        run: cross build --release --target=aarch64-unknown-linux-gnu
       - name: Check (rndr.rs)
         run: (exit $( grep -c panic target/aarch64-unknown-linux-gnu/release/libgetrandom_wrapper.so ))
 
       - name: Build (netbsd.rs)
-        run: cross build --release --target=x86_64-unknown-netbsd --features default-backends
+        run: cross build --release --target=x86_64-unknown-netbsd
       - name: Check (netbsd.rs)
         run: (exit $( grep -c panic target/x86_64-unknown-netbsd/release/libgetrandom_wrapper.so ))
 
       - name: Build (solaris.rs)
-        run: cross build --release --target=x86_64-pc-solaris --features default-backends
+        run: cross build --release --target=x86_64-pc-solaris
       - name: Check (solaris.rs)
         run: (exit $( grep -c panic target/x86_64-pc-solaris/release/libgetrandom_wrapper.so ))
 
@@ -129,9 +129,9 @@ jobs:
       # We do not need the grep check since linker fails
       # if `panic_nonexistent` can not be eliminated
       - name: Build (getentropy.rs)
-        run: cargo build --release --target=aarch64-apple-darwin --features default-backends
+        run: cargo build --release --target=aarch64-apple-darwin
       - name: Build (apple-other.rs)
-        run: cargo build --release --target=aarch64-apple-ios --features default-backends
+        run: cargo build --release --target=aarch64-apple-ios
 
   windows:
     name: Windows
@@ -142,5 +142,5 @@ jobs:
         with:
           toolchain: nightly-2024-10-14
           components: rust-src
-      - run: cargo build --release --features default-backends
-      - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort" --features default-backends
+      - run: cargo build --release
+      - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test
+      - run: cargo test --features default-backends
       # Make sure enabling the std feature doesn't break anything
-      - run: cargo test --features=std
+      - run: cargo test --features=std,default-backends
       - if: ${{ matrix.toolchain == 'nightly' }}
-        run: cargo test --benches
+        run: cargo test --benches --features default-backends
 
   linux:
     name: Linux
@@ -53,27 +53,27 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --target=${{ matrix.target }} --features=std
+      - run: cargo test --target=${{ matrix.target }} --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="linux_getrandom"
-        run: cargo test --target=${{ matrix.target }} --features=std
+        run: cargo test --target=${{ matrix.target }} --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
-        run: cargo test --target=${{ matrix.target }} --features=std
+        run: cargo test --target=${{ matrix.target }} --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_test_linux_fallback
-        run: cargo test --features=std
+        run: cargo test --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_test_linux_without_fallback
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_test_linux_without_fallback
-        run: cargo test --features=std
+        run: cargo test --features=std,default-backends
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
           RUSTDOCFLAGS: -Dwarnings --cfg getrandom_backend="rdrand"
-        run: cargo test --features=std
+        run: cargo test --features=std,default-backends
 
   ios:
     name: iOS Simulator
@@ -105,7 +105,7 @@ jobs:
           echo "device=$SIM_ID" >> $GITHUB_ENV
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
-        run: cargo dinghy -p auto-ios-aarch64-sim -d ${{ env.device }} test
+        run: cargo dinghy -p auto-ios-aarch64-sim -d ${{ env.device }} test --features default-backends
 
   windows:
     name: Windows
@@ -123,7 +123,7 @@ jobs:
         with:
           toolchain: ${{ matrix.toolchain }}
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --features=std
+      - run: cargo test --features=std,default-backends
 
   windows7:
     name: Windows 7 (on Windows 10)
@@ -136,8 +136,8 @@ jobs:
           toolchain: nightly-2024-05-20
           components: rust-src
       - uses: Swatinem/rust-cache@v2
-      - run: cargo test --target=x86_64-win7-windows-msvc -Z build-std --features=std
-      - run: cargo test --target=i686-win7-windows-msvc -Z build-std --features=std
+      - run: cargo test --target=x86_64-win7-windows-msvc -Z build-std --features=std,default-backends
+      - run: cargo test --target=i686-win7-windows-msvc -Z build-std --features=std,default-backends
 
   sanitizer:
     name: Sanitizer
@@ -151,7 +151,7 @@ jobs:
       - env:
           RUSTFLAGS: -Dwarnings -Zsanitizer=memory
           RUSTDOCFLAGS: -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=x86_64-unknown-linux-gnu
+        run: cargo test -Zbuild-std --target=x86_64-unknown-linux-gnu --features default-backends
 
   cross:
     name: Cross
@@ -180,7 +180,7 @@ jobs:
           wget -O - $URL | tar -xz -C ~/.cargo/bin
           cross --version
       - name: Test
-        run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std
+        run: cross test --no-fail-fast --target=${{ matrix.target }} --features=std,default-backends
 
   freebsd:
     name: FreeBSD VM
@@ -194,7 +194,7 @@ jobs:
           usesh: true
           prepare: |
             pkg install -y rust
-          run: cargo test
+          run: cargo test --features default-backends
 
   openbsd:
     name: OpenBSD VM
@@ -208,7 +208,7 @@ jobs:
           usesh: true
           prepare: |
             pkg_add rust
-          run: cargo test
+          run: cargo test --features default-backends
 
   netbsd:
     name: NetBSD VM
@@ -223,8 +223,8 @@ jobs:
           prepare: |
             /usr/sbin/pkg_add rust
           run: |
-            cargo test
-            RUSTFLAGS="--cfg getrandom_test_netbsd_fallback -D warnings" cargo test
+            cargo test --features default-backends
+            RUSTFLAGS="--cfg getrandom_test_netbsd_fallback -D warnings" cargo test --features default-backends
 
   web:
     name: ${{ matrix.rust.description }}
@@ -237,14 +237,14 @@ jobs:
               description: Web,
               version: stable,
               flags: '-Dwarnings --cfg getrandom_backend="wasm_js"',
-              args: '--features=std,wasm_js',
+              args: '--features=std,wasm_js,default-backends',
             }
           - {
               description: Web with Atomics,
               version: nightly,
               components: rust-src,
               flags: '-Dwarnings --cfg getrandom_backend="wasm_js" -Ctarget-feature=+atomics,+bulk-memory',
-              args: '--features=std,wasm_js -Zbuild-std=panic_abort,std',
+              args: '--features=std,wasm_js,default-backends -Zbuild-std=panic_abort,std',
             }
     steps:
       - uses: actions/checkout@v4
@@ -314,6 +314,6 @@ jobs:
           wasmtime --version
       - uses: Swatinem/rust-cache@v2
       - name: WASI 0.1 Test
-        run: cargo test --target wasm32-wasip1
+        run: cargo test --target wasm32-wasip1 --features default-backends
       - name: WASI 0.2 Test
-        run: cargo test --target wasm32-wasip2
+        run: cargo test --target wasm32-wasip2 --features default-backends

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "448068da8f2326b2a0472353cb401dd8795a89c007ef30fff90f50706e862e72"
 
 [[package]]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.0"
 dependencies = [
  "cfg-if",
  "compiler_builtins",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.3.3"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.63" # Sync tests.yml and README.md.
 authors = ["The Rand Project Developers"]
@@ -18,12 +18,14 @@ std = []
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
 
+# Provides a default implementations of the backend for many supported targets.
+default-backends = ["dep:libc", "dep:r-efi", "dep:wasi"]
 # Optional backend: wasm_js
 # This flag enables the backend but does not select it. To use the backend, use
 # this flag *and* set getrandom_backend=wasm_js (see README).
 # WARNING: It is highly recommended to enable this feature only for binary crates and tests,
 # i.e. avoid unconditionally enabling it in library crates.
-wasm_js = ["dep:wasm-bindgen", "dep:js-sys"]
+wasm_js = ["dep:wasm-bindgen", "dep:js-sys", "default-backends"]
 
 [dependencies]
 cfg-if = "1"
@@ -34,43 +36,43 @@ core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" 
 
 # getrandom / linux_android_with_fallback
 [target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom", getrandom_backend = "linux_raw", getrandom_backend = "rdrand", getrandom_backend = "rndr"))))'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # apple-other
 [target.'cfg(any(target_os = "ios", target_os = "visionos", target_os = "watchos", target_os = "tvos"))'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # efi_rng
 [target.'cfg(all(target_os = "uefi", getrandom_backend = "efi_rng"))'.dependencies]
-r-efi = { version = "5.1", default-features = false }
+r-efi = { version = "5.1", default-features = false, optional = true }
 
 # getentropy
 [target.'cfg(any(target_os = "macos", target_os = "openbsd", target_os = "vita", target_os = "emscripten"))'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # getrandom
 [target.'cfg(any(target_os = "dragonfly", target_os = "freebsd", target_os = "hurd", target_os = "illumos", target_os = "cygwin", all(target_os = "horizon", target_arch = "arm")))'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # netbsd
 [target.'cfg(target_os = "netbsd")'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # solaris
 [target.'cfg(target_os = "solaris")'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # use_file
 [target.'cfg(any(target_os = "haiku", target_os = "redox", target_os = "nto", target_os = "aix"))'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # vxworks
 [target.'cfg(target_os = "vxworks")'.dependencies]
-libc = { version = "0.2.154", default-features = false }
+libc = { version = "0.2.154", default-features = false, optional = true }
 
 # wasi (0.2 only)
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))'.dependencies]
-wasi = { version = "0.14", default-features = false }
+wasi = { version = "0.14", default-features = false, optional = true }
 
 # wasm_js
 [target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]

--- a/nopanic_check/Cargo.toml
+++ b/nopanic_check/Cargo.toml
@@ -12,7 +12,7 @@ name = "getrandom_wrapper"
 crate-type = ["cdylib"]
 
 [dependencies]
-getrandom = { path = ".." }
+getrandom = { path = "..", features = ["default-backends"]}
 
 [profile.release]
 panic = "abort"

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,0 +1,182 @@
+//! An implementation which calls out to an externally defined function.
+use crate::Error;
+use core::{mem::MaybeUninit, slice};
+
+/// Describes how `getrandom` can collect random values from a particular backend.
+///
+/// Implementers can pair this with [`set_backend`] to always use their [`Backend`],
+/// or allow users to call it themselves if that's more appropriate.
+pub unsafe trait Backend {
+    /// Writes `len` random values starting at `dest`.
+    ///
+    /// # Safety
+    ///
+    /// - `dest` must be a valid pointer at least `len` bytes long.
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error>;
+
+    /// Fill a slice of [`MaybeUninit`] bytes with random values.
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        let ptr = dest.as_mut_ptr().cast();
+        let len = dest.len();
+
+        // SAFETY: `ptr` is valid and exactly `len` bytes in size
+        unsafe { Self::fill_ptr(ptr, len) }
+    }
+
+    /// Fill a slice of bytes with random values.
+    #[inline]
+    fn fill(dest: &mut [u8]) -> Result<(), Error> {
+        // SAFETY: The `&mut MaybeUninit<_>` reference doesn't escape,
+        // and `fill_uninit` guarantees it will never de-initialize
+        // any part of `dest`.
+        Self::fill_uninit(unsafe { crate::util::slice_as_uninit_mut(dest) })?;
+        Ok(())
+    }
+
+    /// Generates a single random [`u32`] value.
+    #[inline]
+    fn u32() -> Result<u32, Error> {
+        let mut res = MaybeUninit::<u32>::uninit();
+        // SAFETY: the created slice has the same size as `res`
+        let dst = unsafe {
+            let p: *mut MaybeUninit<u8> = res.as_mut_ptr().cast();
+            slice::from_raw_parts_mut(p, core::mem::size_of::<u32>())
+        };
+        Self::fill_uninit(dst)?;
+        // SAFETY: `dst` has been fully initialized by `imp::fill_inner`
+        // since it returned `Ok`.
+        Ok(unsafe { res.assume_init() })
+    }
+
+    /// Generates a single random [`u64`] value.
+    #[inline]
+    fn u64() -> Result<u64, Error> {
+        let mut res = MaybeUninit::<u64>::uninit();
+        // SAFETY: the created slice has the same size as `res`
+        let dst = unsafe {
+            let p: *mut MaybeUninit<u8> = res.as_mut_ptr().cast();
+            slice::from_raw_parts_mut(p, core::mem::size_of::<u64>())
+        };
+        Self::fill_uninit(dst)?;
+        // SAFETY: `dst` has been fully initialized by `imp::fill_inner`
+        // since it returned `Ok`.
+        Ok(unsafe { res.assume_init() })
+    }
+
+    /// Describes a custom [`Error`] code reported by this [`Backend`].
+    #[inline]
+    #[expect(unused_variables)]
+    fn describe_custom_error(n: u16) -> Option<&'static str> {
+        None
+    }
+}
+
+/// An implementation of [`Backend`] that relies on some other external implementation, paired
+/// with a call to [`set_backend`].
+pub(crate) struct ExternBackend;
+
+unsafe impl Backend for ExternBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error>;
+        }
+        __getrandom_v04_backend_fill_ptr(dest, len)
+    }
+
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_fill_uninit(
+                dest: &mut [MaybeUninit<u8>],
+            ) -> Result<(), Error>;
+        }
+        unsafe { __getrandom_v04_backend_fill_uninit(dest) }
+    }
+
+    #[inline]
+    fn fill(dest: &mut [u8]) -> Result<(), Error> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_fill(dest: &mut [u8]) -> Result<(), Error>;
+        }
+        unsafe { __getrandom_v04_backend_fill(dest) }
+    }
+
+    #[inline]
+    fn u32() -> Result<u32, Error> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_u32() -> Result<u32, Error>;
+        }
+        unsafe { __getrandom_v04_backend_u32() }
+    }
+
+    #[inline]
+    fn u64() -> Result<u64, Error> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_u64() -> Result<u64, Error>;
+        }
+        unsafe { __getrandom_v04_backend_u64() }
+    }
+
+    #[inline]
+    fn describe_custom_error(n: u16) -> Option<&'static str> {
+        extern "Rust" {
+            fn __getrandom_v04_backend_describe_custom_error(n: u16) -> Option<&'static str>;
+        }
+        unsafe { __getrandom_v04_backend_describe_custom_error(n) }
+    }
+}
+
+/// Uses the provided [`Backend`].
+/// This macro must be called exactly once, otherwise the final linking will fail due to either
+/// duplicated or missing symbols.
+#[macro_export]
+macro_rules! set_backend {
+    ($t: ty) => {
+        const _: () = {
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_fill_ptr(
+                dest: *mut u8,
+                len: usize,
+            ) -> Result<(), $crate::Error> {
+                <$t as $crate::Backend>::fill_ptr(dest, len)
+            }
+
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_fill_uninit(
+                dest: &mut [core::mem::MaybeUninit<u8>],
+            ) -> Result<(), $crate::Error> {
+                <$t as $crate::Backend>::fill_uninit(dest)
+            }
+
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_fill(dest: &mut [u8]) -> Result<(), $crate::Error> {
+                <$t as $crate::Backend>::fill(dest)
+            }
+
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_u32() -> Result<u32, $crate::Error> {
+                <$t as $crate::Backend>::u32()
+            }
+
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_u64() -> Result<u64, $crate::Error> {
+                <$t as $crate::Backend>::u64()
+            }
+
+            #[inline]
+            #[no_mangle]
+            unsafe fn __getrandom_v04_backend_describe_custom_error(
+                n: u16,
+            ) -> Option<&'static str> {
+                <$t as $crate::Backend>::describe_custom_error(n)
+            }
+        };
+    };
+}

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -9,7 +9,6 @@ use core::{mem::MaybeUninit, slice};
 macro_rules! set_backend {
     ($t: ty) => {
         const _: () = {
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_fill_ptr(
                 dest: *mut u8,
@@ -18,7 +17,6 @@ macro_rules! set_backend {
                 <$t as $crate::Backend>::fill_ptr(dest, len)
             }
 
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_fill_uninit(
                 dest: &mut [core::mem::MaybeUninit<u8>],
@@ -26,25 +24,21 @@ macro_rules! set_backend {
                 <$t as $crate::Backend>::fill_uninit(dest)
             }
 
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_fill(dest: &mut [u8]) -> Result<(), $crate::Error> {
                 <$t as $crate::Backend>::fill(dest)
             }
 
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_u32() -> Result<u32, $crate::Error> {
                 <$t as $crate::Backend>::u32()
             }
 
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_u64() -> Result<u64, $crate::Error> {
                 <$t as $crate::Backend>::u64()
             }
 
-            #[inline]
             #[no_mangle]
             unsafe fn __getrandom_v04_backend_describe_custom_error(
                 n: u16,

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -117,7 +117,7 @@ pub unsafe trait Backend {
 
     /// Describes a custom [`Error`] code reported by this [`Backend`].
     #[inline]
-    #[expect(unused_variables)]
+    #[allow(unused_variables)]
     fn describe_custom_error(n: u16) -> Option<&'static str> {
         None
     }

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -9,44 +9,34 @@
 cfg_if! {
     if #[cfg(getrandom_backend = "custom")] {
         mod custom;
-        pub use custom::*;
+        crate::set_backend!(custom::LegacyCustomBackend);
     } else if #[cfg(getrandom_backend = "linux_getrandom")] {
         mod getrandom;
-        pub use getrandom::*;
+        crate::set_backend!(getrandom::GetrandomBackend);
     } else if #[cfg(getrandom_backend = "linux_raw")] {
         mod linux_raw;
-        pub use linux_raw::*;
+        crate::set_backend!(linux_raw::LinuxRawBackend);
     } else if #[cfg(getrandom_backend = "rdrand")] {
         mod rdrand;
-        pub use rdrand::*;
+        crate::set_backend!(rdrand::RdrandBackend);
     } else if #[cfg(getrandom_backend = "rndr")] {
         mod rndr;
-        pub use rndr::*;
+        crate::set_backend!(rndr::RndrBackend);
     } else if #[cfg(getrandom_backend = "efi_rng")] {
         mod efi_rng;
-        pub use efi_rng::*;
-    } else if #[cfg(all(getrandom_backend = "wasm_js"))] {
-        cfg_if! {
-            if #[cfg(feature = "wasm_js")] {
-                mod wasm_js;
-                pub use wasm_js::*;
-            } else {
-                compile_error!(concat!(
-                    "The \"wasm_js\" backend requires the `wasm_js` feature \
-                    for `getrandom`. For more information see: \
-                    https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
-                ));
-            }
-        }
+        crate::set_backend!(efi_rng::UefiBackend);
+    } else if #[cfg(all(getrandom_backend = "wasm_js", feature = "wasm_js"))] {
+        mod wasm_js;
+        crate::set_backend!(wasm_js::WasmJsBackend);
     } else if #[cfg(getrandom_backend = "unsupported")] {
         mod unsupported;
-        pub use unsupported::*;
+        crate::set_backend!(unsupported::UnsupportedBackend);
     } else if #[cfg(all(target_os = "linux", target_env = ""))] {
         mod linux_raw;
-        pub use linux_raw::*;
+        crate::set_backend!(linux_raw::LinuxRawBackend);
     } else if #[cfg(target_os = "espidf")] {
         mod esp_idf;
-        pub use esp_idf::*;
+        crate::set_backend!(esp_idf::EspIdfBackend);
     } else if #[cfg(any(
         target_os = "haiku",
         target_os = "redox",
@@ -54,7 +44,7 @@ cfg_if! {
         target_os = "aix",
     ))] {
         mod use_file;
-        pub use use_file::*;
+        crate::set_backend!(use_file::UseFileBackend);
     } else if #[cfg(any(
         target_os = "macos",
         target_os = "openbsd",
@@ -62,7 +52,7 @@ cfg_if! {
         target_os = "emscripten",
     ))] {
         mod getentropy;
-        pub use getentropy::*;
+        crate::set_backend!(getentropy::GetentropyBackend);
     } else if #[cfg(any(
         // Rust supports Android API level 19 (KitKat) [0] and the next upgrade targets
         // level 21 (Lollipop) [1], while `getrandom(2)` was added only in
@@ -102,7 +92,7 @@ cfg_if! {
     ))] {
         mod use_file;
         mod linux_android_with_fallback;
-        pub use linux_android_with_fallback::*;
+        crate::set_backend!(linux_android_with_fallback::LinuxBackend);
     } else if #[cfg(any(
         target_os = "android",
         target_os = "linux",
@@ -116,16 +106,16 @@ cfg_if! {
         all(target_os = "horizon", target_arch = "arm"),
     ))] {
         mod getrandom;
-        pub use getrandom::*;
+        crate::set_backend!(getrandom::GetrandomBackend);
     } else if #[cfg(target_os = "solaris")] {
         mod solaris;
-        pub use solaris::*;
+        crate::set_backend!(solaris::SolarisBackend);
     } else if #[cfg(target_os = "netbsd")] {
         mod netbsd;
-        pub use netbsd::*;
+        crate::set_backend!(netbsd::NetBsdBackend);
     } else if #[cfg(target_os = "fuchsia")] {
         mod fuchsia;
-        pub use fuchsia::*;
+        crate::set_backend!(fuchsia::FuchsiaBackend);
     } else if #[cfg(any(
         target_os = "ios",
         target_os = "visionos",
@@ -133,48 +123,31 @@ cfg_if! {
         target_os = "tvos",
     ))] {
         mod apple_other;
-        pub use apple_other::*;
-    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi"))] {
-        cfg_if! {
-            if #[cfg(target_env = "p1")] {
-                mod wasi_p1;
-                pub use wasi_p1::*;
-            } else if #[cfg(target_env = "p2")] {
-                mod wasi_p2;
-                pub use wasi_p2::*;
-            } else {
-                compile_error!(
-                    "Unknown version of WASI (only previews 1 and 2 are supported) \
-                    or Rust version older than 1.80 was used"
-                );
-            }
-        }
+        crate::set_backend!(apple_other::AppleOtherBackend);
+    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p1"))] {
+        mod wasi_p1;
+        crate::set_backend!(wasi_p1::WasiP1Backend);
+    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))] {
+        mod wasi_p2;
+        crate::set_backend!(wasi_p2::WasiP2Backend);
     } else if #[cfg(target_os = "hermit")] {
         mod hermit;
-        pub use hermit::*;
+        crate::set_backend!(hermit::HermitBackend);
     } else if #[cfg(target_os = "vxworks")] {
         mod vxworks;
-        pub use vxworks::*;
+        crate::set_backend!(vxworks::VxWorksBackend);
     } else if #[cfg(target_os = "solid_asp3")] {
         mod solid;
-        pub use solid::*;
+        crate::set_backend!(solid::SolidBackend);
     } else if #[cfg(all(windows, any(target_vendor = "win7", getrandom_windows_legacy)))] {
         mod windows7;
-        pub use windows7::*;
+        crate::set_backend!(windows7::WindowsLegacyBackend);
     } else if #[cfg(windows)] {
         mod windows;
-        pub use windows::*;
+        crate::set_backend!(windows::WindowsBackend);
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
         mod rdrand;
-        pub use rdrand::*;
-    } else if #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))] {
-        compile_error!(concat!(
-            "The wasm32-unknown-unknown targets are not supported by default; \
-            you may need to enable the \"wasm_js\" configuration flag. Note \
-            that enabling the `wasm_js` feature flag alone is insufficient. \
-            For more information see: \
-            https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
-        ));
+        crate::set_backend!(rdrand::RdrandBackend);
     } else {
         compile_error!(concat!(
             "target is not supported. You may need to define a custom backend see: \

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -124,12 +124,16 @@ cfg_if! {
     ))] {
         mod apple_other;
         crate::set_backend!(apple_other::AppleOtherBackend);
-    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p1"))] {
-        mod wasi_p1;
-        crate::set_backend!(wasi_p1::WasiP1Backend);
-    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))] {
-        mod wasi_p2;
-        crate::set_backend!(wasi_p2::WasiP2Backend);
+    } else if #[cfg(all(target_arch = "wasm32", target_os = "wasi"))] {
+        cfg_if! {
+            if #[cfg(target_env = "p1")] {
+                mod wasi_p1;
+                crate::set_backend!(wasi_p1::WasiP1Backend);
+            } else if #[cfg(target_env = "p2")] {
+                mod wasi_p2;
+                crate::set_backend!(wasi_p2::WasiP2Backend);
+            }
+        }
     } else if #[cfg(target_os = "hermit")] {
         mod hermit;
         crate::set_backend!(hermit::HermitBackend);

--- a/src/backends/apple_other.rs
+++ b/src/backends/apple_other.rs
@@ -1,21 +1,31 @@
 //! Implementation for iOS, tvOS, and watchOS where `getentropy` is unavailable.
+use crate::Backend;
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
 
-pub use crate::util::{inner_u32, inner_u64};
+pub struct AppleOtherBackend;
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    let dst_ptr = dest.as_mut_ptr().cast::<c_void>();
-    let ret = unsafe { libc::CCRandomGenerateBytes(dst_ptr, dest.len()) };
-    if ret == libc::kCCSuccess {
-        Ok(())
-    } else {
-        Err(Error::IOS_RANDOM_GEN)
+unsafe impl Backend for AppleOtherBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let dst_ptr = dest.cast::<c_void>();
+        let ret = unsafe { libc::CCRandomGenerateBytes(dst_ptr, len) };
+        if ret == libc::kCCSuccess {
+            Ok(())
+        } else {
+            Err(Error::new_custom(IOS_RANDOM_GEN))
+        }
+    }
+
+    #[inline]
+    fn describe_custom_error(n: u16) -> Option<&'static str> {
+        if n == IOS_RANDOM_GEN {
+            Some("SecRandomCopyBytes: iOS Security framework failure")
+        } else {
+            None
+        }
     }
 }
 
-impl Error {
-    /// Call to `CCRandomGenerateBytes` failed.
-    pub(crate) const IOS_RANDOM_GEN: Error = Self::new_internal(10);
-}
+/// Call to `CCRandomGenerateBytes` failed.
+const IOS_RANDOM_GEN: u16 = 10;

--- a/src/backends/apple_other.rs
+++ b/src/backends/apple_other.rs
@@ -1,7 +1,7 @@
 //! Implementation for iOS, tvOS, and watchOS where `getentropy` is unavailable.
 use crate::Backend;
 use crate::Error;
-use core::{ffi::c_void, mem::MaybeUninit};
+use core::ffi::c_void;
 
 pub struct AppleOtherBackend;
 

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -1,13 +1,16 @@
 //! An implementation which calls out to an externally defined function.
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub struct LegacyCustomBackend;
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    extern "Rust" {
-        fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
+unsafe impl Backend for LegacyCustomBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        extern "Rust" {
+            fn __getrandom_v03_custom(dest: *mut u8, len: usize) -> Result<(), Error>;
+        }
+        __getrandom_v03_custom(dest, len)
     }
-    unsafe { __getrandom_v03_custom(dest.as_mut_ptr().cast(), dest.len()) }
 }

--- a/src/backends/custom.rs
+++ b/src/backends/custom.rs
@@ -1,7 +1,6 @@
 //! An implementation which calls out to an externally defined function.
 use crate::Backend;
 use crate::Error;
-use core::mem::MaybeUninit;
 
 pub struct LegacyCustomBackend;
 

--- a/src/backends/efi_rng.rs
+++ b/src/backends/efi_rng.rs
@@ -1,4 +1,5 @@
 //! Implementation for UEFI using EFI_RNG_PROTOCOL
+use crate::Backend;
 use crate::Error;
 use core::{
     mem::MaybeUninit,
@@ -12,8 +13,6 @@ use r_efi::{
 
 extern crate std;
 
-pub use crate::util::{inner_u32, inner_u64};
-
 #[cfg(not(target_os = "uefi"))]
 compile_error!("`efi_rng` backend can be enabled only for UEFI targets!");
 
@@ -25,7 +24,7 @@ fn init() -> Result<NonNull<rng::Protocol>, Error> {
     const HANDLE_SIZE: usize = size_of::<Handle>();
 
     let boot_services = std::os::uefi::env::boot_services()
-        .ok_or(Error::BOOT_SERVICES_UNAVAILABLE)?
+        .ok_or(Error::new_custom(BOOT_SERVICES_UNAVAILABLE))?
         .cast::<BootServices>();
 
     let mut handles = [ptr::null_mut(); 16];
@@ -91,34 +90,39 @@ fn init() -> Result<NonNull<rng::Protocol>, Error> {
         RNG_PROTOCOL.store(protocol.as_ptr(), Relaxed);
         return Ok(protocol);
     }
-    Err(Error::NO_RNG_HANDLE)
+    Err(Error::new_custom(NO_RNG_HANDLE))
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    let protocol = match NonNull::new(RNG_PROTOCOL.load(Relaxed)) {
-        Some(p) => p,
-        None => init()?,
-    };
+pub struct UefiBackend;
 
-    let mut alg_guid = rng::ALGORITHM_RAW;
-    let ret = unsafe {
-        ((*protocol.as_ptr()).get_rng)(
-            protocol.as_ptr(),
-            &mut alg_guid,
-            dest.len(),
-            dest.as_mut_ptr().cast::<u8>(),
-        )
-    };
+unsafe impl Backend for UefiBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let protocol = match NonNull::new(RNG_PROTOCOL.load(Relaxed)) {
+            Some(p) => p,
+            None => init()?,
+        };
 
-    if ret.is_error() {
-        Err(Error::from_uefi_code(ret.as_usize()))
-    } else {
-        Ok(())
+        let mut alg_guid = rng::ALGORITHM_RAW;
+        let ret =
+            unsafe { ((*protocol.as_ptr()).get_rng)(protocol.as_ptr(), &mut alg_guid, len, dest) };
+
+        if ret.is_error() {
+            Err(Error::from_uefi_code(ret.as_usize()))
+        } else {
+            Ok(())
+        }
+    }
+
+    #[inline]
+    fn describe_custom_error(n: u16) -> Option<&'static str> {
+        match n {
+            BOOT_SERVICES_UNAVAILABLE => None, // TODO: Custom error message?
+            NO_RNG_HANDLE => None,             // TODO: Custom error message?
+            _ => None,
+        }
     }
 }
 
-impl Error {
-    pub(crate) const BOOT_SERVICES_UNAVAILABLE: Error = Self::new_internal(10);
-    pub(crate) const NO_RNG_HANDLE: Error = Self::new_internal(11);
-}
+const BOOT_SERVICES_UNAVAILABLE: u16 = 10;
+const NO_RNG_HANDLE: u16 = 11;

--- a/src/backends/esp_idf.rs
+++ b/src/backends/esp_idf.rs
@@ -1,21 +1,23 @@
 //! Implementation for ESP-IDF
+use crate::Backend;
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
-
-pub use crate::util::{inner_u32, inner_u64};
 
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
-    // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
-    // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
-    //
-    // However tracking if some of these entropy sources is enabled is way too difficult to implement here
-    unsafe { esp_fill_random(dest.as_mut_ptr().cast(), dest.len()) };
+pub struct EspIdfBackend;
 
-    Ok(())
+unsafe impl Backend for EspIdfBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        // Not that NOT enabling WiFi, BT, or the voltage noise entropy source (via `bootloader_random_enable`)
+        // will cause ESP-IDF to return pseudo-random numbers based on the voltage noise entropy, after the initial boot process:
+        // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
+        //
+        // However tracking if some of these entropy sources is enabled is way too difficult to implement here
+        esp_fill_random(dest.as_mut_ptr().cast(), dest.len());
+        Ok(())
+    }
 }

--- a/src/backends/esp_idf.rs
+++ b/src/backends/esp_idf.rs
@@ -1,7 +1,7 @@
 //! Implementation for ESP-IDF
 use crate::Backend;
 use crate::Error;
-use core::{ffi::c_void, mem::MaybeUninit};
+use core::ffi::c_void;
 
 extern "C" {
     fn esp_fill_random(buf: *mut c_void, len: usize) -> u32;
@@ -17,7 +17,7 @@ unsafe impl Backend for EspIdfBackend {
         // https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/random.html
         //
         // However tracking if some of these entropy sources is enabled is way too difficult to implement here
-        esp_fill_random(dest.as_mut_ptr().cast(), dest.len());
+        esp_fill_random(dest.cast(), len);
         Ok(())
     }
 }

--- a/src/backends/fuchsia.rs
+++ b/src/backends/fuchsia.rs
@@ -1,7 +1,6 @@
 //! Implementation for Fuchsia Zircon
 use crate::Backend;
 use crate::Error;
-use core::mem::MaybeUninit;
 
 #[link(name = "zircon")]
 extern "C" {

--- a/src/backends/fuchsia.rs
+++ b/src/backends/fuchsia.rs
@@ -1,16 +1,19 @@
 //! Implementation for Fuchsia Zircon
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
-
-pub use crate::util::{inner_u32, inner_u64};
 
 #[link(name = "zircon")]
 extern "C" {
     fn zx_cprng_draw(buffer: *mut u8, length: usize);
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    unsafe { zx_cprng_draw(dest.as_mut_ptr().cast::<u8>(), dest.len()) }
-    Ok(())
+pub struct FuchsiaBackend;
+
+unsafe impl Backend for FuchsiaBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        zx_cprng_draw(dest, len);
+        Ok(())
+    }
 }

--- a/src/backends/getentropy.rs
+++ b/src/backends/getentropy.rs
@@ -19,7 +19,7 @@ pub struct GetentropyBackend;
 unsafe impl Backend for GetentropyBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/getentropy.rs
+++ b/src/backends/getentropy.rs
@@ -7,21 +7,30 @@
 //!   - vita newlib since Dec 2021
 //!
 //! For these targets, we use getentropy(2) because getrandom(2) doesn't exist.
+use crate::Backend;
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
-
-pub use crate::util::{inner_u32, inner_u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    for chunk in dest.chunks_mut(256) {
-        let ret = unsafe { libc::getentropy(chunk.as_mut_ptr().cast::<c_void>(), chunk.len()) };
-        if ret != 0 {
-            return Err(util_libc::last_os_error());
-        }
+pub struct GetentropyBackend;
+
+unsafe impl Backend for GetentropyBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
     }
-    Ok(())
+
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        for chunk in dest.chunks_mut(256) {
+            let ret = unsafe { libc::getentropy(chunk.as_mut_ptr().cast::<c_void>(), chunk.len()) };
+            if ret != 0 {
+                return Err(util_libc::last_os_error());
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/backends/getrandom.rs
+++ b/src/backends/getrandom.rs
@@ -27,7 +27,7 @@ pub struct GetrandomBackend;
 unsafe impl Backend for GetrandomBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/hermit.rs
+++ b/src/backends/hermit.rs
@@ -23,7 +23,7 @@ unsafe impl Backend for HermitBackend {
     }
 
     #[inline]
-    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    fn fill_uninit(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         while !dest.is_empty() {
             let res = unsafe { sys_read_entropy(dest.as_mut_ptr().cast::<u8>(), dest.len(), 0) };
             match res {

--- a/src/backends/hermit.rs
+++ b/src/backends/hermit.rs
@@ -18,7 +18,7 @@ pub struct HermitBackend;
 unsafe impl Backend for HermitBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -1,5 +1,6 @@
 //! Implementation for Linux / Android with `/dev/urandom` fallback
 use super::use_file;
+use crate::Backend;
 use crate::Error;
 use core::{
     ffi::c_void,
@@ -8,8 +9,6 @@ use core::{
     sync::atomic::{AtomicPtr, Ordering},
 };
 use use_file::util_libc;
-
-pub use crate::util::{inner_u32, inner_u64};
 
 type GetRandomFn = unsafe extern "C" fn(*mut c_void, libc::size_t, libc::c_uint) -> libc::ssize_t;
 
@@ -72,30 +71,40 @@ fn init() -> NonNull<c_void> {
 // Prevent inlining of the fallback implementation
 #[inline(never)]
 fn use_file_fallback(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    use_file::fill_inner(dest)
+    use_file::UseFileBackend::fill_uninit(dest)
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // Despite being only a single atomic variable, we still cannot always use
-    // Ordering::Relaxed, as we need to make sure a successful call to `init`
-    // is "ordered before" any data read through the returned pointer (which
-    // occurs when the function is called). Our implementation mirrors that of
-    // the one in libstd, meaning that the use of non-Relaxed operations is
-    // probably unnecessary.
-    let raw_ptr = GETRANDOM_FN.load(Ordering::Acquire);
-    let fptr = match NonNull::new(raw_ptr) {
-        Some(p) => p,
-        None => init(),
-    };
+pub struct LinuxBackend;
 
-    if fptr == NOT_AVAILABLE {
-        use_file_fallback(dest)
-    } else {
-        // note: `transmute` is currently the only way to convert a pointer into a function reference
-        let getrandom_fn = unsafe { transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
-        util_libc::sys_fill_exact(dest, |buf| unsafe {
-            getrandom_fn(buf.as_mut_ptr().cast(), buf.len(), 0)
-        })
+unsafe impl Backend for LinuxBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
+    }
+
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        // Despite being only a single atomic variable, we still cannot always use
+        // Ordering::Relaxed, as we need to make sure a successful call to `init`
+        // is "ordered before" any data read through the returned pointer (which
+        // occurs when the function is called). Our implementation mirrors that of
+        // the one in libstd, meaning that the use of non-Relaxed operations is
+        // probably unnecessary.
+        let raw_ptr = GETRANDOM_FN.load(Ordering::Acquire);
+        let fptr = match NonNull::new(raw_ptr) {
+            Some(p) => p,
+            None => init(),
+        };
+
+        if fptr == NOT_AVAILABLE {
+            use_file_fallback(dest)
+        } else {
+            // note: `transmute` is currently the only way to convert a pointer into a function reference
+            let getrandom_fn = unsafe { transmute::<NonNull<c_void>, GetRandomFn>(fptr) };
+            util_libc::sys_fill_exact(dest, |buf| unsafe {
+                getrandom_fn(buf.as_mut_ptr().cast(), buf.len(), 0)
+            })
+        }
     }
 }

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -79,7 +79,7 @@ pub struct LinuxBackend;
 unsafe impl Backend for LinuxBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/linux_raw.rs
+++ b/src/backends/linux_raw.rs
@@ -115,7 +115,7 @@ pub struct LinuxRawBackend;
 unsafe impl Backend for LinuxRawBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/linux_raw.rs
+++ b/src/backends/linux_raw.rs
@@ -120,7 +120,7 @@ unsafe impl Backend for LinuxRawBackend {
     }
 
     #[inline]
-    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    fn fill_uninit(mut dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         // Value of this error code is stable across all target arches.
         const EINTR: isize = -4;
 

--- a/src/backends/netbsd.rs
+++ b/src/backends/netbsd.rs
@@ -3,6 +3,7 @@
 //! `getrandom(2)` was introduced in NetBSD 10. To support older versions we
 //! implement our own weak linkage to it, and provide a fallback based on the
 //! KERN_ARND sysctl.
+use crate::Backend;
 use crate::Error;
 use core::{
     cmp,
@@ -11,8 +12,6 @@ use core::{
     ptr,
     sync::atomic::{AtomicPtr, Ordering},
 };
-
-pub use crate::util::{inner_u32, inner_u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
@@ -59,20 +58,30 @@ fn init() -> *mut c_void {
     ptr
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // Despite being only a single atomic variable, we still cannot always use
-    // Ordering::Relaxed, as we need to make sure a successful call to `init`
-    // is "ordered before" any data read through the returned pointer (which
-    // occurs when the function is called). Our implementation mirrors that of
-    // the one in libstd, meaning that the use of non-Relaxed operations is
-    // probably unnecessary.
-    let mut fptr = GETRANDOM.load(Ordering::Acquire);
-    if fptr.is_null() {
-        fptr = init();
+pub struct NetBsdBackend;
+
+unsafe impl Backend for NetBsdBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
     }
-    let fptr = unsafe { mem::transmute::<*mut c_void, GetRandomFn>(fptr) };
-    util_libc::sys_fill_exact(dest, |buf| unsafe {
-        fptr(buf.as_mut_ptr().cast::<c_void>(), buf.len(), 0)
-    })
+
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        // Despite being only a single atomic variable, we still cannot always use
+        // Ordering::Relaxed, as we need to make sure a successful call to `init`
+        // is "ordered before" any data read through the returned pointer (which
+        // occurs when the function is called). Our implementation mirrors that of
+        // the one in libstd, meaning that the use of non-Relaxed operations is
+        // probably unnecessary.
+        let mut fptr = GETRANDOM.load(Ordering::Acquire);
+        if fptr.is_null() {
+            fptr = init();
+        }
+        let fptr = unsafe { mem::transmute::<*mut c_void, GetRandomFn>(fptr) };
+        util_libc::sys_fill_exact(dest, |buf| unsafe {
+            fptr(buf.as_mut_ptr().cast::<c_void>(), buf.len(), 0)
+        })
+    }
 }

--- a/src/backends/netbsd.rs
+++ b/src/backends/netbsd.rs
@@ -63,7 +63,7 @@ pub struct NetBsdBackend;
 unsafe impl Backend for NetBsdBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/rdrand.rs
+++ b/src/backends/rdrand.rs
@@ -153,7 +153,7 @@ pub struct RdrandBackend;
 unsafe impl Backend for RdrandBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/rndr.rs
+++ b/src/backends/rndr.rs
@@ -114,7 +114,7 @@ pub struct RndrBackend;
 unsafe impl Backend for RndrBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/solaris.rs
+++ b/src/backends/solaris.rs
@@ -26,7 +26,7 @@ pub struct SolarisBackend;
 unsafe impl Backend for SolarisBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/solaris.rs
+++ b/src/backends/solaris.rs
@@ -12,31 +12,40 @@
 //! For more information, see the man page linked in lib.rs and this blog post:
 //! https://blogs.oracle.com/solaris/post/solaris-new-system-calls-getentropy2-and-getrandom2
 //! which also explains why this crate should not use getentropy(2).
+use crate::Backend;
 use crate::Error;
 use core::{ffi::c_void, mem::MaybeUninit};
-
-pub use crate::util::{inner_u32, inner_u64};
 
 #[path = "../util_libc.rs"]
 mod util_libc;
 
 const MAX_BYTES: usize = 1024;
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    for chunk in dest.chunks_mut(MAX_BYTES) {
-        let ptr = chunk.as_mut_ptr().cast::<c_void>();
-        let ret = unsafe { libc::getrandom(ptr, chunk.len(), libc::GRND_RANDOM) };
-        // In case the man page has a typo, we also check for negative ret.
-        // If getrandom(2) succeeds, it should have completely filled chunk.
-        match usize::try_from(ret) {
-            // Good. Keep going.
-            Ok(ret) if ret == chunk.len() => {}
-            // The syscall failed.
-            Ok(0) => return Err(util_libc::last_os_error()),
-            // All other cases should be impossible.
-            _ => return Err(Error::UNEXPECTED),
-        }
+pub struct SolarisBackend;
+
+unsafe impl Backend for SolarisBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
     }
-    Ok(())
+
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        for chunk in dest.chunks_mut(MAX_BYTES) {
+            let ptr = chunk.as_mut_ptr().cast::<c_void>();
+            let ret = unsafe { libc::getrandom(ptr, chunk.len(), libc::GRND_RANDOM) };
+            // In case the man page has a typo, we also check for negative ret.
+            // If getrandom(2) succeeds, it should have completely filled chunk.
+            match usize::try_from(ret) {
+                // Good. Keep going.
+                Ok(ret) if ret == chunk.len() => {}
+                // The syscall failed.
+                Ok(0) => return Err(util_libc::last_os_error()),
+                // All other cases should be impossible.
+                _ => return Err(Error::UNEXPECTED),
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/backends/solid.rs
+++ b/src/backends/solid.rs
@@ -1,7 +1,6 @@
 //! Implementation for SOLID
 use crate::Backend;
 use crate::Error;
-use core::mem::MaybeUninit;
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;

--- a/src/backends/solid.rs
+++ b/src/backends/solid.rs
@@ -1,19 +1,22 @@
 //! Implementation for SOLID
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
-
-pub use crate::util::{inner_u32, inner_u64};
 
 extern "C" {
     pub fn SOLID_RNG_SampleRandomBytes(buffer: *mut u8, length: usize) -> i32;
 }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest.as_mut_ptr().cast::<u8>(), dest.len()) };
-    if ret >= 0 {
-        Ok(())
-    } else {
-        Err(Error::from_neg_error_code(ret))
+pub struct SolidBackend;
+
+unsafe impl Backend for SolidBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let ret = unsafe { SOLID_RNG_SampleRandomBytes(dest, len) };
+        if ret >= 0 {
+            Ok(())
+        } else {
+            Err(Error::from_neg_error_code(ret))
+        }
     }
 }

--- a/src/backends/unsupported.rs
+++ b/src/backends/unsupported.rs
@@ -6,7 +6,7 @@ pub struct UnsupportedBackend;
 
 unsafe impl Backend for UnsupportedBackend {
     #[inline]
-    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+    unsafe fn fill_ptr(_dest: *mut u8, _len: usize) -> Result<(), Error> {
         Err(Error::UNSUPPORTED)
     }
 }

--- a/src/backends/unsupported.rs
+++ b/src/backends/unsupported.rs
@@ -1,6 +1,6 @@
 //! Implementation that errors at runtime.
+use crate::Backend;
 use crate::Error;
-use core::mem::MaybeUninit;
 
 pub struct UnsupportedBackend;
 

--- a/src/backends/unsupported.rs
+++ b/src/backends/unsupported.rs
@@ -2,8 +2,11 @@
 use crate::Error;
 use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+pub struct UnsupportedBackend;
 
-pub fn fill_inner(_dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    Err(Error::UNSUPPORTED)
+unsafe impl Backend for UnsupportedBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        Err(Error::UNSUPPORTED)
+    }
 }

--- a/src/backends/use_file.rs
+++ b/src/backends/use_file.rs
@@ -43,7 +43,7 @@ pub struct UseFileBackend;
 unsafe impl Backend for UseFileBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/vxworks.rs
+++ b/src/backends/vxworks.rs
@@ -15,7 +15,7 @@ pub struct VxWorksBackend;
 unsafe impl Backend for VxWorksBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/wasi_p1.rs
+++ b/src/backends/wasi_p1.rs
@@ -1,7 +1,6 @@
 //! Implementation for WASI Preview 1
 use crate::Backend;
 use crate::Error;
-use core::mem::MaybeUninit;
 
 // This linking is vendored from the wasi crate:
 // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2344-2350

--- a/src/backends/wasi_p1.rs
+++ b/src/backends/wasi_p1.rs
@@ -1,8 +1,7 @@
 //! Implementation for WASI Preview 1
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
-
-pub use crate::util::{inner_u32, inner_u64};
 
 // This linking is vendored from the wasi crate:
 // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2344-2350
@@ -15,18 +14,22 @@ extern "C" {
 /// https://github.com/WebAssembly/WASI/blob/38454e9e/legacy/preview1/witx/typenames.witx#L34-L39
 const MAX_ERROR_CODE: i32 = u16::MAX as i32;
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // Based on the wasi code:
-    // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2046-2062
-    // Note that size of an allocated object can not be bigger than isize::MAX bytes.
-    // WASI 0.1 supports only 32-bit WASM, so casting length to `i32` is safe.
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-    let ret = unsafe { random_get(dest.as_mut_ptr() as i32, dest.len() as i32) };
-    match ret {
-        0 => Ok(()),
-        // WASI functions should return positive error codes which are smaller than `MAX_ERROR_CODE`
-        code if code <= MAX_ERROR_CODE => Err(Error::from_neg_error_code(-code)),
-        _ => Err(Error::UNEXPECTED),
+pub struct WasiP1Backend;
+
+unsafe impl Backend for WasiP1Backend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        // Based on the wasi code:
+        // https://docs.rs/wasi/0.11.0+wasi-snapshot-preview1/src/wasi/lib_generated.rs.html#2046-2062
+        // Note that size of an allocated object can not be bigger than isize::MAX bytes.
+        // WASI 0.1 supports only 32-bit WASM, so casting length to `i32` is safe.
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let ret = unsafe { random_get(dest as i32, len as i32) };
+        match ret {
+            0 => Ok(()),
+            // WASI functions should return positive error codes which are smaller than `MAX_ERROR_CODE`
+            code if code <= MAX_ERROR_CODE => Err(Error::from_neg_error_code(-code)),
+            _ => Err(Error::UNEXPECTED),
+        }
     }
 }

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -9,7 +9,7 @@ pub struct WasiP2Backend;
 unsafe impl Backend for WasiP2Backend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -1,50 +1,60 @@
 //! Implementation for WASI Preview 2.
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
 use wasi::random::random::get_random_u64;
 
-#[inline]
-pub fn inner_u32() -> Result<u32, Error> {
-    let val = get_random_u64();
-    Ok(crate::util::truncate(val))
-}
+pub struct WasiP2Backend;
 
-#[inline]
-pub fn inner_u64() -> Result<u64, Error> {
-    Ok(get_random_u64())
-}
+unsafe impl Backend for WasiP2Backend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
+    }
 
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    use core::ptr::copy_nonoverlapping;
-    use wasi::random::random::get_random_u64;
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        use core::ptr::copy_nonoverlapping;
 
-    let (prefix, chunks, suffix) = unsafe { dest.align_to_mut::<MaybeUninit<u64>>() };
+        let (prefix, chunks, suffix) = unsafe { dest.align_to_mut::<MaybeUninit<u64>>() };
 
-    // We use `get_random_u64` instead of `get_random_bytes` because the latter creates
-    // an allocation due to the Wit IDL [restrictions][0]. This should be fine since
-    // the main use case of `getrandom` is seed generation.
-    //
-    // [0]: https://github.com/WebAssembly/wasi-random/issues/27
-    if !prefix.is_empty() {
-        let val = get_random_u64();
-        let src = (&val as *const u64).cast();
-        unsafe {
-            copy_nonoverlapping(src, prefix.as_mut_ptr(), prefix.len());
+        // We use `get_random_u64` instead of `get_random_bytes` because the latter creates
+        // an allocation due to the Wit IDL [restrictions][0]. This should be fine since
+        // the main use case of `getrandom` is seed generation.
+        //
+        // [0]: https://github.com/WebAssembly/wasi-random/issues/27
+        if !prefix.is_empty() {
+            let val = get_random_u64();
+            let src = (&val as *const u64).cast();
+            unsafe {
+                copy_nonoverlapping(src, prefix.as_mut_ptr(), prefix.len());
+            }
         }
-    }
 
-    for dst in chunks {
-        dst.write(get_random_u64());
-    }
-
-    if !suffix.is_empty() {
-        let val = get_random_u64();
-        let src = (&val as *const u64).cast();
-        unsafe {
-            copy_nonoverlapping(src, suffix.as_mut_ptr(), suffix.len());
+        for dst in chunks {
+            dst.write(get_random_u64());
         }
+
+        if !suffix.is_empty() {
+            let val = get_random_u64();
+            let src = (&val as *const u64).cast();
+            unsafe {
+                copy_nonoverlapping(src, suffix.as_mut_ptr(), suffix.len());
+            }
+        }
+
+        Ok(())
     }
 
-    Ok(())
+    #[inline]
+    fn u32() -> Result<u32, Error> {
+        let val = get_random_u64();
+        Ok(crate::util::truncate(val))
+    }
+
+    #[inline]
+    fn u64() -> Result<u64, Error> {
+        Ok(get_random_u64())
+    }
 }

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -13,7 +13,7 @@ pub struct WasmJsBackend;
 unsafe impl Backend for WasmJsBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -22,7 +22,7 @@ unsafe impl Backend for WasmJsBackend {
     fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
         for chunk in dest.chunks_mut(MAX_BUFFER_SIZE) {
             if get_random_values(chunk).is_err() {
-                return Err(Error::WEB_CRYPTO);
+                return Err(Error::new_custom(WEB_CRYPTO));
             }
         }
         Ok(())

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -1,58 +1,73 @@
 //! Implementation for WASM based on Web and Node.js
+use crate::Backend;
 use crate::Error;
 use core::mem::MaybeUninit;
-
-pub use crate::util::{inner_u32, inner_u64};
 
 #[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
 compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
 
 use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
 
-// Maximum buffer size allowed in `Crypto.getRandomValuesSize` is 65536 bytes.
-// See https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
-const MAX_BUFFER_SIZE: usize = 65536;
+pub struct WasmJsBackend;
 
-#[cfg(not(target_feature = "atomics"))]
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    for chunk in dest.chunks_mut(MAX_BUFFER_SIZE) {
-        if get_random_values(chunk).is_err() {
-            return Err(Error::WEB_CRYPTO);
-        }
+unsafe impl Backend for WasmJsBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        Self::fill_uninit(slice)
     }
-    Ok(())
-}
 
-#[cfg(target_feature = "atomics")]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    // getRandomValues does not work with all types of WASM memory,
-    // so we initially write to browser memory to avoid exceptions.
-    let buf_len = usize::min(dest.len(), MAX_BUFFER_SIZE);
-    let buf_len_u32 = buf_len
-        .try_into()
-        .expect("buffer length is bounded by MAX_BUFFER_SIZE");
-    let buf = js_sys::Uint8Array::new_with_length(buf_len_u32);
-    for chunk in dest.chunks_mut(buf_len) {
-        let chunk_len = chunk
-            .len()
+    #[cfg(not(target_feature = "atomics"))]
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        for chunk in dest.chunks_mut(MAX_BUFFER_SIZE) {
+            if get_random_values(chunk).is_err() {
+                return Err(Error::WEB_CRYPTO);
+            }
+        }
+        Ok(())
+    }
+
+    #[cfg(target_feature = "atomics")]
+    #[inline]
+    fn fill_uninit(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+        // getRandomValues does not work with all types of WASM memory,
+        // so we initially write to browser memory to avoid exceptions.
+        let buf_len = usize::min(dest.len(), MAX_BUFFER_SIZE);
+        let buf_len_u32 = buf_len
             .try_into()
-            .expect("chunk length is bounded by MAX_BUFFER_SIZE");
-        // The chunk can be smaller than buf's length, so we call to
-        // JS to create a smaller view of buf without allocation.
-        let sub_buf = if chunk_len == buf_len_u32 {
-            &buf
-        } else {
-            &buf.subarray(0, chunk_len)
-        };
+            .expect("buffer length is bounded by MAX_BUFFER_SIZE");
+        let buf = js_sys::Uint8Array::new_with_length(buf_len_u32);
+        for chunk in dest.chunks_mut(buf_len) {
+            let chunk_len = chunk
+                .len()
+                .try_into()
+                .expect("chunk length is bounded by MAX_BUFFER_SIZE");
+            // The chunk can be smaller than buf's length, so we call to
+            // JS to create a smaller view of buf without allocation.
+            let sub_buf = if chunk_len == buf_len_u32 {
+                &buf
+            } else {
+                &buf.subarray(0, chunk_len)
+            };
 
-        if get_random_values(sub_buf).is_err() {
-            return Err(Error::WEB_CRYPTO);
+            if get_random_values(sub_buf).is_err() {
+                return Err(Error::new_custom(WEB_CRYPTO));
+            }
+
+            sub_buf.copy_to_uninit(chunk);
         }
-
-        sub_buf.copy_to_uninit(chunk);
+        Ok(())
     }
-    Ok(())
+
+    #[inline]
+    fn describe_custom_error(n: u16) -> Option<&'static str> {
+        if n == WEB_CRYPTO {
+            Some("Web Crypto API is unavailable")
+        } else {
+            None
+        }
+    }
 }
 
 #[wasm_bindgen]
@@ -66,7 +81,9 @@ extern "C" {
     fn get_random_values(buf: &js_sys::Uint8Array) -> Result<(), JsValue>;
 }
 
-impl Error {
-    /// The environment does not support the Web Crypto API.
-    pub(crate) const WEB_CRYPTO: Error = Self::new_internal(10);
-}
+/// The environment does not support the Web Crypto API.
+const WEB_CRYPTO: u16 = 10;
+
+/// Maximum buffer size allowed in `Crypto.getRandomValuesSize` is 65536 bytes.
+/// See https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
+const MAX_BUFFER_SIZE: usize = 65536;

--- a/src/backends/windows.rs
+++ b/src/backends/windows.rs
@@ -20,10 +20,25 @@
 //!     - Thin wrapper around ProcessPrng
 //!
 //! For more information see the Windows RNG Whitepaper: https://aka.ms/win10rng
-use crate::Error;
-use core::mem::MaybeUninit;
 
-pub use crate::util::{inner_u32, inner_u64};
+use crate::Backend;
+use crate::Error;
+
+pub struct WindowsBackend;
+
+unsafe impl Backend for WindowsBackend {
+    #[inline]
+    unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
+        let result = unsafe { ProcessPrng(dest, len) };
+        // Since Windows 10, calls to the user-mode RNG are guaranteed to never
+        // fail during runtime (rare windows W); `ProcessPrng` will only ever
+        // return 1 (which is how windows represents TRUE).
+        // See the bottom of page 6 of the aforementioned Windows RNG
+        // whitepaper for more information.
+        debug_assert!(result == TRUE);
+        Ok(())
+    }
+}
 
 // Binding to the Windows.Win32.Security.Cryptography.ProcessPrng API. As
 // bcryptprimitives.dll lacks an import library, we use "raw-dylib". This
@@ -47,15 +62,3 @@ extern "system" {
 #[allow(clippy::upper_case_acronyms)]
 type BOOL = core::ffi::c_int; // MSRV 1.64, similarly OK for this backend.
 const TRUE: BOOL = 1;
-
-#[inline]
-pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    let result = unsafe { ProcessPrng(dest.as_mut_ptr().cast::<u8>(), dest.len()) };
-    // Since Windows 10, calls to the user-mode RNG are guaranteed to never
-    // fail during runtime (rare windows W); `ProcessPrng` will only ever
-    // return 1 (which is how windows represents TRUE).
-    // See the bottom of page 6 of the aforementioned Windows RNG
-    // whitepaper for more information.
-    debug_assert!(result == TRUE);
-    Ok(())
-}

--- a/src/backends/windows7.rs
+++ b/src/backends/windows7.rs
@@ -19,7 +19,7 @@ pub struct WindowsLegacyBackend;
 unsafe impl Backend for WindowsLegacyBackend {
     #[inline]
     unsafe fn fill_ptr(dest: *mut u8, len: usize) -> Result<(), Error> {
-        let slice = core::slice::from_raw_parts_mut(dest as *mut MaybeUninit<u8>, len);
+        let slice = core::slice::from_raw_parts_mut(dest.cast(), len);
         Self::fill_uninit(slice)
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,7 +130,7 @@ impl Error {
     }
 
     /// Creates a new instance of an `Error` from a particular custom error code.
-    const fn as_custom(self) -> Option<u16> {
+    fn as_custom(self) -> Option<u16> {
         let mut value = self.0.get();
 
         if value < Self::CUSTOM_START {
@@ -139,11 +139,7 @@ impl Error {
 
         value -= Self::CUSTOM_START;
 
-        if value > u16::MAX as RawOsError {
-            return None;
-        }
-
-        Some(value as u16)
+        u16::try_from(value).ok()
     }
 
     /// Creates a new instance of an `Error` from a particular internal error code.

--- a/src/error.rs
+++ b/src/error.rs
@@ -131,12 +131,19 @@ impl Error {
 
     /// Creates a new instance of an `Error` from a particular custom error code.
     const fn as_custom(self) -> Option<u16> {
-        let value = self.0.get().checked_sub(Error::CUSTOM_START);
+        let mut value = self.0.get();
 
-        match value {
-            Some(value) if 0 <= value && value <= u16::MAX as RawOsError => Some(value as u16),
-            _ => None,
+        if value < Self::CUSTOM_START {
+            return None;
         }
+
+        value -= Self::CUSTOM_START;
+
+        if value > u16::MAX as RawOsError {
+            return None;
+        }
+
+        Some(value as u16)
     }
 
     /// Creates a new instance of an `Error` from a particular internal error code.

--- a/src/util.rs
+++ b/src/util.rs
@@ -5,6 +5,7 @@ use core::{mem::MaybeUninit, ptr};
 /// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
 /// been initialized.
 #[inline(always)]
+#[deny(unsafe_op_in_unsafe_fn)]
 pub(crate) unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
     let ptr = ptr_from_mut::<[MaybeUninit<T>]>(slice) as *mut [T];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
@@ -16,6 +17,7 @@ pub(crate) unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &
 /// This is unsafe because it allows assigning uninitialized values into
 /// `slice`, which would be undefined behavior.
 #[inline(always)]
+#[deny(unsafe_op_in_unsafe_fn)]
 pub(crate) unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
     let ptr = ptr_from_mut::<[T]>(slice) as *mut [MaybeUninit<T>];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,29 +1,13 @@
-#![allow(dead_code)]
-use crate::Error;
-use core::{mem::MaybeUninit, ptr, slice};
+use core::mem::MaybeUninit;
 
 /// Polyfill for `maybe_uninit_slice` feature's
 /// `MaybeUninit::slice_assume_init_mut`. Every element of `slice` must have
 /// been initialized.
 #[inline(always)]
-#[allow(unused_unsafe)] // TODO(MSRV 1.65): Remove this.
-pub unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
+pub(crate) unsafe fn slice_assume_init_mut<T>(slice: &mut [MaybeUninit<T>]) -> &mut [T] {
     let ptr = ptr_from_mut::<[MaybeUninit<T>]>(slice) as *mut [T];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
     unsafe { &mut *ptr }
-}
-
-#[inline]
-pub fn uninit_slice_fill_zero(slice: &mut [MaybeUninit<u8>]) -> &mut [u8] {
-    unsafe { ptr::write_bytes(slice.as_mut_ptr(), 0, slice.len()) };
-    unsafe { slice_assume_init_mut(slice) }
-}
-
-#[inline(always)]
-pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
-    let ptr = ptr_from_ref::<[T]>(slice) as *const [MaybeUninit<T>];
-    // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
-    unsafe { &*ptr }
 }
 
 /// View an mutable initialized array as potentially-uninitialized.
@@ -31,8 +15,7 @@ pub fn slice_as_uninit<T>(slice: &[T]) -> &[MaybeUninit<T>] {
 /// This is unsafe because it allows assigning uninitialized values into
 /// `slice`, which would be undefined behavior.
 #[inline(always)]
-#[allow(unused_unsafe)] // TODO(MSRV 1.65): Remove this.
-pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
+pub(crate) unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
     let ptr = ptr_from_mut::<[T]>(slice) as *mut [MaybeUninit<T>];
     // SAFETY: `MaybeUninit<T>` is guaranteed to be layout-compatible with `T`.
     unsafe { &mut *ptr }
@@ -41,44 +24,4 @@ pub unsafe fn slice_as_uninit_mut<T>(slice: &mut [T]) -> &mut [MaybeUninit<T>] {
 // TODO: MSRV(1.76.0): Replace with `core::ptr::from_mut`.
 fn ptr_from_mut<T: ?Sized>(r: &mut T) -> *mut T {
     r
-}
-
-// TODO: MSRV(1.76.0): Replace with `core::ptr::from_ref`.
-fn ptr_from_ref<T: ?Sized>(r: &T) -> *const T {
-    r
-}
-
-/// Default implementation of `inner_u32` on top of `fill_uninit`
-#[inline]
-pub fn inner_u32() -> Result<u32, Error> {
-    let mut res = MaybeUninit::<u32>::uninit();
-    // SAFETY: the created slice has the same size as `res`
-    let dst = unsafe {
-        let p: *mut MaybeUninit<u8> = res.as_mut_ptr().cast();
-        slice::from_raw_parts_mut(p, core::mem::size_of::<u32>())
-    };
-    crate::fill_uninit(dst)?;
-    // SAFETY: `dst` has been fully initialized by `imp::fill_inner`
-    // since it returned `Ok`.
-    Ok(unsafe { res.assume_init() })
-}
-
-/// Default implementation of `inner_u64` on top of `fill_uninit`
-#[inline]
-pub fn inner_u64() -> Result<u64, Error> {
-    let mut res = MaybeUninit::<u64>::uninit();
-    // SAFETY: the created slice has the same size as `res`
-    let dst = unsafe {
-        let p: *mut MaybeUninit<u8> = res.as_mut_ptr().cast();
-        slice::from_raw_parts_mut(p, core::mem::size_of::<u64>())
-    };
-    crate::fill_uninit(dst)?;
-    // SAFETY: `dst` has been fully initialized by `imp::fill_inner`
-    // since it returned `Ok`.
-    Ok(unsafe { res.assume_init() })
-}
-
-/// Truncates `u64` and returns the lower 32 bits as `u32`
-pub(crate) fn truncate(val: u64) -> u32 {
-    u32::try_from(val & u64::from(u32::MAX)).expect("The higher 32 bits are masked")
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code)]
 use core::{mem::MaybeUninit, ptr};
 
 /// Polyfill for `maybe_uninit_slice` feature's


### PR DESCRIPTION
# Background

`getrandom` is a foundational crate with a high level of importance across the entire Rust ecosystem. Unfortunately, the ergonomics around using this crate on fringe platforms within a library ecosystem is sub-par. Even more unfortunately, "fringe" includes Wasm in the browser, an otherwise excellent platform for Rust.

As an outsider to the project, I feel the same frustrations that have already been litigated in #658, but I also appreciate that this crate must walk a _very_ fine line between performance, ergonomics, and security.

I've had a bit of experience in the embedded Rust ecosystem, where problems like this are quite prevalent (since there's no `std` to rely on for common APIs). One exemplar from that space is [`critical-section`](https://crates.io/crates/critical-seciton), which has a similar problem to solve: platform dependent backend which can only be declared once (globally) and a universal frontend. To achieve this, they use an `Impl` trait to describe a backend implementation, and a macro `set_impl!` which exports the implementation using `extern "Rust"` functions.

This technique has the benefit of moving the "a backend must be declared exactly once" problem into the linker, which already has such a requirement.

## Objective

I'd like to demonstrate a prototype of `getrandom` which puts a larger design emphasis on external backends using the `critical-section` technique. Since a backend could only be declared exactly once, it is not possible for a rogue dependency to "sneak" an implementation in (similar to the current `custom` backend).

## Solution

- Defined a new `Backend` trait which contains all methods which would previously be internally defined (`e.g., `fill_inner`, `inner_u32`, etc.).
- Created an implementation of `Backend`, `ExternBackend`, which defers all its methods to `extern "Rust"` functions.
- Created a macro, `set_backend!`, which exports a type implementing `Backend` as `extern "Rust"` functions compatible with `ExternBackend`.
- Switched to using `ExternBackend` in the implementation of the public-facing API.
- Adjusted the current backends to instead implement `Backend` on a unit struct, and then call `set_backend!` on said struct.
- Altered the current `Error` type to allow descriptions to be declared in `Backend`, allowing external backends to provide rich error messages.
- Added a feature, `default-backends`, which enables the current default backends. This allows `getrandom` to act like a core library crate, and `getrandom = { features = ["default-backends"] }` to be the consumer-facing one. This could also be achieved by splitting `getrandom` into `getrandom_core` and `getrandom`, but that's a much more controversial change.
- If a default backend is not available, allow a linking error to prevent final compilation instead of throwing an explicit `compile_error!`. This allows another crate in the dependency graph to provide a `Backend` implementation _if and only if_ no other backend is declared. As previously stated, any attempts to "override" the backend will fail to link.

---

## Notes

I haven't removed any of the current requirements for `RUSTFLAGS` usage for things like `wasm_js`. The goal of this change is to instead allow a 3rd party crate to cleanly be included by the user (or a relevant library such as Bevy, HAL, etc.) and provide the backend implementation. Since this is offloaded to a 3rd party dependency, it is substantially harder for a misconfigured library to break Wasm (non-web) compilation by simply activating a feature. Instead, they must bring in a whole extra dependency. This is also a benefit for libraries, as they can simply add such an implementation to `dev-dependencies` for CI.

I'm opening this PR in _draft_ to highlight that I don't believe this is ready to just merge as-is; I want to start a discussion on practical changes that could be made to benefit ergonomics without sacrificing the other critical focus areas of the project.