### PR TITLE
Allow `custom` to act as a Fallback Backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,18 @@ categories = ["os", "no-std"]
 exclude = [".*"]
 
 [features]
+# `first-party-backends-only` is enabled by default for conservative backwards compatibility in 0.3
+# NOTE: Future versions may wish to remove this default depending on the security ramifications.
+default = ["first-party-backends-only"]
 # Implement std::error::Error for getrandom::Error and
 # use std to retrieve OS error descriptions
 std = []
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
+# Throw a compiler error when a first-party backend is not available
+# WARNING: It is highly recommended to enable this feature only for binary crates and tests,
+# i.e. avoid unconditionally enabling it in library crates.
+first-party-backends-only = []
 
 # Optional backend: wasm_js
 # This flag enables the backend but does not select it. To use the backend, use

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,18 +12,11 @@ categories = ["os", "no-std"]
 exclude = [".*"]
 
 [features]
-# `first-party-backends-only` is enabled by default for conservative backwards compatibility in 0.3
-# NOTE: Future versions may wish to remove this default depending on the security ramifications.
-default = ["first-party-backends-only"]
 # Implement std::error::Error for getrandom::Error and
 # use std to retrieve OS error descriptions
 std = []
 # Unstable feature to support being a libstd dependency
 rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
-# Throw a compiler error when a first-party backend is not available
-# WARNING: It is highly recommended to enable this feature only for binary crates and tests,
-# i.e. avoid unconditionally enabling it in library crates.
-first-party-backends-only = []
 
 # Optional backend: wasm_js
 # This flag enables the backend but does not select it. To use the backend, use
@@ -31,6 +24,13 @@ first-party-backends-only = []
 # WARNING: It is highly recommended to enable this feature only for binary crates and tests,
 # i.e. avoid unconditionally enabling it in library crates.
 wasm_js = ["dep:wasm-bindgen", "dep:js-sys"]
+
+# Optional backend: custom-fallback
+# This flag enables the use of a 3rd party backend when this crate does not have a suitable option.
+# This flag can be overridden using the getrandom_no_fallback RUSTFLAG.
+# WARNING: It is highly recommended to enable this feature only for binary crates and tests,
+# i.e. avoid unconditionally enabling it in library crates.
+custom-fallback = []
 
 [dependencies]
 cfg-if = "1"
@@ -97,6 +97,7 @@ check-cfg = [
   'cfg(getrandom_test_linux_without_fallback)',
   'cfg(getrandom_test_netbsd_fallback)',
   'cfg(target_os, values("cygwin"))', # TODO(MSRV 1.86): Remove this.
+  'cfg(getrandom_no_fallback)',
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
# Objective

As highlighted in #671, there is room for ergonomic improvements in how `getrandom` handles unsupported platforms. Since `getrandom` already has a backend which supports external integration, `custom`, it would be beneficial to end users to have a way to allow 3rd party dependencies to provide a `getrandom` backend _without_ modifying `RUSTFLAGS`.

## Solution

- Added a new feature, `first-party-backends-only`, which will throw a compiler error if a first party backend is not available for the current target (either due to misconfiguration or lack of support). This is sem-ver compatible with a patch release.
- Enabled `first-party-backends-only` by default to preserve the current behaviour, where an unsupported configuration will fail to compile. This is not required for sem-ver compatibility since it would at worst _allow_ compilation where it was already failing. This is done as a conservative guard against a hypothetical supply chain attack.
- Adjusted the `backends.rs` `cfg_if` statement to fall back to `custom` if no other option is available. Note that `custom` is still included as the first branch to preserve current behaviour.

## Intended Use

This fallback would allow HAL-style crates to include a dependency as a way to provide a fallback backend for `getrandom`. Since it relies on `extern` linking, defining multiple fallback backends will cause a compile-time error, as will failing to provide one. Consider the contentious `wasm_js` backend. In order to work around `getrandom`'s use of `RUSTFLAGS` to enable that backend, `uuid` [just vendored the backend](https://github.com/uuid-rs/uuid/blob/2fd9b614c92e4e4b18928e2f539d82accf8eaeee/src/rng.rs#L211-L310). This is highly undesirable as an outcome, since there is now an increased risk of `uuid` containing a bug or vulnerability that is fixed in `getrandom` but not in their copy.

With this fallback functionality, now `rust-random` or a 3rd party could publish the `wasm_js` backend for `getrandom` as a dedicated crate, allowing users or libraries to activate it as they require. This may be a desirable path forward for more experimental backends anyway, as it would allow iteration without changes to `getrandom` directly.

---

## Notes

- Crates will need to be updated to disable default features on `getrandom` to allow this approach to work, but I don't see many difficulties here since it would be in service of improved ergonomics for their consumers.
- I think there's room to improve the `custom` backend to allow overriding the `u32` and `u64` methods, and potentially providing error messages back to the user, but that's a larger breaking change that isn't required for the ergonomic benefits discussed here.