### PR TITLE
CI: Update Rust Nightly to a very recent version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-02-15
+          toolchain: nightly-2025-06-01
           components: rust-src
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
@@ -190,7 +190,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           targets: ${{ matrix.target.target }}
-          toolchain: nightly-2024-10-24
+          toolchain: nightly-2025-06-01
           components: rust-src
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-10-14
+          toolchain: nightly-2025-06-01
           components: rust-src
       - run: cargo build --release
       - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       # Win7 targets are Tier3, so pin a nightly where libstd builds.
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-05-20
+          toolchain: nightly-2025-06-01
           components: rust-src
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --target=x86_64-win7-windows-msvc -Z build-std --features=std
@@ -146,7 +146,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2024-10-08
+          toolchain: nightly-2025-06-01
           components: rust-src
       - env:
           RUSTFLAGS: -Dwarnings -Zsanitizer=memory

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
         # Fixed Nigthly version is used to prevent
         # CI failures which are not relevant to PR changes
         # on introduction of new Clippy lints.
-        toolchain: nightly-2024-10-08
+        toolchain: nightly-2025-06-01
         components: clippy,rust-src
     - name: std feature
       run: cargo clippy --features std
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           # We need Nightly for doc_auto_cfg
-          toolchain: nightly-2024-09-04
+          toolchain: nightly-2025-06-01
       - uses: Swatinem/rust-cache@v2
       - name: Generate Docs
         env:

--- a/src/error.rs
+++ b/src/error.rs
@@ -200,7 +200,7 @@ impl fmt::Display for Error {
                 if #[cfg(feature = "std")] {
                     std::io::Error::from_raw_os_error(errno).fmt(f)
                 } else {
-                    write!(f, "OS Error: {}", errno)
+                    write!(f, "OS Error: {errno}")
                 }
             }
         } else if let Some(desc) = self.internal_desc() {


### PR DESCRIPTION
Address a Nightly Clippy complaint and update to the nightly-2025-06-01 toolchain. This allows us to validate upcoming changes. This will help with filing issues against rust-lang/rust for recent Nightly releases that affect us.