### PR TITLE
Remove the unstable `rustc-dep-of-std` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `unsupported` opt-in backend [#667]
 
+### Removed
+- Unstable `rustc-dep-of-std` crate feature [#694]
+
 [#667]: https://github.com/rust-random/getrandom/pull/667
 [#688]: https://github.com/rust-random/getrandom/pull/688
+[#694]: https://github.com/rust-random/getrandom/pull/694
 
 ## [0.3.3] - 2025-05-09
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,21 +30,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "compiler_builtins"
-version = "0.1.160"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6376049cfa92c0aa8b9ac95fae22184b981c658208d4ed8a1dc553cd83612895"
-
-[[package]]
 name = "getrandom"
 version = "0.3.3"
 dependencies = [
  "cfg-if",
- "compiler_builtins",
  "js-sys",
  "libc",
  "r-efi",
- "rustc-std-workspace-core",
  "wasi",
  "wasm-bindgen",
  "wasm-bindgen-test",
@@ -111,12 +103,6 @@ name = "r-efi"
 version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
-
-[[package]]
-name = "rustc-std-workspace-core"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "same-file"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,6 @@ exclude = [".*"]
 # Implement std::error::Error for getrandom::Error and
 # use std to retrieve OS error descriptions
 std = []
-# Unstable feature to support being a libstd dependency
-rustc-dep-of-std = ["dep:compiler_builtins", "dep:core"]
 
 # Optional backend: wasm_js
 # This flag enables the backend but does not select it. To use the backend, use
@@ -27,10 +25,6 @@ wasm_js = ["dep:wasm-bindgen", "dep:js-sys"]
 
 [dependencies]
 cfg-if = "1"
-
-# When built as part of libstd
-compiler_builtins = { version = "0.1", optional = true }
-core = { version = "1.0", optional = true, package = "rustc-std-workspace-core" }
 
 # getrandom / linux_android_with_fallback
 [target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom", getrandom_backend = "linux_raw", getrandom_backend = "rdrand", getrandom_backend = "rndr"))))'.dependencies]


### PR DESCRIPTION
The feature was initially added for potential use of `getrandom` in `std`. Unfortunately,  the proposal did not get traction, so the feature is effectively useless. Before reviving this feature we should resolve #365 at the very least and even with that it's unlikely that `getrandom` will be used by `std` considering the proposals to properly expose entropy sources in `std`.

Closes #693