### PR TITLE
ci: update `cargo dinghy` to v0.8.1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -86,7 +86,7 @@ jobs:
           targets: aarch64-apple-ios-sim
       - name: Install precompiled cargo-dinghy
         run: |
-          VERSION=0.8.0
+          VERSION=0.8.1
           URL="https://github.com/sonos/dinghy/releases/download/${VERSION}/cargo-dinghy-macos-${VERSION}.tgz"
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
       - name: Check cargo-dinghy version.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -82,7 +82,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: stable
+          toolchain: 1.88.0
           targets: aarch64-apple-ios-sim
       - name: Install precompiled cargo-dinghy
         run: |


### PR DESCRIPTION
Temporarily downgrades Rust toolchain in the Dinghy job to 1.88 to work around https://github.com/sonos/dinghy/issues/255