### PR TITLE
Add optee backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ fn get_random_u128() -> Result<u128, getrandom::Error> {
 | WASI 0.1           | `wasm32‑wasip1`    | [`random_get`]
 | WASI 0.2           | `wasm32‑wasip2`    | [`get-random-u64`]
 | SOLID              | `*-kmc-solid_*`    | `SOLID_RNG_SampleRandomBytes`
+| OP-TEE             | `*-optee`          | [`TEE_GenerateRandom`] from OP-TEE UTEE API
 | Nintendo 3DS       | `*-nintendo-3ds`   | [`getrandom`][18]
 | ESP-IDF            | `*‑espidf`         | [`esp_fill_random`] WARNING: see "Early Boot" section below
 | PS Vita            | `*-vita-*`         | [`getentropy`][19]
@@ -372,6 +373,7 @@ dual licensed as above, without any additional terms or conditions.
 [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 [`module`]: https://rustwasm.github.io/wasm-bindgen/reference/attributes/on-js-imports/module.html
 [`sys_read_entropy`]: https://github.com/hermit-os/kernel/blob/315f58ff5efc81d9bf0618af85a59963ff55f8b1/src/syscalls/entropy.rs#L47-L55
+[`TEE_GenerateRandom`]: https://github.com/OP-TEE/optee_os/blob/master/lib/libutee/include/tee_internal_api.h
 [platform-support]: https://doc.rust-lang.org/stable/rustc/platform-support.html
 [WASI]: https://github.com/WebAssembly/WASI
 [Emscripten]: https://emscripten.org

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -173,6 +173,9 @@ cfg_if! {
     } else if #[cfg(target_os = "solid_asp3")] {
         mod solid;
         pub use solid::*;
+    } else if #[cfg(target_os = "optee")] {
+        mod optee;
+        pub use optee::*;
     } else if #[cfg(all(windows, any(target_vendor = "win7", getrandom_windows_legacy)))] {
         mod windows7;
         pub use windows7::*;

--- a/src/backends/optee.rs
+++ b/src/backends/optee.rs
@@ -1,0 +1,14 @@
+use crate::Error;
+use core::mem::MaybeUninit;
+
+pub use crate::util::{inner_u32, inner_u64};
+
+#[link(name = "utee")]
+extern "C" {
+    fn TEE_GenerateRandom(randomBuffer: *mut core::ffi::c_void, randomBufferLen: usize);
+}
+
+pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
+    unsafe { TEE_GenerateRandom(dest.as_mut_ptr() as *mut core::ffi::c_void, dest.len()) }
+    Ok(())
+}


### PR DESCRIPTION
This adds support for the {arm,aarch64}-unknown-optee targets, enabling `getrandom` to work in OP-TEE environments.

For more information about OP-TEE, see:
https://optee.readthedocs.io/en/latest/