### PR TITLE
Replace `wasi` crate with `wasip2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "cc"
-version = "1.2.36"
+version = "1.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5252b3d2648e5eedbc1a6f501e3c795e07025c1e93bbf8bbdd6eef7f447a6d54"
+checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -38,7 +38,7 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi",
+ "wasip2",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]
@@ -133,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "walkdir"
@@ -148,10 +148,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasi"
-version = "0.14.4+wasi-0.2.4"
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a5f4a424faf49c3c2c344f166f0662341d470ea185e939657aaff130f0ec4a"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
@@ -287,6 +287,6 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.45.1"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,9 +62,9 @@ libc = { version = "0.2.154", default-features = false }
 [target.'cfg(target_os = "vxworks")'.dependencies]
 libc = { version = "0.2.154", default-features = false }
 
-# wasi (0.2 only)
+# wasi_p2
 [target.'cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))'.dependencies]
-wasi = { version = "0.14", default-features = false }
+wasip2 = { version = "1", default-features = false }
 
 # wasm_js
 [target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -1,6 +1,6 @@
 //! Implementation for WASI Preview 2.
 use crate::Error;
-use core::mem::MaybeUninit;
+use core::{mem::MaybeUninit, ptr::copy_nonoverlapping};
 use wasip2::random::random::get_random_u64;
 
 #[inline]
@@ -16,8 +16,6 @@ pub fn inner_u64() -> Result<u64, Error> {
 
 #[inline]
 pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
-    use core::ptr::copy_nonoverlapping;
-
     let (prefix, chunks, suffix) = unsafe { dest.align_to_mut::<MaybeUninit<u64>>() };
 
     // We use `get_random_u64` instead of `get_random_bytes` because the latter creates

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -17,7 +17,6 @@ pub fn inner_u64() -> Result<u64, Error> {
 #[inline]
 pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
     use core::ptr::copy_nonoverlapping;
-    use wasi::random::random::get_random_u64;
 
     let (prefix, chunks, suffix) = unsafe { dest.align_to_mut::<MaybeUninit<u64>>() };
 

--- a/src/backends/wasi_p2.rs
+++ b/src/backends/wasi_p2.rs
@@ -1,7 +1,7 @@
 //! Implementation for WASI Preview 2.
 use crate::Error;
 use core::mem::MaybeUninit;
-use wasi::random::random::get_random_u64;
+use wasip2::random::random::get_random_u64;
 
 #[inline]
 pub fn inner_u32() -> Result<u32, Error> {


### PR DESCRIPTION
The recent releases of `wasi` simply re-export contents of `wasip2`.