### PR TITLE
Update all nightly toolchains to latest nightly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -156,7 +156,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
           components: rust-src
       - env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="linux_raw"
@@ -190,7 +190,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           targets: ${{ matrix.target.target }}
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
           components: rust-src
       - uses: Swatinem/rust-cache@v2
       - name: Build

--- a/.github/workflows/nopanic.yaml
+++ b/.github/workflows/nopanic.yaml
@@ -140,7 +140,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
           components: rust-src
       - run: cargo build --release
       - run: cargo build --release --target=x86_64-win7-windows-msvc -Zbuild-std="std,panic_abort"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,42 +157,37 @@ jobs:
         with:
           toolchain: nightly-2025-09-28
           components: rust-src
+      # Use --all-targets to skip doctests, which don't work with the -Zsanitizer=memory flag.
+      # See: https://github.com/rust-lang/rust/issues/134172
       - name: default configuration
         env:
           RUSTFLAGS: -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - name: --cfg getrandom_backend="linux_getrandom"
         env:
           RUSTFLAGS: --cfg getrandom_backend="linux_getrandom" -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_backend="linux_getrandom" -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - name: --cfg getrandom_backend="linux_raw"
         env:
           RUSTFLAGS: --cfg getrandom_backend="linux_raw" -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_backend="linux_raw" -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - name: --cfg getrandom_backend="linux_fallback"
         env:
           RUSTFLAGS: --cfg getrandom_backend="linux_fallback" -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_backend="linux_fallback" -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - if: ${{ matrix.arch == 'x86_64' }}
         name: --cfg getrandom_backend="rdrand"
         env:
           RUSTFLAGS: --cfg getrandom_backend="rdrand" -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_backend="rdrand" -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - name: --cfg getrandom_test_linux_fallback
         env:
           RUSTFLAGS: --cfg getrandom_test_linux_fallback -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_test_linux_fallback -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
       - name: --cfg getrandom_test_linux_without_fallback
         env:
           RUSTFLAGS: --cfg getrandom_test_linux_without_fallback -Dwarnings -Zsanitizer=memory
-          RUSTDOCFLAGS: --cfg getrandom_test_linux_without_fallback -Dwarnings -Zsanitizer=memory
-        run: cargo test -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
+        run: cargo test --all-targets -Zbuild-std --target=${{ matrix.arch }}-unknown-linux-gnu
 
   cross:
     name: Cross

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -133,7 +133,7 @@ jobs:
       # Win7 targets are Tier3, so pin a nightly where libstd builds.
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
           components: rust-src
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --target=x86_64-win7-windows-msvc -Z build-std --features=std
@@ -155,7 +155,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
           components: rust-src
       - name: default configuration
         env:

--- a/.github/workflows/workspace.yml
+++ b/.github/workflows/workspace.yml
@@ -23,7 +23,7 @@ jobs:
         # Fixed Nigthly version is used to prevent
         # CI failures which are not relevant to PR changes
         # on introduction of new Clippy lints.
-        toolchain: nightly-2025-09-15
+        toolchain: nightly-2025-09-28
         components: clippy,rust-src
     - name: std feature
       run: cargo clippy --features std
@@ -110,7 +110,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           # We need Nightly for doc_auto_cfg
-          toolchain: nightly-2025-06-01
+          toolchain: nightly-2025-09-28
       - uses: Swatinem/rust-cache@v2
       - name: Generate Docs
         env:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 #![doc = include_str!("../README.md")]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(getrandom_backend = "efi_rng", feature(uefi_std))]
 #![deny(
     clippy::cast_lossless,


### PR DESCRIPTION
Update all the nightly toolchains to `nightly-2025-09-28`. I also included the following fixes:
  - Don't use the `doc_auto_cfg` feature
    - It was removed in a recent nightly, see https://github.com/rust-lang/rust/pull/138907
    - If we just use `doc_cfg`, everything gets generated correctly:
      <details>
      <summary>Example only using cfg(doc_cfg)</summary>
      <img width="626" height="576" alt="Screenshot 2025-09-29 at 3 40 25 PM" src="https://github.com/user-attachments/assets/4ff0d380-dda4-4d7b-8173-128c45001f47" />
      </details>
  - Stop running doctests with `-Zsanitizer=memory`
    - Passing the correct flags to doctests is tricky with `-Zbuild-std` and the doc tests don't really gain us much.
    - See: https://github.com/rust-lang/rust/issues/134172#issuecomment-3349433658
    - I use `--all-targets` to skip the doctests but include everything else.
