### PR TITLE
Implement core::error::Error without std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["os", "no-std"]
 exclude = [".*"]
 
 [features]
-# Implement std::error::Error for getrandom::Error and
+# Implement From<getrandom::Error> for std::io::Error and
 # use std to retrieve OS error descriptions
 std = []
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -185,6 +185,8 @@ impl Error {
     }
 }
 
+impl core::error::Error for Error {}
+
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut dbg = f.debug_struct("Error");

--- a/src/error_std_impls.rs
+++ b/src/error_std_impls.rs
@@ -11,5 +11,3 @@ impl From<Error> for io::Error {
         }
     }
 }
-
-impl std::error::Error for Error {}


### PR DESCRIPTION
There are several other places that `std` is used.