### PR TITLE
Avoid conditional module inclusion

### DIFF
--- a/src/backends/getentropy.rs
+++ b/src/backends/getentropy.rs
@@ -7,13 +7,10 @@
 //!   - vita newlib since Dec 2021
 //!
 //! For these targets, we use getentropy(2) because getrandom(2) doesn't exist.
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{ffi::c_void, mem::MaybeUninit};
 
 pub use crate::util::{inner_u32, inner_u64};
-
-#[path = "../util_libc.rs"]
-mod util_libc;
 
 #[inline]
 pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {

--- a/src/backends/getrandom.rs
+++ b/src/backends/getrandom.rs
@@ -15,13 +15,10 @@
 //! GRND_RANDOM is not recommended. On NetBSD/FreeBSD/Dragonfly/3ds, it does
 //! nothing. On illumos, the default pool is used to implement getentropy(2),
 //! so we assume it is acceptable here.
-use crate::Error;
+use crate::{Error, util_libc};
 use core::mem::MaybeUninit;
 
 pub use crate::util::{inner_u32, inner_u64};
-
-#[path = "../util_libc.rs"]
-mod util_libc;
 
 #[inline]
 pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {

--- a/src/backends/linux_android_with_fallback.rs
+++ b/src/backends/linux_android_with_fallback.rs
@@ -1,13 +1,12 @@
 //! Implementation for Linux / Android with `/dev/urandom` fallback
 use super::{sanitizer, use_file};
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{
     ffi::c_void,
     mem::{MaybeUninit, transmute},
     ptr::NonNull,
     sync::atomic::{AtomicPtr, Ordering},
 };
-use use_file::util_libc;
 
 pub use crate::util::{inner_u32, inner_u64};
 

--- a/src/backends/netbsd.rs
+++ b/src/backends/netbsd.rs
@@ -3,7 +3,7 @@
 //! `getrandom(2)` was introduced in NetBSD 10. To support older versions we
 //! implement our own weak linkage to it, and provide a fallback based on the
 //! KERN_ARND sysctl.
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{
     cmp,
     ffi::c_void,
@@ -13,9 +13,6 @@ use core::{
 };
 
 pub use crate::util::{inner_u32, inner_u64};
-
-#[path = "../util_libc.rs"]
-mod util_libc;
 
 unsafe extern "C" fn polyfill_using_kern_arand(
     buf: *mut c_void,

--- a/src/backends/rdrand.rs
+++ b/src/backends/rdrand.rs
@@ -1,12 +1,6 @@
 //! RDRAND backend for x86(-64) targets
-use crate::{Error, util::slice_as_uninit};
+use crate::{Error, lazy, util::slice_as_uninit};
 use core::mem::{MaybeUninit, size_of};
-
-#[path = "../lazy.rs"]
-mod lazy;
-
-#[cfg(not(any(target_arch = "x86_64", target_arch = "x86")))]
-compile_error!("`rdrand` backend can be enabled only for x86 and x86-64 targets!");
 
 cfg_if! {
     if #[cfg(target_arch = "x86_64")] {
@@ -17,6 +11,8 @@ cfg_if! {
         use core::arch::x86 as arch;
         use arch::_rdrand32_step as rdrand_step;
         type Word = u32;
+    } else {
+        compile_error!("`rdrand` backend can be enabled only for x86 and x86-64 targets!");
     }
 }
 

--- a/src/backends/rndr.rs
+++ b/src/backends/rndr.rs
@@ -69,8 +69,7 @@ fn is_rndr_available() -> bool {
 
 #[cfg(not(target_feature = "rand"))]
 fn is_rndr_available() -> bool {
-    #[path = "../lazy.rs"]
-    mod lazy;
+    use crate::lazy;
     static RNDR_GOOD: lazy::LazyBool = lazy::LazyBool::new();
 
     cfg_if::cfg_if! {

--- a/src/backends/solaris.rs
+++ b/src/backends/solaris.rs
@@ -12,13 +12,10 @@
 //! For more information, see the man page linked in lib.rs and this blog post:
 //! https://blogs.oracle.com/solaris/post/solaris-new-system-calls-getentropy2-and-getrandom2
 //! which also explains why this crate should not use getentropy(2).
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{ffi::c_void, mem::MaybeUninit};
 
 pub use crate::util::{inner_u32, inner_u64};
-
-#[path = "../util_libc.rs"]
-mod util_libc;
 
 const MAX_BYTES: usize = 1024;
 

--- a/src/backends/use_file.rs
+++ b/src/backends/use_file.rs
@@ -1,5 +1,5 @@
 //! Implementations that just need to read from a file
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{
     ffi::{CStr, c_void},
     mem::MaybeUninit,
@@ -8,9 +8,6 @@ use core::{
 
 #[cfg(not(any(target_os = "android", target_os = "linux")))]
 pub use crate::util::{inner_u32, inner_u64};
-
-#[path = "../util_libc.rs"]
-pub(super) mod util_libc;
 
 /// For all platforms, we use `/dev/urandom` rather than `/dev/random`.
 /// For more information see the linked man pages in lib.rs.

--- a/src/backends/vxworks.rs
+++ b/src/backends/vxworks.rs
@@ -1,13 +1,10 @@
 //! Implementation for VxWorks
-use crate::Error;
+use crate::{Error, util_libc};
 use core::{
     cmp::Ordering::{Equal, Greater, Less},
     mem::MaybeUninit,
     sync::atomic::{AtomicBool, Ordering::Relaxed},
 };
-
-#[path = "../util_libc.rs"]
-mod util_libc;
 
 pub use crate::util::{inner_u32, inner_u64};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -59,7 +59,6 @@ impl Error {
 
     /// Creates a new instance of an `Error` from a negative error code.
     #[cfg(not(target_os = "uefi"))]
-    #[allow(dead_code)]
     pub(super) fn from_neg_error_code(code: RawOsError) -> Self {
         if code < 0 {
             let code = NonZeroRawOsError::new(code).expect("`code` is negative");
@@ -71,7 +70,6 @@ impl Error {
 
     /// Creates a new instance of an `Error` from an UEFI error code.
     #[cfg(target_os = "uefi")]
-    #[allow(dead_code)]
     pub(super) fn from_uefi_code(code: RawOsError) -> Self {
         if code & UEFI_ERROR_FLAG != 0 {
             let code = NonZeroRawOsError::new(code).expect("The highest bit of `code` is set to 1");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,8 +33,13 @@ extern crate cfg_if;
 use core::mem::MaybeUninit;
 
 mod backends;
+#[allow(dead_code, reason = "not used in all backends")]
 mod error;
+#[allow(dead_code, reason = "not used in all backends")]
+mod lazy;
+#[allow(dead_code, reason = "not used in all backends")]
 mod util;
+mod util_libc;
 
 #[cfg(feature = "std")]
 mod error_std_impls;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use crate::Error;
 use core::{mem::MaybeUninit, ptr, slice};
 

--- a/src/util_libc.rs
+++ b/src/util_libc.rs
@@ -1,81 +1,93 @@
-use crate::Error;
-use core::mem::MaybeUninit;
+#[allow(unused_macros, reason = "not always used")]
+macro_rules! emit_impl {
+    ($get_errno:expr) => {
+        use crate::Error;
+        use core::mem::MaybeUninit;
 
-cfg_if! {
-    if #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android", target_os = "cygwin"))] {
-        use libc::__errno as errno_location;
-    } else if #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "hurd", target_os = "redox", target_os = "dragonfly"))] {
-        use libc::__errno_location as errno_location;
-    } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
-        use libc::___errno as errno_location;
-    } else if #[cfg(any(target_os = "macos", target_os = "freebsd"))] {
-        use libc::__error as errno_location;
-    } else if #[cfg(target_os = "haiku")] {
-        use libc::_errnop as errno_location;
-    } else if #[cfg(target_os = "nto")] {
-        use libc::__get_errno_ptr as errno_location;
-    } else if #[cfg(any(all(target_os = "horizon", target_arch = "arm"), target_os = "vita"))] {
-        unsafe extern "C" {
-            // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
-            fn __errno() -> *mut libc::c_int;
+        pub(crate) fn last_os_error() -> Error {
+            // We assume that on all targets which use the `util_libc` module `c_int` is equal to `i32`
+            let errno: i32 = unsafe { $get_errno };
+
+            if errno > 0 {
+                let code = errno
+                    .checked_neg()
+                    .expect("Positive number can be always negated");
+                Error::from_neg_error_code(code)
+            } else {
+                Error::ERRNO_NOT_POSITIVE
+            }
         }
-        use __errno as errno_location;
-    } else if #[cfg(target_os = "aix")] {
-        use libc::_Errno as errno_location;
-    }
+
+        /// Fill a buffer by repeatedly invoking `sys_fill`.
+        ///
+        /// The `sys_fill` function:
+        ///   - should return -1 and set errno on failure
+        ///   - should return the number of bytes written on success
+        #[allow(dead_code, reason = "not used in all backends")]
+        pub(crate) fn sys_fill_exact(
+            mut buf: &mut [MaybeUninit<u8>],
+            sys_fill: impl Fn(&mut [MaybeUninit<u8>]) -> libc::ssize_t,
+        ) -> Result<(), Error> {
+            while !buf.is_empty() {
+                let res = sys_fill(buf);
+                match res {
+                    res if res > 0 => {
+                        let len = usize::try_from(res).map_err(|_| Error::UNEXPECTED)?;
+                        buf = buf.get_mut(len..).ok_or(Error::UNEXPECTED)?;
+                    }
+                    -1 => {
+                        let err = last_os_error();
+                        // We should try again if the call was interrupted.
+                        if err.raw_os_error() != Some(libc::EINTR) {
+                            return Err(err);
+                        }
+                    }
+                    // Negative return codes not equal to -1 should be impossible.
+                    // EOF (ret = 0) should be impossible, as the data we are reading
+                    // should be an infinite stream of random bytes.
+                    _ => return Err(Error::UNEXPECTED),
+                }
+            }
+            Ok(())
+        }
+    };
+}
+
+#[allow(unused_macros, reason = "not always used")]
+macro_rules! emit_impl_from_ptr {
+    ($fn:path) => {
+        emit_impl!(*$fn());
+    };
 }
 
 cfg_if! {
     if #[cfg(target_os = "vxworks")] {
-        use libc::errnoGet as get_errno;
+        emit_impl!(libc::errnoGet());
     } else {
-        unsafe fn get_errno() -> libc::c_int { unsafe { *errno_location() }}
-    }
-}
-
-pub(crate) fn last_os_error() -> Error {
-    // We assume that on all targets which use the `util_libc` module `c_int` is equal to `i32`
-    let errno: i32 = unsafe { get_errno() };
-
-    if errno > 0 {
-        let code = errno
-            .checked_neg()
-            .expect("Positive number can be always negated");
-        Error::from_neg_error_code(code)
-    } else {
-        Error::ERRNO_NOT_POSITIVE
-    }
-}
-
-/// Fill a buffer by repeatedly invoking `sys_fill`.
-///
-/// The `sys_fill` function:
-///   - should return -1 and set errno on failure
-///   - should return the number of bytes written on success
-#[allow(dead_code)]
-pub(crate) fn sys_fill_exact(
-    mut buf: &mut [MaybeUninit<u8>],
-    sys_fill: impl Fn(&mut [MaybeUninit<u8>]) -> libc::ssize_t,
-) -> Result<(), Error> {
-    while !buf.is_empty() {
-        let res = sys_fill(buf);
-        match res {
-            res if res > 0 => {
-                let len = usize::try_from(res).map_err(|_| Error::UNEXPECTED)?;
-                buf = buf.get_mut(len..).ok_or(Error::UNEXPECTED)?;
-            }
-            -1 => {
-                let err = last_os_error();
-                // We should try again if the call was interrupted.
-                if err.raw_os_error() != Some(libc::EINTR) {
-                    return Err(err);
+        cfg_if! {
+            if #[cfg(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom", getrandom_backend = "linux_raw", getrandom_backend = "rdrand", getrandom_backend = "rndr"))] {
+                // No libc.
+            } else if #[cfg(any(target_os = "netbsd", target_os = "openbsd", target_os = "android", target_os = "cygwin"))] {
+                emit_impl_from_ptr!(libc::__errno);
+            } else if #[cfg(any(target_os = "linux", target_os = "emscripten", target_os = "hurd", target_os = "redox", target_os = "dragonfly"))] {
+                emit_impl_from_ptr!(libc::__errno_location);
+            } else if #[cfg(any(target_os = "solaris", target_os = "illumos"))] {
+                emit_impl_from_ptr!(libc::___errno);
+            } else if #[cfg(any(target_os = "macos", target_os = "freebsd"))] {
+                emit_impl_from_ptr!(libc::__error);
+            } else if #[cfg(target_os = "haiku")] {
+                emit_impl_from_ptr!(libc::_errnop);
+            } else if #[cfg(target_os = "nto")] {
+                emit_impl_from_ptr!(libc::__get_errno_ptr);
+            } else if #[cfg(any(all(target_os = "horizon", target_arch = "arm"), target_os = "vita"))] {
+                unsafe extern "C" {
+                    // Not provided by libc: https://github.com/rust-lang/libc/issues/1995
+                    fn __errno() -> *mut libc::c_int;
                 }
+                emit_impl_from_ptr!(__errno);
+            } else if #[cfg(target_os = "aix")] {
+                emit_impl_from_ptr!(libc::_Errno);
             }
-            // Negative return codes not equal to -1 should be impossible.
-            // EOF (ret = 0) should be impossible, as the data we are reading
-            // should be an infinite stream of random bytes.
-            _ => return Err(Error::UNEXPECTED),
         }
     }
-    Ok(())
 }


### PR DESCRIPTION
This requires slightly more logic in util_libc, but produces a more
typical setup for the crate.

Extracted from #759.