### PR TITLE
Backport #c904801

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@
 )]
 #![no_std]
 #![warn(rust_2018_idioms, unused_lifetimes, missing_docs)]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 #[macro_use]
 extern crate cfg_if;


### PR DESCRIPTION
Backport https://github.com/rust-random/getrandom/commit/c904801e8bdac1f2b1903f80edeb07a0d4a81b20 to make it possible to publish crates depending on the latest stable version of 0.2 branch