### PR TITLE
Prepare v0.4.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.0-rc.0"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.3.4"
+version = "0.4.0-rc.0"
 edition = "2024"
 rust-version = "1.85" # Sync tests.yml and README.md.
 authors = ["The Rand Project Developers"]
@@ -31,7 +31,7 @@ sys_rng = ["dep:rand_core"]
 
 [dependencies]
 cfg-if = "1"
-rand_core = { version = "0.10.0-rc-2", optional = true }
+rand_core = { version = "0.10.0-rc-3", optional = true }
 
 # getrandom / linux_android_with_fallback
 [target.'cfg(all(any(target_os = "linux", target_os = "android"), not(any(all(target_os = "linux", target_env = ""), getrandom_backend = "custom", getrandom_backend = "linux_raw", getrandom_backend = "rdrand", getrandom_backend = "rndr"))))'.dependencies]


### PR DESCRIPTION
We would like a pre-release for testing purposes. (Due to the `rand_core` pre-release dependency we cannot yet release v0.4, though I believe otherwise the repo is ready for v0.4.)