### PR TITLE
rdrand: `allow(unused_unsafe)` when calling `__cpuid`

### DIFF
--- a/src/backends/rdrand.rs
+++ b/src/backends/rdrand.rs
@@ -77,6 +77,8 @@ fn is_rdrand_good() -> bool {
     {
         // SAFETY: All Rust x86 targets are new enough to have CPUID, and we
         // check that leaf 1 is supported before using it.
+        //
+        // TODO(MSRV 1.94): remove allow(unused_unsafe) and the unsafe blocks for `__cpuid`.
         #[allow(unused_unsafe)]
         let cpuid0 = unsafe { arch::__cpuid(0) };
         if cpuid0.eax < 1 {


### PR DESCRIPTION
This is currently a release blocker: #769

NOTE: this must've been a very recent change, as it's still marked `unsafe` on `beta`: https://doc.rust-lang.org/beta/core/arch/x86_64/fn.__cpuid.html

However, it's safe on `nightly`: https://doc.rust-lang.org/nightly/core/arch/x86_64/fn.__cpuid.html

~~I can add a comment similar to the one earlier in the file where there's another `allow(unused_unsafe)` if that helps:~~

```rust
// TODO(MSRV 1.94): remove allow(unused_unsafe) and the unsafe block.
```

Edit: added TODO in [558282a](https://github.com/rust-random/getrandom/pull/770/commits/558282a2db2425f0eaeb541a39dab8ad4cc754bc)