### PR TITLE
Add rdrand backend for Motor OS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `RawOsError` type alias [#739]
 - `SysRng` behind new feature `sys_rng` [#751]
 - WASIp3 support [#779]
+- Motor OS support [#797]
 
 ### Changed
 - Use Edition 2024 and MSRV 1.85 [#749]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ check-cfg = [
   'cfg(getrandom_test_linux_without_fallback)',
   'cfg(getrandom_test_netbsd_fallback)',
   'cfg(target_os, values("cygwin"))', # TODO(MSRV 1.86): Remove this.
+  'cfg(target_os, values("motor"))',
 ]
 
 [lints.rust]

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ fn get_random_u128() -> Result<u128, getrandom::Error> {
 | QNX Neutrino       | `*‑nto-qnx*`       | [`/dev/urandom`][14] (identical to `/dev/random`)
 | AIX                | `*-ibm-aix`        | [`/dev/urandom`][15]
 | Cygwin             | `*-cygwin`         | [`getrandom`][20] (based on [`RtlGenRandom`])
+| Motor OS           | `x86_64-unknown-motor` | [`RDRAND`]
 
 Pull Requests that add support for new targets to `getrandom` are always welcome.
 

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -149,6 +149,9 @@ cfg_if! {
     } else if #[cfg(target_os = "hermit")] {
         mod hermit;
         pub use hermit::*;
+    } else if #[cfg(all(target_arch = "x86_64", target_os = "motor"))] {
+        mod rdrand;
+        pub use rdrand::*;
     } else if #[cfg(target_os = "vxworks")] {
         mod vxworks;
         pub use vxworks::*;


### PR DESCRIPTION
Motor OS is a newish Tier 3 Rust target: https://doc.rust-lang.org/beta/rustc/platform-support/motor.html
