### PR TITLE
ci: fix tests.yml

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,10 +90,12 @@ jobs:
         with:
           toolchain: nightly
       - uses: Swatinem/rust-cache@v2
-      - env:
+      - name: Test getrandom_backend="custom"
+        env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="custom"
         run: cargo test
-      - env:
+      - name: Test getrandom_backend="extern_impl"
+        env:
           RUSTFLAGS: -Dwarnings --cfg getrandom_backend="extern_impl"
         run: cargo test
 


### PR DESCRIPTION
In #794 I used `working_directory` instead of `working-directory`. Unfortunately, it resulted in a silent failure since `tests.yml` was ignored as an invalid config. I only discovered it because of the red CI badge.

It may be worth to add a job to the workspace config which checks that all CI configs are valid, but it's better to do in a separate PR.