### PR TITLE
Avoid accessing `errno` on unexpected return values.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump `r-efi` dependency to v6 [#814]
 
 ### Fixed
+- Read `errno` only when it is set [#810]
 - Check the return value of `ProcessPrng` on Windows [#811]
 
 [Unreleased]: https://github.com/rust-random/getrandom/compare/v0.4.1...master
+[#810]: https://github.com/rust-random/getrandom/pull/810
 [#811]: https://github.com/rust-random/getrandom/pull/811
 [#814]: https://github.com/rust-random/getrandom/pull/814
 

--- a/src/backends/vxworks.rs
+++ b/src/backends/vxworks.rs
@@ -38,9 +38,13 @@ pub fn fill_inner(dest: &mut [MaybeUninit<u8>]) -> Result<(), Error> {
             .expect("chunk size is bounded by i32::MAX");
         let p: *mut libc::c_uchar = chunk.as_mut_ptr().cast();
         let ret = unsafe { libc::randABytes(p, chunk_len) };
-        if ret != 0 {
-            let errno = unsafe { libc::errnoGet() };
-            return Err(Error::from_errno(errno));
+        match ret {
+            0 => continue,
+            -1 => {
+                let errno = unsafe { libc::errnoGet() };
+                return Err(Error::from_errno(errno));
+            }
+            _ => return Err(Error::UNEXPECTED),
         }
     }
     Ok(())


### PR DESCRIPTION
We expect that these system calls will never return anything other than 0 or -1 but if they do for some reason, then we shouldn't access `errno`.