### PR TITLE
Add `wasm64-unknown-unknown` support for `wasm_js` backend

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,8 @@
 # Allow normal use of "cargo run" and "cargo test" on these wasm32 platforms.
 [target.wasm32-unknown-unknown]
 runner = 'wasm-bindgen-test-runner'
+[target.wasm64-unknown-unknown]
+runner = 'wasm-bindgen-test-runner'
 [target.wasm32-wasip1]
 runner = 'wasmtime'
 [target.wasm32-wasip2]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -308,14 +308,16 @@ jobs:
               flags: '-Dwarnings -Ctarget-feature=+atomics,+bulk-memory',
               args: '--features=std,sys_rng,wasm_js -Zbuild-std=panic_abort,std',
             }
-          - {
-              description: wasm64,
-              version: nightly,
-              target: wasm64-unknown-unknown,
-              components: rust-src,
-              flags: '-Dwarnings',
-              args: '--features=std,sys_rng,wasm_js -Zbuild-std=panic_abort,std',
-            }
+          # wasm64 support in wasm-pack is currently broken:
+          # https://github.com/wasm-bindgen/wasm-pack/issues/1576
+          # - {
+          #     description: wasm64,
+          #     version: nightly,
+          #     target: wasm64-unknown-unknown,
+          #     components: rust-src,
+          #     flags: '-Dwarnings',
+          #     args: '--features=std,sys_rng,wasm_js -Zbuild-std=panic_abort,std',
+          #   }
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -294,16 +294,26 @@ jobs:
       matrix:
         rust:
           - {
-              description: Web,
+              description: wasm32,
               version: stable,
+              target: wasm32-unknown-unknown,
               flags: '-Dwarnings',
               args: '--features=std,sys_rng,wasm_js',
             }
           - {
-              description: Web with Atomics,
+              description: wasm32 with Atomics,
               version: nightly,
+              target: wasm32-unknown-unknown,
               components: rust-src,
               flags: '-Dwarnings -Ctarget-feature=+atomics,+bulk-memory',
+              args: '--features=std,sys_rng,wasm_js -Zbuild-std=panic_abort,std',
+            }
+          - {
+              description: wasm64,
+              version: nightly,
+              target: wasm64-unknown-unknown,
+              components: rust-src,
+              flags: '-Dwarnings',
               args: '--features=std,sys_rng,wasm_js -Zbuild-std=panic_abort,std',
             }
     steps:
@@ -315,7 +325,7 @@ jobs:
       - name: Install precompiled wasm-pack
         shell: bash
         run: |
-          VERSION=v0.13.1
+          VERSION=v0.15.0
           URL=https://github.com/rustwasm/wasm-pack/releases/download/${VERSION}/wasm-pack-${VERSION}-x86_64-unknown-linux-musl.tar.gz
           wget -O - $URL | tar -xz --strip-components=1 -C ~/.cargo/bin
           wasm-pack --version
@@ -324,38 +334,39 @@ jobs:
         env:
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-        run: wasm-pack test --node -- ${{ matrix.rust.args }}
+        run: wasm-pack test --node ${{ matrix.rust.pack_args }} --
+          --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
       - name: Test (Firefox)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-        run: wasm-pack test --headless --firefox -- ${{ matrix.rust.args }}
+        run: wasm-pack test --headless --firefox -- --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
       - name: Test (Chrome)
         env:
           WASM_BINDGEN_USE_BROWSER: 1
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-        run: wasm-pack test --headless --chrome -- ${{ matrix.rust.args }}
+        run: wasm-pack test --headless --chrome -- --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
       - name: Test (dedicated worker)
         env:
           WASM_BINDGEN_USE_DEDICATED_WORKER: 1
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-        run: wasm-pack test --headless --firefox -- ${{ matrix.rust.args }}
+        run: wasm-pack test --headless --firefox -- --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
       - name: Test (shared worker)
         env:
           WASM_BINDGEN_USE_SHARED_WORKER: 1
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
-        run: wasm-pack test --headless --firefox -- ${{ matrix.rust.args }}
+        run: wasm-pack test --headless --firefox -- --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
       - name: Test (service worker)
         env:
           WASM_BINDGEN_USE_SERVICE_WORKER: 1
           RUSTFLAGS: ${{ matrix.rust.flags }}
           RUSTDOCFLAGS: ${{ matrix.rust.flags }}
         # Firefox doesn't support module service workers and therefor can't import scripts
-        run: wasm-pack test --headless --chrome -- ${{ matrix.rust.args }}
+        run: wasm-pack test --headless --chrome -- --target ${{ matrix.rust.target }} ${{ matrix.rust.args }}
 
   wasi_p1:
     name: WASIp1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Restore MSRV to 1.85 for wasm32-wasip3 targets. [#824]
+### Added
+- `wasm64-unknown-unknown` target support for `wasm_js` backend [#848]
+
+### Changed
+- Restore MSRV to 1.85 for wasm32-wasip3 targets [#824]
 
 [Unreleased]: https://github.com/rust-random/getrandom/compare/v0.4.2...master
 [#824]: https://github.com/rust-random/getrandom/pull/824
+[#848]: https://github.com/rust-random/getrandom/pull/848
 
 ## [0.4.2] - 2026-03-03
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,11 @@ wasip2 = { version = "1", default-features = false }
 wasip3 = ">=0.3, <=0.4"
 
 # wasm_js
-[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none")))'.dependencies]
 wasm-bindgen = { version = "0.2.98", default-features = false, optional = true }
-[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
 js-sys = { version = "0.3.77", default-features = false, optional = true }
-[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
+[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [lints.rust.unexpected_cfgs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,11 +86,11 @@ wasip2 = { version = "1", default-features = false }
 wasip3 = ">=0.3, <=0.4"
 
 # wasm_js
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none")))'.dependencies]
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 wasm-bindgen = { version = "0.2.98", default-features = false, optional = true }
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none"), target_feature = "atomics"))'.dependencies]
 js-sys = { version = "0.3.77", default-features = false, optional = true }
-[target.'cfg(all(any(target_arch = "wasm32", target_arch = "wasm64"), any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [lints.rust.unexpected_cfgs]

--- a/README.md
+++ b/README.md
@@ -67,16 +67,16 @@ Pull Requests that add support for new targets to `getrandom` are always welcome
 
 ### WebAssembly support
 
-This crate fully supports the [WASI] and [Emscripten] targets. However,
-the `wasm32-unknown-unknown` target (i.e. the target used by `wasm-pack`)
-is not automatically supported since, from the target name alone, we cannot deduce
+This crate fully supports the [WASI] and [Emscripten] targets. However, the `wasm32-unknown-unknown`
+and `wasm64-unknown-unknown` targets (i.e. the target used by `wasm-pack`)
+are not automatically supported since, from the target name alone, we cannot deduce
 which JavaScript interface should be used (or if JavaScript is available at all).
 
-We do not include support for this target in the default configuration because our JS backend
+We do not include support for these targets in the default configuration because our JS backend
 (supporting web browsers, web workers and Node.js v19 or later) requires [`wasm-bindgen`],
 **bloating `Cargo.lock`** and **potentially breaking builds** on non-web WASM platforms.
 
-To enable `getrandom`'s functionality on `wasm32-unknown-unknown` using
+To enable `getrandom`'s functionality on `wasm32/64-unknown-unknown` using
 [`Crypto.getRandomValues`] via [`wasm-bindgen`], enable the `wasm_js` crate feature.
 
 WARNING: We strongly recommend against enabling this feature in libraries (except for tests)

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -167,18 +167,15 @@ cfg_if! {
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
         mod rdrand;
         pub use rdrand::*;
-    } else if #[cfg(all(
-        any(target_arch = "wasm32", target_arch = "wasm64"),
-        any(target_os = "unknown", target_os = "none"),
-    ))] {
+    } else if #[cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))] {
         cfg_if! {
             if #[cfg(feature = "wasm_js")] {
                 mod wasm_js;
                 pub use wasm_js::*;
             } else {
                 compile_error!(concat!(
-                    "The wasm32-unknown-unknown and wasm64-unknown-unknown targets are not supported
-                    by default; you may need to enable the \"wasm_js\" crate feature. \
+                    "The wasm32/64-unknown-unknown are not supported by default; \
+                    you may need to enable the \"wasm_js\" crate feature. \
                     For more information see: \
                     https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
                 ));

--- a/src/backends.rs
+++ b/src/backends.rs
@@ -167,15 +167,18 @@ cfg_if! {
     } else if #[cfg(all(target_arch = "x86_64", target_env = "sgx"))] {
         mod rdrand;
         pub use rdrand::*;
-    } else if #[cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))] {
+    } else if #[cfg(all(
+        any(target_arch = "wasm32", target_arch = "wasm64"),
+        any(target_os = "unknown", target_os = "none"),
+    ))] {
         cfg_if! {
             if #[cfg(feature = "wasm_js")] {
                 mod wasm_js;
                 pub use wasm_js::*;
             } else {
                 compile_error!(concat!(
-                    "The wasm32-unknown-unknown targets are not supported by default; \
-                    you may need to enable the \"wasm_js\" crate feature. \
+                    "The wasm32-unknown-unknown and wasm64-unknown-unknown targets are not supported
+                    by default; you may need to enable the \"wasm_js\" crate feature. \
                     For more information see: \
                     https://docs.rs/getrandom/", env!("CARGO_PKG_VERSION"), "/#webassembly-support"
                 ));

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -4,10 +4,7 @@ use core::mem::MaybeUninit;
 
 pub use crate::util::{inner_u32, inner_u64};
 
-#[cfg(not(all(
-    any(target_arch = "wasm32", target_arch = "wasm64"),
-    any(target_os = "unknown", target_os = "none"),
-)))]
+#[cfg(not(all(target_family = "wasm", any(target_os = "unknown", target_os = "none"),)))]
 compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
 
 use wasm_bindgen::{JsValue, prelude::wasm_bindgen};

--- a/src/backends/wasm_js.rs
+++ b/src/backends/wasm_js.rs
@@ -4,10 +4,13 @@ use core::mem::MaybeUninit;
 
 pub use crate::util::{inner_u32, inner_u64};
 
-#[cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))]
+#[cfg(not(all(
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    any(target_os = "unknown", target_os = "none"),
+)))]
 compile_error!("`wasm_js` backend can be enabled only for OS-less WASM targets!");
 
-use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+use wasm_bindgen::{JsValue, prelude::wasm_bindgen};
 
 // Maximum buffer size allowed in `Crypto.getRandomValuesSize` is 65536 bytes.
 // See https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -2,7 +2,11 @@
 use core::mem::MaybeUninit;
 use getrandom::{fill, fill_uninit};
 
-#[cfg(all(feature = "wasm_js", target_arch = "wasm32", target_os = "unknown"))]
+#[cfg(all(
+    feature = "wasm_js",
+    any(target_arch = "wasm32", target_arch = "wasm64"),
+    any(target_os = "unknown", target_os = "none"),
+))]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 
 #[test]

--- a/tests/mod.rs
+++ b/tests/mod.rs
@@ -4,7 +4,7 @@ use getrandom::{fill, fill_uninit};
 
 #[cfg(all(
     feature = "wasm_js",
-    any(target_arch = "wasm32", target_arch = "wasm64"),
+    target_family = "wasm",
     any(target_os = "unknown", target_os = "none"),
 ))]
 use wasm_bindgen_test::wasm_bindgen_test as test;


### PR DESCRIPTION
WASM64 support was [merged](https://github.com/wasm-bindgen/wasm-bindgen/pull/5004) to `wasm-bindgen` and `wasm-pack`.