### PR TITLE
Release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.3] - 2026-06-17
 ### Added
 - `wasm64-unknown-unknown` target support for `wasm_js` backend [#848]
 
 ### Changed
 - Drop `wasip2` and `wasip3` dependencies in favor of manual bindings [#830]
 
-[Unreleased]: https://github.com/rust-random/getrandom/compare/v0.4.2...master
+[0.4.3]: https://github.com/rust-random/getrandom/compare/v0.4.2...v0.4.3
 [#830]: https://github.com/rust-random/getrandom/pull/830
 [#848]: https://github.com/rust-random/getrandom/pull/848
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "cfg-if",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 rust-version = "1.85" # Sync tests.yml and README.md.
 authors = ["The Rand Project Developers"]


### PR DESCRIPTION
### Added
- `wasm64-unknown-unknown` target support for `wasm_js` backend [#848]

### Changed
- Drop `wasip2` and `wasip3` dependencies in favor of manual bindings [#830]

[#830]: https://github.com/rust-random/getrandom/pull/830
[#848]: https://github.com/rust-random/getrandom/pull/848